### PR TITLE
Fix layout: make sidebar fixed and remove centered container

### DIFF
--- a/app/(authenticated)/page.tsx
+++ b/app/(authenticated)/page.tsx
@@ -75,7 +75,7 @@ export default async function HomePage({
     <main className="min-h-screen bg-white dark:bg-gray-950 text-gray-900 dark:text-white">
       {/* Header: mobilanpassad med 2 rader på små skärmar */}
       <header className="sticky top-0 z-30 bg-white/90 dark:bg-gray-950/90 backdrop-blur-sm border-b border-gray-200 dark:border-gray-800">
-        <div className="max-w-5xl mx-auto px-4 py-4">
+        <div className="px-4 py-4">
           {/* Rad 1: titel + avatar/tema */}
           <div className="flex items-center justify-between">
             <h1 className="text-base font-semibold tracking-tight shrink-0">Streckspel Analys</h1>
@@ -98,12 +98,12 @@ export default async function HomePage({
       </header>
 
       {selectedGame && (
-        <div className="max-w-5xl mx-auto px-4 py-2 text-xs text-gray-400 dark:text-gray-500 border-b border-gray-200 dark:border-gray-800 tracking-wide">
+        <div className="px-4 py-2 text-xs text-gray-400 dark:text-gray-500 border-b border-gray-200 dark:border-gray-800 tracking-wide">
           {selectedGame.date} &middot; {selectedGame.game_type} &middot; {selectedGame.track}
         </div>
       )}
 
-      <div className="max-w-5xl mx-auto px-4 py-6">
+      <div className="px-4 py-6">
         <div className="mb-6">
           <UsefulLinks />
         </div>

--- a/components/MainPageClient.tsx
+++ b/components/MainPageClient.tsx
@@ -92,41 +92,39 @@ export function MainPageClient({
         </div>
       )}
 
-      {/* Flex-rad: listan + desktop-sidopanel */}
-      <div className={systemMode ? "flex items-start" : ""}>
-        <div className={systemMode ? "flex-1 min-w-0" : ""}>
-          {races.length === 0 ? (
-            <div className="text-center py-20 text-gray-400 dark:text-gray-500">
-              <p className="text-lg mb-2">Ingen data inladdad ännu.</p>
-              <p className="text-sm">
-                Välj ett datum och klicka på ett spel för att ladda en omgång från ATG.
-              </p>
-            </div>
-          ) : (
-            <RaceList
-              races={races}
-              userGroups={userGroups}
-              currentUserId={currentUserId}
-              systemMode={systemMode}
-              systemSelections={systemSelections}
-              onToggleHorse={handleToggleHorse}
-            />
-          )}
-        </div>
-
-        {/* Desktop-sidopanel (dold på mobil) */}
-        {systemMode && (
-          <SystemSidebar
+      {/* Innehåll: får högerpadding på desktop när sidopanelen är öppen */}
+      <div className={systemMode ? "md:pr-[320px]" : ""}>
+        {races.length === 0 ? (
+          <div className="text-center py-20 text-gray-400 dark:text-gray-500">
+            <p className="text-lg mb-2">Ingen data inladdad ännu.</p>
+            <p className="text-sm">
+              Välj ett datum och klicka på ett spel för att ladda en omgång från ATG.
+            </p>
+          </div>
+        ) : (
+          <RaceList
             races={races}
-            selections={systemSelections}
+            userGroups={userGroups}
+            currentUserId={currentUserId}
+            systemMode={systemMode}
+            systemSelections={systemSelections}
             onToggleHorse={handleToggleHorse}
-            onSave={handleOpenSaveDialog}
-            onCancel={handleCancelSystemMode}
-            totalRows={totalRows}
-            gameType={gameType}
           />
         )}
       </div>
+
+      {/* Desktop-sidopanel: fast till högerkanten (dold på mobil) */}
+      {systemMode && (
+        <SystemSidebar
+          races={races}
+          selections={systemSelections}
+          onToggleHorse={handleToggleHorse}
+          onSave={handleOpenSaveDialog}
+          onCancel={handleCancelSystemMode}
+          totalRows={totalRows}
+          gameType={gameType}
+        />
+      )}
 
       {/* Mobil: sticky banner längst ner (dold på desktop) */}
       {systemMode && (

--- a/components/SystemSidebar.tsx
+++ b/components/SystemSidebar.tsx
@@ -45,7 +45,7 @@ export function SystemSidebar({
   const completedRaces = selections.length;
 
   return (
-    <aside className="hidden md:flex flex-col w-[320px] flex-shrink-0 sticky top-0 self-start max-h-screen border-l border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900">
+    <aside className="hidden md:flex flex-col fixed right-0 top-[120px] bottom-0 z-20 w-[320px] border-l border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900">
       {/* Header */}
       <div className="px-3 py-3 border-b border-gray-200 dark:border-gray-800 flex-shrink-0">
         <div className="font-bold text-sm text-gray-900 dark:text-white">🎯 Din kupong</div>


### PR DESCRIPTION
Remove max-width centered containers in page layout (replace max-w-5xl mx-auto with full-width px padding) so content spans the available width. Reserve space for a fixed 320px desktop sidebar by adding md:pr-[320px] to the main content when systemMode is active. Move desktop SystemSidebar out of the main flex flow and make it fixed to the right (right-0, top-[120px], bottom-0, z-20), and keep the mobile sticky banner behavior. Also move save/cancel/totalRows/gameType props out of RaceList into the SystemSidebar and simplify RaceList props accordingly. These changes simplify responsive behavior and allow the sidebar to remain fixed at the viewport edge on desktop.