### PR TITLE
Add sällskap group pages, forum, notes & admin

### DIFF
--- a/app/sallskap/[groupId]/SallskapPageClient.tsx
+++ b/app/sallskap/[groupId]/SallskapPageClient.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { ThemeToggle } from "@/components/ThemeToggle";
+import { TabBar, type SallskapTab } from "@/components/sallskap/TabBar";
+import { ForumTab } from "@/components/sallskap/forum/ForumTab";
+import { NotesTab } from "@/components/sallskap/notes/NotesTab";
+import { AdminTab } from "@/components/sallskap/admin/AdminTab";
+import type { Group, GroupMember, GroupPost } from "@/lib/types";
+import type { RaceWithNotes } from "@/lib/actions/notes";
+
+type Game = { id: string; date: string; track: string | null };
+
+interface SallskapPageClientProps {
+  group: Group;
+  members: GroupMember[];
+  games: Game[];
+  initialPosts: GroupPost[];
+  initialNotes: RaceWithNotes[];
+  defaultGameId: string | null;
+  currentUserId: string;
+}
+
+export function SallskapPageClient({
+  group,
+  members,
+  games,
+  initialPosts,
+  initialNotes,
+  defaultGameId,
+  currentUserId,
+}: SallskapPageClientProps) {
+  const [activeTab, setActiveTab] = useState<SallskapTab>("forum");
+
+  return (
+    <div className="min-h-screen bg-white dark:bg-gray-950 text-gray-900 dark:text-white flex flex-col">
+      {/* Header */}
+      <header className="border-b border-gray-200 dark:border-gray-800 px-4 py-3 flex items-center gap-3 sticky top-0 z-30 bg-white dark:bg-gray-950">
+        <Link
+          href="/"
+          className="text-gray-500 hover:text-gray-900 dark:hover:text-white transition text-lg w-8 text-center shrink-0"
+          aria-label="Tillbaka"
+        >
+          ←
+        </Link>
+        <h1 className="text-base font-bold flex-1 truncate">{group.name}</h1>
+        <ThemeToggle />
+      </header>
+
+      {/* Tab bar */}
+      <TabBar activeTab={activeTab} onChange={setActiveTab} />
+
+      {/* Tab content — alltid monterade för att bevara state vid fliktbyte */}
+      <div className="flex-1">
+        <div className={activeTab === "forum" ? undefined : "hidden"}>
+          <ForumTab
+            groupId={group.id}
+            games={games}
+            initialPosts={initialPosts}
+            initialGameId={defaultGameId}
+            currentUserId={currentUserId}
+          />
+        </div>
+        <div className={activeTab === "anteckningar" ? undefined : "hidden"}>
+          <NotesTab
+            groupId={group.id}
+            games={games}
+            initialGameId={defaultGameId}
+            initialNotes={initialNotes}
+          />
+        </div>
+        <div className={activeTab === "sallskap" ? undefined : "hidden"}>
+          <AdminTab
+            group={group}
+            members={members}
+            currentUserId={currentUserId}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/sallskap/[groupId]/page.tsx
+++ b/app/sallskap/[groupId]/page.tsx
@@ -1,0 +1,65 @@
+import { redirect } from "next/navigation";
+import { createClient, createServiceClient } from "@/lib/supabase/server";
+import { getGroupById } from "@/lib/actions/groups";
+import { getGroupMembers } from "@/lib/actions/sallskap";
+import { getGroupPosts } from "@/lib/actions/posts";
+import { getGroupNotesForGame } from "@/lib/actions/notes";
+import { SallskapPageClient } from "./SallskapPageClient";
+
+interface Props {
+  params: Promise<{ groupId: string }>;
+}
+
+async function getAllGames(supabase: Awaited<ReturnType<typeof createClient>>) {
+  const { data } = await supabase
+    .from("games")
+    .select("id, date, track")
+    .order("date", { ascending: false });
+  return data ?? [];
+}
+
+export default async function SallskapPage({ params }: Props) {
+  const { groupId } = await params;
+
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) redirect("/login");
+
+  // Verifiera att användaren är medlem
+  const db = createServiceClient();
+  const { data: membership } = await db
+    .from("group_members")
+    .select("user_id")
+    .eq("group_id", groupId)
+    .eq("user_id", user.id)
+    .single();
+
+  if (!membership) redirect("/");
+
+  const [group, members, games] = await Promise.all([
+    getGroupById(groupId),
+    getGroupMembers(groupId),
+    getAllGames(supabase),
+  ]);
+
+  if (!group) redirect("/");
+
+  const defaultGameId = games[0]?.id ?? null;
+
+  const [initialPosts, initialNotes] = await Promise.all([
+    defaultGameId ? getGroupPosts(groupId, defaultGameId) : Promise.resolve([]),
+    defaultGameId ? getGroupNotesForGame(groupId, defaultGameId) : Promise.resolve([]),
+  ]);
+
+  return (
+    <SallskapPageClient
+      group={group}
+      members={members}
+      games={games}
+      initialPosts={initialPosts}
+      initialNotes={initialNotes}
+      defaultGameId={defaultGameId}
+      currentUserId={user.id}
+    />
+  );
+}

--- a/components/groups/UserMenu.tsx
+++ b/components/groups/UserMenu.tsx
@@ -63,9 +63,14 @@ export function UserMenu({ profile, groups, userEmail }: UserMenuProps) {
               <div className="px-4 py-2 border-b border-gray-300 dark:border-gray-700">
                 <p className="text-gray-400 dark:text-gray-500 text-xs mb-1">Sällskap</p>
                 {groups.map((g) => (
-                  <p key={g.id} className="text-gray-700 dark:text-gray-300 text-xs truncate py-0.5">
+                  <Link
+                    key={g.id}
+                    href={`/sallskap/${g.id}`}
+                    onClick={() => setOpen(false)}
+                    className="block text-gray-700 dark:text-gray-300 hover:text-indigo-600 dark:hover:text-indigo-400 text-xs truncate py-0.5 transition"
+                  >
                     {g.name}
-                  </p>
+                  </Link>
                 ))}
               </div>
             )}

--- a/components/sallskap/TabBar.tsx
+++ b/components/sallskap/TabBar.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+export type SallskapTab = "forum" | "anteckningar" | "sallskap";
+
+const TABS: { key: SallskapTab; label: string }[] = [
+  { key: "forum", label: "Forum" },
+  { key: "anteckningar", label: "Anteckningar" },
+  { key: "sallskap", label: "Sällskap" },
+];
+
+interface TabBarProps {
+  activeTab: SallskapTab;
+  onChange: (tab: SallskapTab) => void;
+}
+
+export function TabBar({ activeTab, onChange }: TabBarProps) {
+  return (
+    <div className="sticky top-0 z-20 bg-white dark:bg-gray-950 border-b border-gray-200 dark:border-gray-800">
+      <div className="flex">
+        {TABS.map((tab) => (
+          <button
+            key={tab.key}
+            onClick={() => onChange(tab.key)}
+            className={`flex-1 py-3 text-sm font-medium transition border-b-2 ${
+              activeTab === tab.key
+                ? "border-indigo-600 text-indigo-600 dark:text-indigo-400"
+                : "border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200"
+            }`}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/components/sallskap/admin/AdminTab.tsx
+++ b/components/sallskap/admin/AdminTab.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { leaveGroup } from "@/lib/actions/groups";
+import { GroupNameForm } from "./GroupNameForm";
+import { MemberList } from "./MemberList";
+import { InviteLinkSection } from "./InviteLinkSection";
+import { AtgTeamUrlForm } from "./AtgTeamUrlForm";
+import type { Group, GroupMember } from "@/lib/types";
+
+interface AdminTabProps {
+  group: Group;
+  members: GroupMember[];
+  currentUserId: string;
+}
+
+export function AdminTab({ group, members, currentUserId }: AdminTabProps) {
+  const router = useRouter();
+  const isCreator = group.created_by === currentUserId;
+  const [groupName, setGroupName] = useState(group.name);
+  const [atgUrl, setAtgUrl] = useState(group.atg_team_url ?? null);
+  const [leaving, setLeaving] = useState(false);
+
+  async function handleLeave() {
+    if (!confirm("Vill du lämna sällskapet?")) return;
+    setLeaving(true);
+    await leaveGroup(group.id);
+    router.push("/");
+  }
+
+  return (
+    <div className="px-4 py-5 space-y-6 max-w-2xl mx-auto">
+      {/* Namn */}
+      <section className="space-y-2">
+        <h2 className="text-sm font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">
+          Sällskapets namn
+        </h2>
+        {isCreator ? (
+          <GroupNameForm groupId={group.id} initialName={groupName} onUpdated={setGroupName} />
+        ) : (
+          <p className="text-gray-900 dark:text-white font-medium">{groupName}</p>
+        )}
+      </section>
+
+      {/* ATG-lag */}
+      <section className="space-y-2">
+        <h2 className="text-sm font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">
+          ATG-lag
+        </h2>
+        <AtgTeamUrlForm
+          groupId={group.id}
+          initialUrl={atgUrl}
+          isCreator={isCreator}
+          onUpdated={setAtgUrl}
+        />
+      </section>
+
+      {/* Inbjudningslänk */}
+      <section className="space-y-2">
+        <h2 className="text-sm font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">
+          Inbjudning
+        </h2>
+        <InviteLinkSection inviteCode={group.invite_code} />
+      </section>
+
+      {/* Medlemmar */}
+      <section className="space-y-2">
+        <h2 className="text-sm font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">
+          Medlemmar ({members.length})
+        </h2>
+        <MemberList members={members} creatorId={group.created_by} />
+      </section>
+
+      {/* Lämna sällskap */}
+      <section className="pt-2 border-t border-gray-200 dark:border-gray-800">
+        <button
+          onClick={handleLeave}
+          disabled={leaving}
+          className="text-sm text-red-400 hover:text-red-300 disabled:opacity-50 transition"
+        >
+          {leaving ? "Lämnar…" : "Lämna sällskap"}
+        </button>
+        {isCreator && (
+          <p className="text-xs text-gray-400 dark:text-gray-500 mt-1">
+            Du är skaparen — sällskapet kvarstår för övriga medlemmar.
+          </p>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/components/sallskap/admin/AtgTeamUrlForm.tsx
+++ b/components/sallskap/admin/AtgTeamUrlForm.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { useState } from "react";
+import { updateGroup } from "@/lib/actions/groups";
+
+interface AtgTeamUrlFormProps {
+  groupId: string;
+  initialUrl: string | null | undefined;
+  isCreator: boolean;
+  onUpdated: (url: string | null) => void;
+}
+
+export function AtgTeamUrlForm({ groupId, initialUrl, isCreator, onUpdated }: AtgTeamUrlFormProps) {
+  const [savedUrl, setSavedUrl] = useState(initialUrl ?? null);
+  const [editing, setEditing] = useState(false);
+  const [url, setUrl] = useState(initialUrl ?? "");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setLoading(true);
+    setError(null);
+    const trimmed = url.trim() || null;
+    const { error } = await updateGroup(groupId, { atg_team_url: trimmed });
+    setLoading(false);
+    if (error) {
+      setError(error);
+    } else {
+      setSavedUrl(trimmed);
+      onUpdated(trimmed);
+      setEditing(false);
+    }
+  }
+
+  // Icke-skapare: bara visa länk
+  if (!isCreator) {
+    if (!savedUrl) {
+      return <p className="text-sm text-gray-500 dark:text-gray-400 italic">Ingen ATG-lagslänk inlagd ännu.</p>;
+    }
+    return (
+      <a
+        href={savedUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="text-sm text-indigo-600 dark:text-indigo-400 hover:underline break-all"
+      >
+        {savedUrl}
+      </a>
+    );
+  }
+
+  // Skapare i visningsläge
+  if (!editing) {
+    return (
+      <div className="flex items-start gap-3 flex-wrap">
+        {savedUrl ? (
+          <a
+            href={savedUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-sm text-indigo-600 dark:text-indigo-400 hover:underline break-all flex-1"
+          >
+            {savedUrl}
+          </a>
+        ) : (
+          <p className="text-sm text-gray-500 dark:text-gray-400 italic flex-1">Ingen länk inlagd ännu.</p>
+        )}
+        <button
+          onClick={() => { setUrl(savedUrl ?? ""); setEditing(true); setError(null); }}
+          className="text-xs text-indigo-600 dark:text-indigo-400 hover:text-indigo-300 transition shrink-0"
+        >
+          {savedUrl ? "Redigera" : "Lägg till"}
+        </button>
+      </div>
+    );
+  }
+
+  // Redigeringsläge
+  return (
+    <form onSubmit={handleSubmit} className="space-y-2">
+      <div className="flex gap-2 items-center flex-wrap">
+        <input
+          type="url"
+          value={url}
+          onChange={(e) => setUrl(e.target.value)}
+          placeholder="https://www.atg.se/lag/..."
+          autoFocus
+          className="flex-1 min-w-0 bg-gray-100 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-sm text-gray-900 dark:text-white placeholder-gray-400 focus:outline-none focus:border-indigo-500"
+        />
+        <button
+          type="button"
+          onClick={() => { setEditing(false); setError(null); }}
+          className="text-xs text-gray-500 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200 px-3 py-2 rounded-lg transition"
+        >
+          Avbryt
+        </button>
+        <button
+          type="submit"
+          disabled={loading}
+          className="bg-indigo-600 hover:bg-indigo-500 disabled:opacity-50 text-white text-sm px-4 py-2 rounded-lg transition"
+        >
+          {loading ? "Sparar…" : "Spara"}
+        </button>
+      </div>
+      {error && <p className="text-red-400 text-xs">{error}</p>}
+    </form>
+  );
+}

--- a/components/sallskap/admin/GroupNameForm.tsx
+++ b/components/sallskap/admin/GroupNameForm.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useState } from "react";
+import { updateGroup } from "@/lib/actions/groups";
+
+interface GroupNameFormProps {
+  groupId: string;
+  initialName: string;
+  onUpdated: (name: string) => void;
+}
+
+export function GroupNameForm({ groupId, initialName, onUpdated }: GroupNameFormProps) {
+  const [name, setName] = useState(initialName);
+  const [loading, setLoading] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setLoading(true);
+    setMessage(null);
+    const { error } = await updateGroup(groupId, { name: name.trim() });
+    setLoading(false);
+    if (error) {
+      setMessage(error);
+    } else {
+      setMessage("Sparat!");
+      onUpdated(name.trim());
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="flex gap-2 items-center flex-wrap">
+      <input
+        type="text"
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        placeholder="Sällskapets namn"
+        maxLength={60}
+        className="flex-1 min-w-0 bg-gray-100 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-sm text-gray-900 dark:text-white placeholder-gray-400 focus:outline-none focus:border-indigo-500"
+      />
+      <button
+        type="submit"
+        disabled={loading || !name.trim()}
+        className="bg-indigo-600 hover:bg-indigo-500 disabled:opacity-50 text-white text-sm px-4 py-2 rounded-lg transition"
+      >
+        {loading ? "Sparar…" : "Spara"}
+      </button>
+      {message && (
+        <span className="text-xs text-gray-500 dark:text-gray-400">{message}</span>
+      )}
+    </form>
+  );
+}

--- a/components/sallskap/admin/InviteLinkSection.tsx
+++ b/components/sallskap/admin/InviteLinkSection.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { useState } from "react";
+
+function CopyButton({ text, label, mono }: { text: string; label: string; mono?: boolean }) {
+  const [copied, setCopied] = useState(false);
+
+  async function handleCopy() {
+    await navigator.clipboard.writeText(text);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }
+
+  return (
+    <button
+      onClick={handleCopy}
+      className={`text-xs text-indigo-600 dark:text-indigo-400 hover:text-indigo-300 transition ${mono ? "font-mono tracking-widest" : ""}`}
+      title={`Kopiera ${label}`}
+    >
+      {mono ? text : label} {copied ? "✓" : "⎘"}
+    </button>
+  );
+}
+
+function CopyLinkButton({ inviteCode }: { inviteCode: string }) {
+  const [copied, setCopied] = useState(false);
+
+  async function handleCopy() {
+    const url = `${window.location.origin}/join/${inviteCode}`;
+    await navigator.clipboard.writeText(url);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }
+
+  return (
+    <button
+      onClick={handleCopy}
+      className="text-xs text-indigo-600 dark:text-indigo-400 hover:text-indigo-300 transition"
+      title="Kopiera inbjudningslänk"
+    >
+      Kopiera länk {copied ? "✓" : "🔗"}
+    </button>
+  );
+}
+
+export function InviteLinkSection({ inviteCode }: { inviteCode: string }) {
+  return (
+    <div className="bg-gray-100 dark:bg-gray-800 rounded-lg px-3 py-3 flex items-center gap-3 flex-wrap">
+      <div className="flex items-center gap-1.5">
+        <span className="text-xs text-gray-500 dark:text-gray-400">Kod:</span>
+        <CopyButton text={inviteCode} label="inbjudningskod" mono />
+      </div>
+      <CopyLinkButton inviteCode={inviteCode} />
+      <p className="text-xs text-gray-400 dark:text-gray-500 w-full">
+        Dela koden eller länken med dina vänner så kan de gå med i sällskapet.
+      </p>
+    </div>
+  );
+}

--- a/components/sallskap/admin/MemberList.tsx
+++ b/components/sallskap/admin/MemberList.tsx
@@ -1,0 +1,36 @@
+import type { GroupMember } from "@/lib/types";
+
+function relativeDate(dateStr: string): string {
+  const diff = Date.now() - new Date(dateStr).getTime();
+  const days = Math.floor(diff / 86_400_000);
+  if (days === 0) return "idag";
+  if (days === 1) return "igår";
+  if (days < 30) return `${days} dagar sedan`;
+  if (days < 365) return `${Math.floor(days / 30)} månader sedan`;
+  return new Date(dateStr).toLocaleDateString("sv-SE");
+}
+
+export function MemberList({ members, creatorId }: { members: GroupMember[]; creatorId: string }) {
+  return (
+    <ul className="space-y-2">
+      {members.map((m) => (
+        <li key={m.user_id} className="flex items-center justify-between gap-2 bg-gray-100 dark:bg-gray-800 rounded-lg px-3 py-2">
+          <div className="flex items-center gap-2 min-w-0">
+            <span className="w-7 h-7 rounded-full bg-indigo-700 flex items-center justify-center text-white text-xs font-bold shrink-0">
+              {m.display_name.slice(0, 2).toUpperCase()}
+            </span>
+            <span className="text-sm text-gray-900 dark:text-white truncate">{m.display_name}</span>
+            {m.user_id === creatorId && (
+              <span className="text-xs bg-gray-200 dark:bg-gray-700 text-gray-500 dark:text-gray-400 px-1.5 py-0.5 rounded shrink-0">
+                skapare
+              </span>
+            )}
+          </div>
+          <span className="text-xs text-gray-400 dark:text-gray-500 shrink-0">
+            {relativeDate(m.joined_at)}
+          </span>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/components/sallskap/forum/ForumTab.tsx
+++ b/components/sallskap/forum/ForumTab.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import { getGroupPosts } from "@/lib/actions/posts";
+import { PostList } from "./PostList";
+import { PostForm } from "./PostForm";
+import type { GroupPost } from "@/lib/types";
+
+type Game = { id: string; date: string; track: string | null };
+
+interface ForumTabProps {
+  groupId: string;
+  games: Game[];
+  initialPosts: GroupPost[];
+  initialGameId: string | null;
+  currentUserId: string;
+}
+
+export function ForumTab({ groupId, games, initialPosts, initialGameId, currentUserId }: ForumTabProps) {
+  const [selectedGameId, setSelectedGameId] = useState(initialGameId);
+  const [posts, setPosts] = useState<GroupPost[]>(initialPosts);
+  const [loading, setLoading] = useState(false);
+
+  async function handleGameChange(gameId: string) {
+    setSelectedGameId(gameId);
+    setLoading(true);
+    const data = await getGroupPosts(groupId, gameId);
+    setPosts(data);
+    setLoading(false);
+  }
+
+  const handleAdded = useCallback((post: GroupPost) => {
+    setPosts((prev) => [...prev, { ...post, replies: [] }]);
+  }, []);
+
+  const handleDeleted = useCallback((postId: string) => {
+    setPosts((prev) =>
+      prev
+        .filter((p) => p.id !== postId)
+        .map((p) => ({
+          ...p,
+          replies: p.replies.filter((r) => r.id !== postId),
+        }))
+    );
+  }, []);
+
+  const handleReplied = useCallback((reply: GroupPost, parentId: string) => {
+    setPosts((prev) =>
+      prev.map((p) =>
+        p.id === parentId ? { ...p, replies: [...p.replies, reply] } : p
+      )
+    );
+  }, []);
+
+  return (
+    <div className="px-4 py-5 space-y-5 max-w-2xl mx-auto">
+      {/* Omgångsväljare */}
+      {games.length > 0 && (
+        <div>
+          <select
+            value={selectedGameId ?? ""}
+            onChange={(e) => handleGameChange(e.target.value)}
+            className="w-full bg-gray-100 dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded-lg px-3 py-2 text-sm text-gray-900 dark:text-white focus:outline-none focus:border-indigo-500"
+          >
+            {games.map((g) => (
+              <option key={g.id} value={g.id}>
+                {g.date}{g.track ? ` – ${g.track}` : ""}
+              </option>
+            ))}
+          </select>
+        </div>
+      )}
+
+      {games.length === 0 && (
+        <p className="text-sm text-gray-500 dark:text-gray-400 italic">
+          Ingen omgång inladdad ännu. Hämta en V85-omgång på startsidan först.
+        </p>
+      )}
+
+      {selectedGameId && (
+        <>
+          {/* Nytt inlägg */}
+          <div>
+            <PostForm
+              groupId={groupId}
+              gameId={selectedGameId}
+              onAdded={handleAdded}
+            />
+          </div>
+
+          {/* Inläggslista */}
+          {loading ? (
+            <p className="text-sm text-gray-400 dark:text-gray-500 text-center py-4">Laddar…</p>
+          ) : (
+            <PostList
+              posts={posts}
+              groupId={groupId}
+              gameId={selectedGameId}
+              currentUserId={currentUserId}
+              onDeleted={handleDeleted}
+              onReplied={handleReplied}
+            />
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/components/sallskap/forum/PostForm.tsx
+++ b/components/sallskap/forum/PostForm.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { useState } from "react";
+import { addPost } from "@/lib/actions/posts";
+import type { GroupPost } from "@/lib/types";
+
+interface PostFormProps {
+  groupId: string;
+  gameId: string;
+  parentId?: string;
+  onAdded: (post: GroupPost) => void;
+  onCancel?: () => void;
+  compact?: boolean;
+}
+
+export function PostForm({ groupId, gameId, parentId, onAdded, onCancel, compact = false }: PostFormProps) {
+  const [content, setContent] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const isReply = !!parentId;
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setLoading(true);
+    setError(null);
+    const { data, error } = await addPost(groupId, gameId, content, parentId);
+    setLoading(false);
+    if (error) {
+      setError(error);
+    } else if (data) {
+      setContent("");
+      onAdded(data);
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-2">
+      <textarea
+        value={content}
+        onChange={(e) => setContent(e.target.value)}
+        placeholder={isReply ? "Skriv ett svar…" : "Dela din analys om omgången…"}
+        rows={compact ? 2 : 3}
+        className="w-full bg-gray-100 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-sm text-gray-900 dark:text-white placeholder-gray-400 focus:outline-none focus:border-indigo-500 resize-none"
+      />
+      <div className="flex gap-2 justify-end">
+        {onCancel && (
+          <button
+            type="button"
+            onClick={onCancel}
+            className="text-xs text-gray-500 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200 px-3 py-1.5 rounded-lg transition"
+          >
+            Avbryt
+          </button>
+        )}
+        <button
+          type="submit"
+          disabled={loading || !content.trim()}
+          className="bg-indigo-600 hover:bg-indigo-500 disabled:opacity-50 text-white text-xs px-3 py-1.5 rounded-lg transition"
+        >
+          {loading ? "Skickar…" : isReply ? "Svara" : "Publicera"}
+        </button>
+      </div>
+      {error && <p className="text-red-400 text-xs">{error}</p>}
+    </form>
+  );
+}

--- a/components/sallskap/forum/PostItem.tsx
+++ b/components/sallskap/forum/PostItem.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { useState } from "react";
+import { deletePost } from "@/lib/actions/posts";
+import { PostForm } from "./PostForm";
+import type { GroupPost } from "@/lib/types";
+
+function relativeTime(dateStr: string): string {
+  const diff = Date.now() - new Date(dateStr).getTime();
+  const minutes = Math.floor(diff / 60_000);
+  if (minutes < 1) return "just nu";
+  if (minutes < 60) return `${minutes} min sedan`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours} tim sedan`;
+  const days = Math.floor(hours / 24);
+  if (days < 30) return `${days} dag${days > 1 ? "ar" : ""} sedan`;
+  return new Date(dateStr).toLocaleDateString("sv-SE");
+}
+
+interface PostItemProps {
+  post: GroupPost;
+  groupId: string;
+  gameId: string;
+  currentUserId: string;
+  onDeleted: (postId: string) => void;
+  onReplied: (reply: GroupPost, parentId: string) => void;
+  isReply?: boolean;
+}
+
+export function PostItem({
+  post,
+  groupId,
+  gameId,
+  currentUserId,
+  onDeleted,
+  onReplied,
+  isReply = false,
+}: PostItemProps) {
+  const [showReplyForm, setShowReplyForm] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+
+  async function handleDelete() {
+    setDeleting(true);
+    await deletePost(post.id);
+    onDeleted(post.id);
+  }
+
+  function handleReplied(reply: GroupPost) {
+    setShowReplyForm(false);
+    onReplied(reply, post.id);
+  }
+
+  return (
+    <div className={`${isReply ? "ml-4 pl-3 border-l-2 border-gray-300 dark:border-gray-700" : ""}`}>
+      <div className="bg-gray-100 dark:bg-gray-800 rounded-lg p-3 space-y-1.5">
+        {/* Header */}
+        <div className="flex items-center gap-2 flex-wrap">
+          <span className="w-6 h-6 rounded-full bg-indigo-700 flex items-center justify-center text-white text-xs font-bold shrink-0">
+            {post.author_display_name.slice(0, 2).toUpperCase()}
+          </span>
+          <span className="text-gray-900 dark:text-white text-xs font-medium">{post.author_display_name}</span>
+          <span className="text-gray-400 dark:text-gray-500 text-xs ml-auto">{relativeTime(post.created_at)}</span>
+        </div>
+
+        {/* Content */}
+        <p className="text-gray-800 dark:text-gray-200 text-sm leading-relaxed whitespace-pre-wrap">{post.content}</p>
+
+        {/* Actions */}
+        <div className="flex items-center gap-3 pt-0.5">
+          {!isReply && (
+            <button
+              onClick={() => setShowReplyForm((v) => !v)}
+              className="text-xs text-indigo-600 dark:text-indigo-400 hover:text-indigo-300 transition"
+            >
+              {showReplyForm ? "Avbryt" : "Svara"}
+            </button>
+          )}
+          {post.author_id === currentUserId && (
+            <button
+              onClick={handleDelete}
+              disabled={deleting}
+              className="text-xs text-red-400 hover:text-red-300 disabled:opacity-50 transition"
+            >
+              {deleting ? "Tar bort…" : "Ta bort"}
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* Reply form */}
+      {showReplyForm && !isReply && (
+        <div className="mt-2 ml-4">
+          <PostForm
+            groupId={groupId}
+            gameId={gameId}
+            parentId={post.id}
+            onAdded={handleReplied}
+            onCancel={() => setShowReplyForm(false)}
+            compact
+          />
+        </div>
+      )}
+
+      {/* Replies */}
+      {post.replies && post.replies.length > 0 && (
+        <div className="mt-2 space-y-2">
+          {post.replies.map((reply) => (
+            <PostItem
+              key={reply.id}
+              post={reply}
+              groupId={groupId}
+              gameId={gameId}
+              currentUserId={currentUserId}
+              onDeleted={onDeleted}
+              onReplied={onReplied}
+              isReply
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/sallskap/forum/PostList.tsx
+++ b/components/sallskap/forum/PostList.tsx
@@ -1,0 +1,37 @@
+import { PostItem } from "./PostItem";
+import type { GroupPost } from "@/lib/types";
+
+interface PostListProps {
+  posts: GroupPost[];
+  groupId: string;
+  gameId: string;
+  currentUserId: string;
+  onDeleted: (postId: string) => void;
+  onReplied: (reply: GroupPost, parentId: string) => void;
+}
+
+export function PostList({ posts, groupId, gameId, currentUserId, onDeleted, onReplied }: PostListProps) {
+  if (posts.length === 0) {
+    return (
+      <p className="text-gray-500 dark:text-gray-400 text-sm italic py-4 text-center">
+        Inga inlägg ännu. Dela din analys!
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {posts.map((post) => (
+        <PostItem
+          key={post.id}
+          post={post}
+          groupId={groupId}
+          gameId={gameId}
+          currentUserId={currentUserId}
+          onDeleted={onDeleted}
+          onReplied={onReplied}
+        />
+      ))}
+    </div>
+  );
+}

--- a/components/sallskap/notes/GroupNotesRaceSection.tsx
+++ b/components/sallskap/notes/GroupNotesRaceSection.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { useState } from "react";
+import { HorseNotes } from "@/components/notes/HorseNotes";
+import type { Group } from "@/lib/types";
+
+interface Starter {
+  id: string;
+  start_number: number;
+  horse_id: string;
+  horses: { name: string } | null;
+}
+
+interface Race {
+  id: string;
+  race_number: number;
+  race_name: string | null;
+  start_time: string | null;
+  starters: Starter[];
+}
+
+interface GroupNotesRaceSectionProps {
+  race: Race;
+  userGroups: Group[];
+  currentUserId: string;
+}
+
+function formatTime(isoStr: string): string {
+  try {
+    return new Date(isoStr).toLocaleTimeString("sv-SE", { hour: "2-digit", minute: "2-digit" });
+  } catch {
+    return "";
+  }
+}
+
+export function GroupNotesRaceSection({ race, userGroups, currentUserId }: GroupNotesRaceSectionProps) {
+  const [expanded, setExpanded] = useState(false);
+
+  const sortedStarters = [...race.starters].sort((a, b) => a.start_number - b.start_number);
+  const timeStr = race.start_time ? formatTime(race.start_time) : null;
+
+  return (
+    <div className="border border-gray-200 dark:border-gray-800 rounded-xl overflow-hidden">
+      <button
+        onClick={() => setExpanded((v) => !v)}
+        className="w-full flex items-center justify-between px-4 py-3 bg-gray-50 dark:bg-gray-900 hover:bg-gray-100 dark:hover:bg-gray-800 transition text-left"
+      >
+        <span className="text-sm font-semibold text-gray-900 dark:text-white">
+          Avd {race.race_number}
+          {race.race_name ? ` – ${race.race_name}` : ""}
+          {timeStr ? ` · ${timeStr}` : ""}
+        </span>
+        <span className="text-gray-400 dark:text-gray-500 text-xs">{expanded ? "▲" : "▼"}</span>
+      </button>
+
+      {expanded && (
+        <div className="divide-y divide-gray-200 dark:divide-gray-800">
+          {sortedStarters.map((starter) => (
+            <div key={starter.id} className="px-4 py-3">
+              <p className="text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">
+                {starter.start_number}. {starter.horses?.name ?? starter.horse_id}
+              </p>
+              <HorseNotes
+                horseId={starter.horse_id}
+                userGroups={userGroups}
+                currentUserId={currentUserId}
+              />
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/sallskap/notes/NotesTab.tsx
+++ b/components/sallskap/notes/NotesTab.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { getGroupNotesForGame, type RaceWithNotes } from "@/lib/actions/notes";
+import { NoteLabelDot } from "@/components/notes/NoteLabel";
+
+type Game = { id: string; date: string; track: string | null };
+
+interface NotesTabProps {
+  groupId: string;
+  games: Game[];
+  initialGameId: string | null;
+  initialNotes: RaceWithNotes[];
+}
+
+function formatTime(isoStr: string): string {
+  try {
+    return new Date(isoStr).toLocaleTimeString("sv-SE", { hour: "2-digit", minute: "2-digit" });
+  } catch {
+    return "";
+  }
+}
+
+function relativeTime(dateStr: string): string {
+  const diff = Date.now() - new Date(dateStr).getTime();
+  const minutes = Math.floor(diff / 60_000);
+  if (minutes < 1) return "just nu";
+  if (minutes < 60) return `${minutes} min sedan`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours} tim sedan`;
+  const days = Math.floor(hours / 24);
+  if (days < 30) return `${days} dag${days > 1 ? "ar" : ""} sedan`;
+  return new Date(dateStr).toLocaleDateString("sv-SE");
+}
+
+export function NotesTab({ groupId, games, initialGameId, initialNotes }: NotesTabProps) {
+  const [selectedGameId, setSelectedGameId] = useState(initialGameId);
+  const [races, setRaces] = useState<RaceWithNotes[]>(initialNotes);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    setRaces(initialNotes);
+  }, [initialNotes]);
+
+  async function handleGameChange(gameId: string) {
+    setSelectedGameId(gameId);
+    setLoading(true);
+    const data = await getGroupNotesForGame(groupId, gameId);
+    setRaces(data);
+    setLoading(false);
+  }
+
+  const totalNotes = races.reduce((sum, r) => sum + r.horses.reduce((s, h) => s + h.notes.length, 0), 0);
+
+  return (
+    <div className="px-4 py-5 space-y-4 max-w-2xl mx-auto">
+      {/* Omgångsväljare */}
+      {games.length > 0 && (
+        <select
+          value={selectedGameId ?? ""}
+          onChange={(e) => handleGameChange(e.target.value)}
+          className="w-full bg-gray-100 dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded-lg px-3 py-2 text-sm text-gray-900 dark:text-white focus:outline-none focus:border-indigo-500"
+        >
+          {games.map((g) => (
+            <option key={g.id} value={g.id}>
+              {g.date}{g.track ? ` – ${g.track}` : ""}
+            </option>
+          ))}
+        </select>
+      )}
+
+      {games.length === 0 && (
+        <p className="text-sm text-gray-500 dark:text-gray-400 italic">
+          Ingen omgång inladdad ännu. Hämta en V85-omgång på startsidan först.
+        </p>
+      )}
+
+      {loading && (
+        <p className="text-sm text-gray-400 dark:text-gray-500 text-center py-4">Laddar…</p>
+      )}
+
+      {!loading && selectedGameId && races.length === 0 && (
+        <p className="text-sm text-gray-500 dark:text-gray-400 italic text-center py-6">
+          Inga sällskapsanteckningar finns för denna omgång.
+        </p>
+      )}
+
+      {!loading && races.length > 0 && (
+        <>
+          <p className="text-xs text-gray-400 dark:text-gray-500">
+            {totalNotes} anteckning{totalNotes !== 1 ? "ar" : ""} på {races.reduce((s, r) => s + r.horses.length, 0)} hästar
+          </p>
+          <div className="space-y-4">
+            {races.map((race) => (
+              <div key={race.race_number} className="space-y-2">
+                {/* Loppheader */}
+                <div className="flex items-center gap-2">
+                  <span className="text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">
+                    Avd {race.race_number}
+                    {race.race_name ? ` – ${race.race_name}` : ""}
+                    {race.start_time ? ` · ${formatTime(race.start_time)}` : ""}
+                  </span>
+                  <div className="flex-1 h-px bg-gray-200 dark:bg-gray-800" />
+                </div>
+
+                {/* Hästar med anteckningar */}
+                {race.horses.map((horse) => (
+                  <div key={horse.horse_id} className="space-y-2">
+                    <p className="text-xs font-medium text-gray-700 dark:text-gray-300 pl-1">
+                      {horse.start_number}. {horse.horse_name}
+                    </p>
+                    <div className="space-y-2 pl-1">
+                      {horse.notes.map((note) => (
+                        <div key={note.id} className="bg-gray-100 dark:bg-gray-800 rounded-lg p-3 space-y-1.5">
+                          <div className="flex items-center gap-2 flex-wrap">
+                            <NoteLabelDot label={note.label} />
+                            <span className="text-xs font-medium text-gray-900 dark:text-white">{note.author_display_name}</span>
+                            <span className="text-xs text-gray-400 dark:text-gray-500 ml-auto">{relativeTime(note.created_at)}</span>
+                          </div>
+                          <p className="text-sm text-gray-800 dark:text-gray-200 leading-relaxed whitespace-pre-wrap">{note.content}</p>
+                          {note.replies.length > 0 && (
+                            <div className="mt-2 space-y-2">
+                              {note.replies.map((reply) => (
+                                <div key={reply.id} className="ml-4 pl-3 border-l-2 border-gray-300 dark:border-gray-700">
+                                  <div className="bg-gray-50 dark:bg-[rgb(40,44,52)] rounded-lg p-2.5 space-y-1">
+                                    <div className="flex items-center gap-2">
+                                      <span className="text-xs font-medium text-gray-900 dark:text-white">{reply.author_display_name}</span>
+                                      <span className="text-xs text-gray-400 dark:text-gray-500 ml-auto">{relativeTime(reply.created_at)}</span>
+                                    </div>
+                                    <p className="text-sm text-gray-800 dark:text-gray-200 leading-relaxed whitespace-pre-wrap">{reply.content}</p>
+                                  </div>
+                                </div>
+                              ))}
+                            </div>
+                          )}
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/lib/actions/groups.ts
+++ b/lib/actions/groups.ts
@@ -147,3 +147,40 @@ export async function leaveGroup(groupId: string): Promise<{ error: string | nul
   revalidatePath("/");
   return { error: null };
 }
+
+export async function getGroupById(groupId: string): Promise<Group | null> {
+  const db = createServiceClient();
+  const { data } = await db
+    .from("groups")
+    .select("id, name, invite_code, created_by, created_at, atg_team_url")
+    .eq("id", groupId)
+    .single();
+  return (data as Group) ?? null;
+}
+
+export async function updateGroup(
+  groupId: string,
+  updates: { name?: string; atg_team_url?: string | null }
+): Promise<{ error: string | null }> {
+  const user = await getAuthUser();
+  if (!user) return { error: "Inte inloggad" };
+
+  const db = createServiceClient();
+
+  const { data: group } = await db
+    .from("groups")
+    .select("created_by")
+    .eq("id", groupId)
+    .single();
+
+  if (!group || group.created_by !== user.id) return { error: "Inte behörig" };
+
+  const { error } = await db
+    .from("groups")
+    .update(updates)
+    .eq("id", groupId);
+
+  if (error) return { error: error.message };
+  revalidatePath(`/sallskap/${groupId}`);
+  return { error: null };
+}

--- a/lib/actions/notes.ts
+++ b/lib/actions/notes.ts
@@ -106,6 +106,114 @@ export async function addNote(
   return { data: mapNote(data as unknown as RawNote), error: null };
 }
 
+export interface HorseWithNotes {
+  horse_id: string;
+  horse_name: string;
+  start_number: number;
+  notes: HorseNote[];
+}
+
+export interface RaceWithNotes {
+  race_number: number;
+  race_name: string | null;
+  start_time: string | null;
+  horses: HorseWithNotes[];
+}
+
+/** Hämta alla grupphästanteckningar för hästar som deltar i ett specifikt spel */
+export async function getGroupNotesForGame(
+  groupId: string,
+  gameId: string
+): Promise<RaceWithNotes[]> {
+  const supabase = await createClient();
+
+  // Hämta alla starters i spelet med löp- och hästinfo
+  const { data: races } = await supabase
+    .from("races")
+    .select("race_number, race_name, start_time, starters ( horse_id, start_number, horses ( name ) )")
+    .eq("game_id", gameId)
+    .order("race_number");
+
+  if (!races || races.length === 0) return [];
+
+  // Samla alla horse_ids
+  const horseIds: string[] = [];
+  for (const race of races) {
+    for (const s of (race.starters as { horse_id: string }[])) {
+      horseIds.push(s.horse_id);
+    }
+  }
+  if (horseIds.length === 0) return [];
+
+  // Hämta alla grupphästanteckningar för dessa hästar
+  const { data: notesData } = await supabase
+    .from("horse_notes")
+    .select(`
+      id, horse_id, group_id, author_id, content, label, parent_id, created_at,
+      groups ( name ),
+      profiles ( display_name )
+    `)
+    .eq("group_id", groupId)
+    .in("horse_id", horseIds)
+    .order("created_at", { ascending: true });
+
+  if (!notesData || notesData.length === 0) return [];
+
+  const rawNotes = notesData as unknown as RawNote[];
+
+  // Bygg trådad struktur per häst
+  const notesByHorse = new Map<string, HorseNote[]>();
+
+  const repliesMap = new Map<string, HorseNote[]>();
+  for (const raw of rawNotes) {
+    if (raw.parent_id) {
+      const arr = repliesMap.get(raw.parent_id) ?? [];
+      arr.push(mapNote(raw));
+      repliesMap.set(raw.parent_id, arr);
+    }
+  }
+  for (const raw of rawNotes) {
+    if (!raw.parent_id) {
+      const note = mapNote(raw, repliesMap.get(raw.id) ?? []);
+      const arr = notesByHorse.get(raw.horse_id) ?? [];
+      arr.push(note);
+      notesByHorse.set(raw.horse_id, arr);
+    }
+  }
+
+  // Bygg resultat per lopp, bara hästar med anteckningar
+  const result: RaceWithNotes[] = [];
+
+  for (const race of races) {
+    const starters = race.starters as unknown as { horse_id: string; start_number: number; horses: { name: string } | null }[];
+    const horsesWithNotes: HorseWithNotes[] = [];
+
+    for (const starter of starters) {
+      const notes = notesByHorse.get(starter.horse_id);
+      if (notes && notes.length > 0) {
+        horsesWithNotes.push({
+          horse_id: starter.horse_id,
+          horse_name: starter.horses?.name ?? starter.horse_id,
+          start_number: starter.start_number,
+          notes,
+        });
+      }
+    }
+
+    if (horsesWithNotes.length > 0) {
+      horsesWithNotes.sort((a, b) => a.start_number - b.start_number);
+      result.push({
+        race_number: race.race_number as number,
+        race_name: race.race_name as string | null,
+        start_time: race.start_time as string | null,
+        horses: horsesWithNotes,
+      });
+    }
+  }
+
+  return result;
+}
+
 export async function deleteNote(noteId: string): Promise<{ error: string | null }> {
   const supabase = await createClient();
   const { data: { user } } = await supabase.auth.getUser();

--- a/lib/actions/posts.ts
+++ b/lib/actions/posts.ts
@@ -1,0 +1,124 @@
+"use server";
+
+import { createClient } from "@/lib/supabase/server";
+import type { GroupPost } from "@/lib/types";
+
+type RawPost = {
+  id: string;
+  group_id: string;
+  game_id: string;
+  author_id: string;
+  content: string;
+  parent_id: string | null;
+  created_at: string;
+};
+
+async function fetchDisplayNames(
+  supabase: Awaited<ReturnType<typeof createClient>>,
+  authorIds: string[]
+): Promise<Map<string, string>> {
+  if (authorIds.length === 0) return new Map();
+  const { data } = await supabase
+    .from("profiles")
+    .select("id, display_name")
+    .in("id", authorIds);
+  const map = new Map<string, string>();
+  for (const p of data ?? []) map.set(p.id, p.display_name ?? "Okänd");
+  return map;
+}
+
+function mapPost(raw: RawPost, displayName: string, replies: GroupPost[] = []): GroupPost {
+  return {
+    id: raw.id,
+    group_id: raw.group_id,
+    game_id: raw.game_id,
+    author_id: raw.author_id,
+    author_display_name: displayName,
+    content: raw.content,
+    parent_id: raw.parent_id,
+    created_at: raw.created_at,
+    replies,
+  };
+}
+
+export async function getGroupPosts(groupId: string, gameId: string): Promise<GroupPost[]> {
+  const supabase = await createClient();
+
+  const { data, error } = await supabase
+    .from("group_posts")
+    .select("id, group_id, game_id, author_id, content, parent_id, created_at")
+    .eq("group_id", groupId)
+    .eq("game_id", gameId)
+    .order("created_at", { ascending: true });
+
+  if (error || !data) return [];
+
+  const raws = data as RawPost[];
+  const uniqueAuthorIds = [...new Set(raws.map((r) => r.author_id))];
+  const names = await fetchDisplayNames(supabase, uniqueAuthorIds);
+
+  const repliesMap = new Map<string, GroupPost[]>();
+  for (const raw of raws) {
+    if (raw.parent_id) {
+      const arr = repliesMap.get(raw.parent_id) ?? [];
+      arr.push(mapPost(raw, names.get(raw.author_id) ?? "Okänd"));
+      repliesMap.set(raw.parent_id, arr);
+    }
+  }
+
+  const topLevel: GroupPost[] = [];
+  for (const raw of raws) {
+    if (!raw.parent_id) {
+      topLevel.push(mapPost(raw, names.get(raw.author_id) ?? "Okänd", repliesMap.get(raw.id) ?? []));
+    }
+  }
+
+  return topLevel;
+}
+
+export async function addPost(
+  groupId: string,
+  gameId: string,
+  content: string,
+  parentId?: string
+): Promise<{ data: GroupPost | null; error: string | null }> {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return { data: null, error: "Inte inloggad" };
+
+  const trimmed = content.trim();
+  if (!trimmed) return { data: null, error: "Innehåll krävs" };
+
+  const { data, error } = await supabase
+    .from("group_posts")
+    .insert({
+      group_id: groupId,
+      game_id: gameId,
+      author_id: user.id,
+      content: trimmed,
+      parent_id: parentId ?? null,
+    })
+    .select("id, group_id, game_id, author_id, content, parent_id, created_at")
+    .single();
+
+  if (error) return { data: null, error: error.message };
+
+  const raw = data as RawPost;
+  const names = await fetchDisplayNames(supabase, [raw.author_id]);
+  return { data: mapPost(raw, names.get(raw.author_id) ?? "Okänd"), error: null };
+}
+
+export async function deletePost(postId: string): Promise<{ error: string | null }> {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return { error: "Inte inloggad" };
+
+  const { error } = await supabase
+    .from("group_posts")
+    .delete()
+    .eq("id", postId)
+    .eq("author_id", user.id);
+
+  if (error) return { error: error.message };
+  return { error: null };
+}

--- a/lib/actions/sallskap.ts
+++ b/lib/actions/sallskap.ts
@@ -1,0 +1,31 @@
+"use server";
+
+import { createServiceClient } from "@/lib/supabase/server";
+import type { GroupMember } from "@/lib/types";
+
+export async function getGroupMembers(groupId: string): Promise<GroupMember[]> {
+  const db = createServiceClient();
+
+  const { data, error } = await db
+    .from("group_members")
+    .select("user_id, joined_at")
+    .eq("group_id", groupId)
+    .order("joined_at", { ascending: true });
+
+  if (error || !data || data.length === 0) return [];
+
+  const userIds = data.map((row) => row.user_id as string);
+  const { data: profiles } = await db
+    .from("profiles")
+    .select("id, display_name")
+    .in("id", userIds);
+
+  const nameMap = new Map<string, string>();
+  for (const p of profiles ?? []) nameMap.set(p.id, p.display_name ?? "Okänd");
+
+  return data.map((row) => ({
+    user_id: row.user_id as string,
+    display_name: nameMap.get(row.user_id as string) ?? "Okänd",
+    joined_at: row.joined_at as string,
+  }));
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -4,6 +4,25 @@ export interface Group {
   invite_code: string;
   created_by: string;
   created_at: string;
+  atg_team_url?: string | null;
+}
+
+export interface GroupMember {
+  user_id: string;
+  display_name: string;
+  joined_at: string;
+}
+
+export interface GroupPost {
+  id: string;
+  group_id: string;
+  game_id: string;
+  author_id: string;
+  author_display_name: string;
+  content: string;
+  parent_id: string | null;
+  created_at: string;
+  replies: GroupPost[];
 }
 
 export interface Profile {

--- a/supabase/migration_v4_sallskap.sql
+++ b/supabase/migration_v4_sallskap.sql
@@ -1,0 +1,47 @@
+-- Migration v4: Sällskapssida
+-- Lägger till ATG-lagslänk på groups och skapar forumtabell (group_posts)
+
+-- 1. ATG-lagslänk på groups
+ALTER TABLE groups ADD COLUMN IF NOT EXISTS atg_team_url text;
+
+-- 2. Forumtabell
+CREATE TABLE IF NOT EXISTS group_posts (
+  id         uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  group_id   uuid NOT NULL REFERENCES groups(id) ON DELETE CASCADE,
+  game_id    text NOT NULL REFERENCES games(id) ON DELETE CASCADE,
+  author_id  uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  content    text NOT NULL,
+  parent_id  uuid REFERENCES group_posts(id) ON DELETE CASCADE,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_group_posts_group_game
+  ON group_posts(group_id, game_id, created_at);
+
+-- 3. RLS
+ALTER TABLE group_posts ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Group members can read posts"
+  ON group_posts FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1 FROM group_members
+      WHERE group_members.group_id = group_posts.group_id
+        AND group_members.user_id = auth.uid()
+    )
+  );
+
+CREATE POLICY "Group members can insert posts"
+  ON group_posts FOR INSERT
+  WITH CHECK (
+    author_id = auth.uid()
+    AND EXISTS (
+      SELECT 1 FROM group_members
+      WHERE group_members.group_id = group_posts.group_id
+        AND group_members.user_id = auth.uid()
+    )
+  );
+
+CREATE POLICY "Authors can delete own posts"
+  ON group_posts FOR DELETE
+  USING (author_id = auth.uid());


### PR DESCRIPTION
Introduce a full "sällskap" (group) feature: adds server and client pages for group view, a TabBar and tabs for Forum, Notes and Admin. Implements forum UI (PostForm, PostItem, PostList) and client-side group notes UI (NotesTab, GroupNotesRaceSection) and admin tools (group name, ATG team URL, invite link, member list). Adds server actions for posts and notes fetching, group lookup/update guards, and updates types. Also wire up UserMenu to link into groups and include a DB migration for the new sallskap schema.