### PR TITLE
Display finish results and dedupe starters

### DIFF
--- a/app/api/games/fetch/route.ts
+++ b/app/api/games/fetch/route.ts
@@ -48,19 +48,27 @@ export async function POST(request: NextRequest) {
         track_surface: null,
       });
 
-      // Upsert horses (stable data — ignorera dubbletter, uppdatera ej)
-      const horseUpserts = race.starters.map((s) => ({
+      // Deduplicera — ATG kan ibland returnera samma häst två gånger i ett lopp
+      const seenHorseIds = new Set<string>();
+      const uniqueStarters = race.starters.filter((s) => {
+        if (seenHorseIds.has(s.horse_id)) return false;
+        seenHorseIds.add(s.horse_id);
+        return true;
+      });
+
+      // Upsert horses — uppdatera namn om det har ändrats
+      const horseUpserts = uniqueStarters.map((s) => ({
         id: s.horse_id,
         name: s.horse_name,
       }));
       if (horseUpserts.length > 0) {
-        await supabase.from("horses").upsert(horseUpserts, { ignoreDuplicates: true });
+        await supabase.from("horses").upsert(horseUpserts, { onConflict: "id" });
       }
 
-      const scores = calculateFormscore(race.starters);
+      const scores = calculateFormscore(uniqueStarters);
 
       await supabase.from("starters").delete().eq("race_id", raceId);
-      const starterRows = race.starters.map((s, i) => ({
+      const starterRows = uniqueStarters.map((s, i) => ({
         race_id: raceId,
         horse_id: s.horse_id,
         start_number: s.start_number,

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -32,7 +32,7 @@ async function getRaces(supabase: Awaited<ReturnType<typeof createClient>>, game
         starts_total, wins_total, places_2nd, places_3rd, earnings_total,
         starts_current_year, wins_current_year, places_2nd_current_year, places_3rd_current_year,
         starts_prev_year, wins_prev_year, places_2nd_prev_year, places_3rd_prev_year,
-        best_time, last_5_results, life_records, formscore, finish_position,
+        best_time, last_5_results, life_records, formscore, finish_position, finish_time,
         horses ( name )
       )
     `)

--- a/components/AnalysisPanel.tsx
+++ b/components/AnalysisPanel.tsx
@@ -153,7 +153,8 @@ function EnhancedAnalysisSection({ starters }: { starters: AnalysisStarter[] }) 
               <th className="text-left py-1 pr-2 font-medium min-w-[90px]">Konsistens</th>
               <th className="text-right py-1 pr-2 font-medium w-20">Tid</th>
               <th className="text-right py-1 pr-2 font-medium w-20">Värde</th>
-              <th className="text-right py-1 font-medium w-16">Poäng</th>
+              <th className="text-right py-1 pr-2 font-medium w-16">Poäng</th>
+              <th className="text-right py-1 font-medium w-20">Resultat</th>
             </tr>
           </thead>
           <tbody>
@@ -191,8 +192,27 @@ function EnhancedAnalysisSection({ starters }: { starters: AnalysisStarter[] }) 
                 <td className="py-1.5 pr-2 text-right">
                   <ValueIndexCell vi={r.valueIndex} />
                 </td>
-                <td className="py-1.5 text-right font-bold tabular-nums text-indigo-700 dark:text-indigo-300">
+                <td className="py-1.5 pr-2 text-right font-bold tabular-nums text-indigo-700 dark:text-indigo-300">
                   {r.compositeScore}
+                </td>
+                <td className="py-1.5 text-right">
+                  {r.finish_position != null ? (
+                    <span
+                      className={`text-xs font-bold px-1.5 py-0.5 rounded-full ${
+                        r.finish_position === 1
+                          ? "bg-yellow-400 text-black"
+                          : r.finish_position === 2
+                          ? "bg-gray-300 text-black"
+                          : r.finish_position === 3
+                          ? "bg-amber-600 text-white"
+                          : "bg-gray-500 text-white"
+                      }`}
+                    >
+                      {r.finish_position}:a{r.finish_time ? ` ${r.finish_time}` : ""}
+                    </span>
+                  ) : (
+                    <span className="text-gray-400 dark:text-gray-600 text-xs">–</span>
+                  )}
                 </td>
               </tr>
             ))}
@@ -240,12 +260,14 @@ export function AnalysisPanel({ starters, raceMeters, raceStartMethod }: Analysi
               <th className="text-right py-1 pr-2 font-medium w-20">Streckning</th>
               <th className="text-right py-1 pr-2 font-medium w-16">Odds</th>
               <th className="text-left py-1 pr-2 font-medium min-w-[100px]">Distans</th>
-              <th className="text-right py-1 font-medium min-w-[100px]">Spelvärde</th>
+              <th className="text-right py-1 pr-2 font-medium min-w-[100px]">Spelvärde</th>
+              <th className="text-right py-1 font-medium w-20">Resultat</th>
             </tr>
           </thead>
           <tbody>
             {results.map((r) => {
               const isValue = r.streckning_loaded && r.value >= 2;
+              const starter = starters.find((s) => s.start_number === r.start_number);
               return (
                 <tr
                   key={r.start_number}
@@ -269,8 +291,27 @@ export function AnalysisPanel({ starters, raceMeters, raceStartMethod }: Analysi
                   <td className="py-1.5 pr-2">
                     <DistBadge factor={r.dist_signal.factor} label={r.dist_signal.label} />
                   </td>
-                  <td className="py-1.5 text-right">
+                  <td className="py-1.5 pr-2 text-right">
                     <ValueBadge value={r.value} active={r.streckning_loaded} />
+                  </td>
+                  <td className="py-1.5 text-right">
+                    {starter?.finish_position != null ? (
+                      <span
+                        className={`text-xs font-bold px-1.5 py-0.5 rounded-full ${
+                          starter.finish_position === 1
+                            ? "bg-yellow-400 text-black"
+                            : starter.finish_position === 2
+                            ? "bg-gray-300 text-black"
+                            : starter.finish_position === 3
+                            ? "bg-amber-600 text-white"
+                            : "bg-gray-500 text-white"
+                        }`}
+                      >
+                        {starter.finish_position}:a{starter.finish_time ? ` ${starter.finish_time}` : ""}
+                      </span>
+                    ) : (
+                      <span className="text-gray-400 dark:text-gray-600 text-xs">–</span>
+                    )}
                   </td>
                 </tr>
               );

--- a/components/HorseCard.tsx
+++ b/components/HorseCard.tsx
@@ -63,6 +63,7 @@ interface Starter {
   last_5_results: LastResult[];
   formscore: number | null;
   finish_position: number | null;
+  finish_time: string | null;
   horses: { name: string } | null;
 }
 
@@ -319,48 +320,12 @@ export function HorseCard({
   return (
     <div className={`bg-gray-100 dark:bg-gray-800 rounded-lg p-4 flex flex-col gap-3 ${isValue ? "ring-2 ring-green-500 ring-inset" : ""}`}>
       {/* Huvud: nummer, namn, driver, streck, odds, FS */}
-      <div className="flex items-start justify-between gap-2">
-        <div className="flex items-center gap-2 min-w-0">
-          <span className="text-gray-500 dark:text-gray-400 text-sm shrink-0 w-5 text-center">
-            {starter.start_number}
-          </span>
-          <div className="min-w-0">
-            <p className="text-gray-900 dark:text-white font-semibold truncate">
-              {starter.horses?.name ?? "–"}
-            </p>
-            <p className="text-gray-500 dark:text-gray-400 text-xs truncate">{starter.driver}</p>
-          </div>
-        </div>
-        <div className="flex items-center gap-2 shrink-0 flex-wrap justify-end">
-          {starter.bet_distribution != null && starter.bet_distribution > 0 && (
-            <span
-              className="text-blue-700 dark:text-blue-400 text-xs font-semibold"
-              title="Streckprocent i V85-poolen"
-            >
-              {starter.bet_distribution.toFixed(1)}%
-            </span>
-          )}
-          {starter.odds != null && (
-            <span className="text-gray-700 dark:text-gray-300 text-sm" title="Vinnarodds">
-              {starter.odds.toFixed(1)}x
-              {vi != null && (
-                <span
-                  className={`ml-1 text-xs font-semibold ${vi > 0 ? "text-green-600 dark:text-green-400" : "text-red-500 dark:text-red-400"}`}
-                  title="Värdeindex: skillnad mellan beräknad vinstchans och odds-implicit sannolikhet"
-                >
-                  {vi > 0 ? "+" : ""}{vi.toFixed(1)}%{vi > 0 ? "↑" : "↓"}
-                </span>
-              )}
-            </span>
-          )}
-          {compScore != null ? (
-            <FormBadge score={compScore} title="Sammansatt poäng (0–100): form, värde, konsistens och tid" label="CS" />
-          ) : (
-            <FormBadge score={starter.formscore} />
-          )}
+      <div className="flex flex-col gap-1">
+        {/* Rad 1: resultat (om finns), startnummer, namn */}
+        <div className="flex items-center gap-2 flex-wrap">
           {starter.finish_position != null && (
             <span
-              className={`text-xs font-bold px-2 py-1 rounded-full ${
+              className={`text-sm font-bold px-2.5 py-1 rounded-full shrink-0 ${
                 starter.finish_position === 1
                   ? "bg-yellow-400 text-black"
                   : starter.finish_position === 2
@@ -371,9 +336,47 @@ export function HorseCard({
               }`}
               title={`Slutplacering: ${starter.finish_position}`}
             >
-              {starter.finish_position}:a
+              {starter.finish_position}:a{starter.finish_time ? ` ${starter.finish_time}` : ""}
             </span>
           )}
+          <span className="text-gray-500 dark:text-gray-400 text-sm shrink-0 w-5 text-center">
+            {starter.start_number}
+          </span>
+          <span className="text-gray-900 dark:text-white font-semibold">
+            {starter.horses?.name ?? "–"}
+          </span>
+        </div>
+        {/* Rad 2: driver + stats */}
+        <div className="flex items-center justify-between gap-2">
+          <p className="text-gray-500 dark:text-gray-400 text-xs">{starter.driver}</p>
+          <div className="flex items-center gap-2 shrink-0 flex-wrap justify-end">
+            {starter.bet_distribution != null && starter.bet_distribution > 0 && (
+              <span
+                className="text-blue-700 dark:text-blue-400 text-xs font-semibold"
+                title="Streckprocent i V85-poolen"
+              >
+                {starter.bet_distribution.toFixed(1)}%
+              </span>
+            )}
+            {starter.odds != null && (
+              <span className="text-gray-700 dark:text-gray-300 text-sm" title="Vinnarodds">
+                {starter.odds.toFixed(1)}x
+                {vi != null && (
+                  <span
+                    className={`ml-1 text-xs font-semibold ${vi > 0 ? "text-green-600 dark:text-green-400" : "text-red-500 dark:text-red-400"}`}
+                    title="Värdeindex: skillnad mellan beräknad vinstchans och odds-implicit sannolikhet"
+                  >
+                    {vi > 0 ? "+" : ""}{vi.toFixed(1)}%{vi > 0 ? "↑" : "↓"}
+                  </span>
+                )}
+              </span>
+            )}
+            {compScore != null ? (
+              <FormBadge score={compScore} title="Sammansatt poäng (0–100): form, värde, konsistens och tid" label="CS" />
+            ) : (
+              <FormBadge score={starter.formscore} />
+            )}
+          </div>
         </div>
       </div>
 

--- a/components/RaceList.tsx
+++ b/components/RaceList.tsx
@@ -58,6 +58,7 @@ interface Starter {
   life_records: LifeRecord[] | null;
   formscore: number | null;
   finish_position: number | null;
+  finish_time: string | null;
   horses: { name: string } | null;
 }
 

--- a/components/TopFiveRanking.tsx
+++ b/components/TopFiveRanking.tsx
@@ -19,6 +19,8 @@ interface RankedHorse {
   estimatedWinPct: number;
   odds: number | null;
   isValue: boolean;
+  finish_position: number | null;
+  finish_time: string | null;
 }
 
 const MEDAL_COLORS = [
@@ -46,6 +48,8 @@ export function TopFiveRanking({ races }: { races: RaceForRanking[] }) {
         estimatedWinPct: h.estimatedWinPct,
         odds: oddsMap[h.startNumber] ?? null,
         isValue: h.isValue,
+        finish_position: h.finish_position ?? null,
+        finish_time: h.finish_time ?? null,
       });
     }
   }
@@ -96,6 +100,24 @@ export function TopFiveRanking({ races }: { races: RaceForRanking[] }) {
                 {horse.odds ? ` \u00B7 Odds ${horse.odds}` : ""}
               </span>
             </div>
+
+            {/* Resultat */}
+            {horse.finish_position != null && (
+              <span
+                className={`text-xs font-bold px-2 py-1 rounded-full shrink-0 ${
+                  horse.finish_position === 1
+                    ? "bg-yellow-400 text-black"
+                    : horse.finish_position === 2
+                    ? "bg-gray-300 text-black"
+                    : horse.finish_position === 3
+                    ? "bg-amber-600 text-white"
+                    : "bg-gray-500 text-white"
+                }`}
+                title={`Slutplacering: ${horse.finish_position}`}
+              >
+                {horse.finish_position}:a{horse.finish_time ? ` ${horse.finish_time}` : ""}
+              </span>
+            )}
 
             {/* Score */}
             <div className="text-right shrink-0">

--- a/lib/analysis.ts
+++ b/lib/analysis.ts
@@ -99,6 +99,8 @@ export interface AnalysisStarter {
   places_3rd?: number | null;
   best_time?: string | null;
   last_5_results?: { place: string; date: string; track: string; time: string }[];
+  finish_position?: number | null;
+  finish_time?: string | null;
 }
 
 /**
@@ -265,6 +267,8 @@ export interface HorseAnalysis {
   impliedWinPct: number;
   isValue: boolean;
   rank: number;
+  finish_position?: number | null;
+  finish_time?: string | null;
 }
 
 function parsePlaceStr(place: string): number {
@@ -372,6 +376,8 @@ export function analyzeRaceEnhanced(starters: AnalysisStarter[]): HorseAnalysis[
       impliedWinPct: Math.round(d.impliedProb * 1000) / 10,
       isValue: cs > 55 && d.vi > 0,
       rank: 0,
+      finish_position: d.s.finish_position ?? null,
+      finish_time: d.s.finish_time ?? null,
     };
   });
 


### PR DESCRIPTION
Add support for finish_position and finish_time across analysis types and UI, show result badges in AnalysisPanel, HorseCard and TopFiveRanking, and adjust layouts to accommodate the new column. On the server side deduplicate ATG starters (some races returned duplicate horses), use uniqueStarters for scoring and DB writes, and switch horse upsert to onConflict:"id" so horse names get updated. Also update the DB select to include finish_time and propagate finish fields into HorseAnalysis.