### PR TITLE
Lägg till kollapsibel mobilmeny och PWA-installationsprompt

### DIFF
--- a/app/(authenticated)/layout.tsx
+++ b/app/(authenticated)/layout.tsx
@@ -1,4 +1,5 @@
 import { BottomNav } from "@/components/BottomNav";
+import { InstallPrompt } from "@/components/InstallPrompt";
 
 export default function AuthenticatedLayout({
   children,
@@ -9,6 +10,7 @@ export default function AuthenticatedLayout({
     <div className="pb-16 md:pb-0">
       {children}
       <BottomNav />
+      <InstallPrompt />
     </div>
   );
 }

--- a/app/(authenticated)/page.tsx
+++ b/app/(authenticated)/page.tsx
@@ -6,6 +6,7 @@ import { GameSelector } from "@/components/GameSelector";
 import { UserMenu } from "@/components/groups/UserMenu";
 import { ThemeToggle } from "@/components/ThemeToggle";
 import { UsefulLinks } from "@/components/UsefulLinks";
+import { CollapsibleControls } from "@/components/CollapsibleControls";
 import { getProfile, getMyGroups } from "@/lib/actions/groups";
 import { redirect } from "next/navigation";
 
@@ -83,12 +84,12 @@ export default async function HomePage({
             />
           </div>
         </div>
-        {/* Rad 2: spelkontroller (alltid synliga) */}
-        <div className="flex items-center gap-2 flex-wrap mt-2">
+        {/* Rad 2: spelkontroller – kollapsibara på mobil, alltid synliga på desktop */}
+        <CollapsibleControls>
           <GameSelector games={games} selectedId={selectedId} />
           <ResultsButton gameId={selectedId} />
           <FetchButton />
-        </div>
+        </CollapsibleControls>
       </header>
 
       {selectedGame && (

--- a/components/CollapsibleControls.tsx
+++ b/components/CollapsibleControls.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { useState } from "react";
+
+export function CollapsibleControls({ children }: { children: React.ReactNode }) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div className="mt-2">
+      {/* Toggle-knapp – bara synlig på mobil */}
+      <button
+        onClick={() => setOpen(!open)}
+        className="md:hidden w-full flex items-center justify-between py-1 text-xs text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition-colors"
+        aria-expanded={open}
+        aria-label={open ? "Dölj spelkontroller" : "Visa spelkontroller"}
+      >
+        <span className="font-medium">{open ? "Dölj kontroller" : "Spelkontroller"}</span>
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          fill="currentColor"
+          className={`w-4 h-4 transition-transform duration-200 ${open ? "rotate-180" : ""}`}
+        >
+          <path
+            fillRule="evenodd"
+            d="M12.53 16.28a.75.75 0 01-1.06 0l-7.5-7.5a.75.75 0 011.06-1.06L12 14.69l6.97-6.97a.75.75 0 111.06 1.06l-7.5 7.5z"
+            clipRule="evenodd"
+          />
+        </svg>
+      </button>
+
+      {/* Kontroller – alltid synliga på desktop, expanderbara på mobil */}
+      <div
+        className={`${
+          open ? "flex" : "hidden"
+        } md:flex items-center gap-2 flex-wrap pt-1`}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/components/InstallPrompt.tsx
+++ b/components/InstallPrompt.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import { useState, useEffect } from "react";
+
+interface BeforeInstallPromptEvent extends Event {
+  prompt: () => Promise<void>;
+  userChoice: Promise<{ outcome: "accepted" | "dismissed" }>;
+}
+
+const DISMISSED_KEY = "pwa-install-dismissed";
+
+export function InstallPrompt() {
+  const [deferredPrompt, setDeferredPrompt] = useState<BeforeInstallPromptEvent | null>(null);
+  const [isIOS, setIsIOS] = useState(false);
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    // Redan installerad som PWA
+    if (window.matchMedia("(display-mode: standalone)").matches) return;
+    // Användaren har stängt prompten tidigare
+    if (localStorage.getItem(DISMISSED_KEY)) return;
+
+    // iOS-detektion (Safari)
+    const ua = navigator.userAgent;
+    const isIOSDevice =
+      /iPad|iPhone|iPod/.test(ua) &&
+      !(window as unknown as { MSStream?: unknown }).MSStream;
+
+    if (isIOSDevice) {
+      setIsIOS(true);
+      setVisible(true);
+      return;
+    }
+
+    // Android / Chrome – lyssna på beforeinstallprompt
+    const handler = (e: Event) => {
+      e.preventDefault();
+      setDeferredPrompt(e as BeforeInstallPromptEvent);
+      setVisible(true);
+    };
+    window.addEventListener("beforeinstallprompt", handler);
+    return () => window.removeEventListener("beforeinstallprompt", handler);
+  }, []);
+
+  const handleInstall = async () => {
+    if (!deferredPrompt) return;
+    await deferredPrompt.prompt();
+    const { outcome } = await deferredPrompt.userChoice;
+    setDeferredPrompt(null);
+    if (outcome === "accepted") {
+      dismiss();
+    }
+  };
+
+  const dismiss = () => {
+    setVisible(false);
+    localStorage.setItem(DISMISSED_KEY, "1");
+  };
+
+  if (!visible) return null;
+
+  return (
+    <div className="fixed bottom-16 left-0 right-0 z-40 px-3 pb-2 md:hidden">
+      <div className="bg-indigo-600 dark:bg-indigo-700 rounded-2xl p-3 flex items-center gap-3 shadow-xl">
+        {/* App-ikon */}
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          src="/apple-touch-icon.png"
+          alt=""
+          className="w-12 h-12 rounded-xl shrink-0 shadow"
+        />
+
+        {/* Text + knapp */}
+        <div className="flex-1 min-w-0">
+          <p className="text-white text-sm font-semibold leading-tight">
+            Installera V85 Analys
+          </p>
+          {isIOS ? (
+            <p className="text-indigo-200 text-xs mt-0.5 leading-snug">
+              Tryck på{" "}
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                fill="currentColor"
+                className="w-3 h-3 inline-block align-middle"
+              >
+                <path d="M11.47 1.72a.75.75 0 011.06 0l3 3a.75.75 0 01-1.06 1.06l-1.72-1.72V7.5h-1.5V4.06L9.53 5.78a.75.75 0 01-1.06-1.06l3-3zM11.25 7.5V15a.75.75 0 001.5 0V7.5h3.75a3 3 0 013 3v9a3 3 0 01-3 3h-9a3 3 0 01-3-3v-9a3 3 0 013-3h3.75z" />
+              </svg>{" "}
+              och välj &quot;Lägg till på hemskärmen&quot;
+            </p>
+          ) : (
+            <>
+              <p className="text-indigo-200 text-xs mt-0.5">
+                Snabbare åtkomst, fungerar offline
+              </p>
+              <button
+                onClick={handleInstall}
+                className="mt-1.5 px-3 py-1 bg-white text-indigo-600 text-xs font-bold rounded-lg shadow"
+              >
+                Installera
+              </button>
+            </>
+          )}
+        </div>
+
+        {/* Stäng */}
+        <button
+          onClick={dismiss}
+          className="self-start text-indigo-200 hover:text-white transition-colors shrink-0 p-1"
+          aria-label="Stäng"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            fill="currentColor"
+            className="w-5 h-5"
+          >
+            <path
+              fillRule="evenodd"
+              d="M5.47 5.47a.75.75 0 011.06 0L12 10.94l5.47-5.47a.75.75 0 111.06 1.06L13.06 12l5.47 5.47a.75.75 0 11-1.06 1.06L12 13.06l-5.47 5.47a.75.75 0 01-1.06-1.06L10.94 12 5.47 6.53a.75.75 0 010-1.06z"
+              clipRule="evenodd"
+            />
+          </svg>
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
- CollapsibleControls: spelkontroller i headern kollapsas på mobil via chevron
  så att de inte täcker innehållet – alltid synliga på desktop
- InstallPrompt: banner ovanför BottomNav föreslår installation som app
  (beforeinstallprompt på Android/Chrome, manuell instruktion för iOS Safari)
  Visas bara på mobil och kan stängas, val sparas i localStorage

https://claude.ai/code/session_01XpA7kjA3ivnSmZxG7hiuwr