### PR TITLE
Redesign horse display: compact cards, sticky race tabs, sort dropdown

### DIFF
--- a/app/(authenticated)/page.tsx
+++ b/app/(authenticated)/page.tsx
@@ -7,8 +7,10 @@ import { UserMenu } from "@/components/groups/UserMenu";
 import { ThemeToggle } from "@/components/ThemeToggle";
 import { UsefulLinks } from "@/components/UsefulLinks";
 import { CollapsibleControls } from "@/components/CollapsibleControls";
+import { RaceTabBar } from "@/components/RaceTabBar";
 import { getProfile, getMyGroups } from "@/lib/actions/groups";
 import { redirect } from "next/navigation";
+import { Suspense } from "react";
 
 async function getAllGames(supabase: Awaited<ReturnType<typeof createClient>>) {
   const { data } = await supabase
@@ -45,7 +47,7 @@ async function getRaces(supabase: Awaited<ReturnType<typeof createClient>>, game
 export default async function HomePage({
   searchParams,
 }: {
-  searchParams: Promise<{ game?: string; systemMode?: string; groupId?: string }>;
+  searchParams: Promise<{ game?: string; systemMode?: string; groupId?: string; avd?: string }>;
 }) {
   const supabase = await createClient();
   const {
@@ -71,6 +73,11 @@ export default async function HomePage({
   const initialSystemMode = params.systemMode === '1'
   const initialGroupId = params.groupId ?? null
 
+  const avdParam = params.avd ? parseInt(params.avd, 10) : NaN;
+  const activeRaceNumber = (!isNaN(avdParam) && races.some((r) => r.race_number === avdParam))
+    ? avdParam
+    : (races[0]?.race_number ?? 1);
+
   return (
     <main className="min-h-screen bg-white dark:bg-gray-950 text-gray-900 dark:text-white">
       {/* Header: mobilanpassad med 2 rader på små skärmar */}
@@ -95,6 +102,14 @@ export default async function HomePage({
             <FetchButton />
           </CollapsibleControls>
         </div>
+        {races.length > 0 && (
+          <Suspense fallback={<div className="h-10 border-t border-gray-200 dark:border-gray-800" />}>
+            <RaceTabBar
+              races={races.map((r) => ({ race_number: r.race_number, start_time: r.start_time }))}
+              activeRaceNumber={activeRaceNumber}
+            />
+          </Suspense>
+        )}
       </header>
 
       {selectedGame && (
@@ -111,6 +126,7 @@ export default async function HomePage({
         <MainPageClient
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           races={races as any}
+          activeRaceNumber={activeRaceNumber}
           userGroups={userGroups}
           currentUserId={user.id}
           initialSystemMode={initialSystemMode}

--- a/components/HorseCard.tsx
+++ b/components/HorseCard.tsx
@@ -95,8 +95,11 @@ function FormBadge({ score, label }: { score: number | null; label?: string }) {
     <span className="relative inline-block">
       <button
         type="button"
-        onClick={(e) => { e.stopPropagation(); setOpen((v) => !v); }}
-        className={`${color} text-white text-xs font-bold font-mono px-2 py-1 rounded-md cursor-pointer select-none`}
+        onClick={(e) => {
+          e.stopPropagation();
+          setOpen((v) => !v);
+        }}
+        className={`${color} text-white text-[10px] font-bold font-mono px-1.5 py-0.5 rounded cursor-pointer select-none`}
       >
         {label ?? "FS"} {score}
       </button>
@@ -201,7 +204,11 @@ function PlacementStr(
   return `${starts} st  ${wins ?? 0}-${p2 ?? 0}-${p3 ?? 0}`;
 }
 
-function LifeRecordsTable({ records, currentMethod, currentDistance }: {
+function LifeRecordsTable({
+  records,
+  currentMethod,
+  currentDistance,
+}: {
   records: LifeRecord[];
   currentMethod: string;
   currentDistance: string;
@@ -221,7 +228,9 @@ function LifeRecordsTable({ records, currentMethod, currentDistance }: {
               <th
                 key={d}
                 className={`text-center pb-1 px-2 font-normal ${
-                  d === currentDistance ? "text-indigo-600 dark:text-indigo-400 font-semibold" : "text-gray-500 dark:text-gray-400"
+                  d === currentDistance
+                    ? "text-indigo-600 dark:text-indigo-400 font-semibold"
+                    : "text-gray-500 dark:text-gray-400"
                 }`}
               >
                 {DIST_LABEL[d]}
@@ -232,7 +241,13 @@ function LifeRecordsTable({ records, currentMethod, currentDistance }: {
         <tbody>
           {methods.map((method) => (
             <tr key={method}>
-              <td className={`pr-2 py-0.5 ${method === currentMethod ? "text-indigo-600 dark:text-indigo-400 font-semibold" : "text-gray-500 dark:text-gray-400"}`}>
+              <td
+                className={`pr-2 py-0.5 ${
+                  method === currentMethod
+                    ? "text-indigo-600 dark:text-indigo-400 font-semibold"
+                    : "text-gray-500 dark:text-gray-400"
+                }`}
+              >
                 {method === "auto" ? "Auto" : "Volt"}
               </td>
               {distances.map((dist) => {
@@ -316,7 +331,11 @@ export function HorseCard({
     : null;
 
   const platsRate = starter.starts_total
-    ? Math.round((((starter.wins_total ?? 0) + (starter.places_2nd ?? 0) + (starter.places_3rd ?? 0)) / starter.starts_total) * 100)
+    ? Math.round(
+        (((starter.wins_total ?? 0) + (starter.places_2nd ?? 0) + (starter.places_3rd ?? 0)) /
+          starter.starts_total) *
+          100
+      )
     : null;
 
   const krPerStart =
@@ -327,7 +346,6 @@ export function HorseCard({
   const sex = SEX_LABEL[starter.horse_sex ?? ""] ?? starter.horse_sex ?? "";
   const shoesChanged = starter.shoes_front_changed || starter.shoes_back_changed;
 
-  // Bestäm nuvarande distans-kategori för life_records-tabellen
   const currentDistanceCategory =
     raceDistance == null
       ? "short"
@@ -338,211 +356,281 @@ export function HorseCard({
       : "long";
   const currentMethod = raceStartMethod ?? "auto";
 
+  // Färg för startnummerboxen baserat på slutplacering
+  const finishBoxColor =
+    starter.finish_position === 1
+      ? "bg-yellow-400 text-black"
+      : starter.finish_position === 2
+      ? "bg-gray-300 text-black"
+      : starter.finish_position === 3
+      ? "bg-amber-600 text-white"
+      : starter.finish_position != null
+      ? "bg-gray-500 text-white"
+      : "bg-gray-100 dark:bg-gray-800 text-gray-900 dark:text-white";
+
+  const cardBorder = isSelected
+    ? "border-gray-200 dark:border-gray-800 border-l-4 border-l-emerald-500"
+    : isValue
+    ? "border-green-400 dark:border-green-600"
+    : "border-gray-200 dark:border-gray-800";
+
   return (
-    <div className={`rounded-lg p-4 flex flex-col gap-3 border ${
-      isSelected
-        ? "bg-white dark:bg-gray-900 border-gray-200 dark:border-gray-800 border-l-4 border-l-emerald-500"
-        : isValue
-        ? "bg-white dark:bg-gray-900 border-green-400 dark:border-green-600"
-        : "bg-white dark:bg-gray-900 border-gray-200 dark:border-gray-800"
-    }`}>
-      {/* Huvud: nummer, namn, driver, streck, odds, FS */}
-      <div className="flex flex-col gap-1">
-        {/* Rad 1: sorteringsrank (om aktiv), resultat (om finns), startnummer, namn */}
-        <div className="flex items-center gap-2 flex-wrap">
-          {sortRank != null && (
-            <span
-              className="text-xs font-bold text-indigo-400 dark:text-indigo-300 shrink-0 w-5 text-center"
-              title="Placering i aktuell sortering"
-            >
-              #{sortRank}
+    <div
+      className={`rounded-lg border bg-white dark:bg-gray-900 ${cardBorder} cursor-pointer select-none`}
+      onClick={() => setExpanded((v) => !v)}
+    >
+      {/* ── Kompakt huvud ── */}
+      <div className="flex items-center gap-2.5 px-3 py-2.5">
+        {/* Startnummerbox / systemknapp */}
+        {onSelect != null ? (
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              onSelect();
+            }}
+            title={isSelected ? "Ta bort från system" : "Lägg till i system"}
+            className={`w-8 h-8 rounded flex items-center justify-center text-sm font-bold transition-colors shrink-0 ${
+              isSelected
+                ? "bg-emerald-500 text-white ring-2 ring-emerald-300"
+                : "bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-200 hover:bg-emerald-200 dark:hover:bg-emerald-800"
+            }`}
+          >
+            {starter.start_number}
+          </button>
+        ) : (
+          <div
+            className={`w-8 h-8 rounded flex items-center justify-center text-sm font-bold shrink-0 ${finishBoxColor}`}
+            title={
+              starter.finish_position != null
+                ? `Slutplacering: ${starter.finish_position}${starter.finish_time ? ` · ${starter.finish_time}` : ""}`
+                : undefined
+            }
+          >
+            {starter.start_number}
+          </div>
+        )}
+
+        {/* Hästnamn + kusk */}
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-1 min-w-0">
+            {sortRank != null && (
+              <span className="text-[10px] font-bold text-indigo-400 dark:text-indigo-300 shrink-0">
+                #{sortRank}
+              </span>
+            )}
+            <span className="font-bold text-[13px] tracking-tight text-gray-900 dark:text-white truncate">
+              {starter.horses?.name ?? "–"}
+              {shoesChanged && (
+                <span className="ml-1 text-[10px] text-amber-400 font-semibold" title="Skoändring">
+                  ★
+                </span>
+              )}
             </span>
-          )}
-          {starter.finish_position != null && (
-            <span
-              className={`text-sm font-bold px-2.5 py-1 rounded-full shrink-0 ${
-                starter.finish_position === 1
-                  ? "bg-yellow-400 text-black"
-                  : starter.finish_position === 2
-                  ? "bg-gray-300 text-black"
-                  : starter.finish_position === 3
-                  ? "bg-amber-600 text-white"
-                  : "bg-gray-500 text-white"
-              }`}
-              title={`Slutplacering: ${starter.finish_position}`}
-            >
-              {starter.finish_position}:a{starter.finish_time ? ` ${starter.finish_time}` : ""}
-            </span>
-          )}
-          {onSelect != null ? (
-            <button
-              onClick={onSelect}
-              title={isSelected ? 'Ta bort från system' : 'Lägg till i system'}
-              className={`w-7 h-7 rounded-full flex items-center justify-center text-sm font-bold transition-colors shrink-0 ${
-                isSelected
-                  ? 'bg-emerald-500 text-white ring-2 ring-emerald-300'
-                  : 'bg-gray-300 dark:bg-gray-600 text-gray-700 dark:text-gray-200 hover:bg-emerald-200 dark:hover:bg-emerald-800'
-              }`}
-            >
-              {starter.start_number}
-            </button>
-          ) : (
-            <span className="text-gray-500 dark:text-gray-400 text-sm shrink-0 w-5 text-center">
-              {starter.start_number}
-            </span>
-          )}
-          <span className="text-gray-900 dark:text-white font-bold text-[15px] tracking-tight">
-            {starter.horses?.name ?? "–"}
+          </div>
+          <span className="text-[11px] text-gray-500 dark:text-gray-400 truncate block">
+            {starter.driver}
           </span>
         </div>
-        {/* Rad 2: driver + odds + streck */}
-        <div className="flex items-center justify-between gap-2">
-          <p className="text-gray-500 dark:text-gray-400 text-xs truncate">{starter.driver}</p>
-          <div className="flex items-center gap-2 shrink-0">
+
+        {/* Höger: streck% · odds · badges */}
+        <div className="flex flex-col items-end gap-0.5 shrink-0">
+          <div className="flex items-center gap-1.5">
             {starter.bet_distribution != null && starter.bet_distribution > 0 && (
               <span
                 className="text-indigo-600 dark:text-indigo-400 text-xs font-semibold"
-                title="Streckprocent i V85-poolen"
+                title="Streckprocent"
               >
                 {starter.bet_distribution.toFixed(1)}%
               </span>
             )}
             {starter.odds != null && (
-              <span className="text-gray-700 dark:text-gray-300 text-sm" title="Vinnarodds">
+              <span className="text-gray-700 dark:text-gray-300 text-xs" title="Vinnarodds">
                 {starter.odds.toFixed(1)}x
-                {vi != null && (
-                  <span
-                    className={`ml-1 text-xs font-semibold ${vi > 0 ? "text-green-600 dark:text-green-400" : "text-red-500 dark:text-red-400"}`}
-                    title="Värdeindex: skillnad mellan beräknad vinstchans och odds-implicit sannolikhet"
-                  >
-                    {vi > 0 ? "+" : ""}{vi.toFixed(1)}%{vi > 0 ? "↑" : "↓"}
-                  </span>
-                )}
               </span>
             )}
           </div>
-        </div>
-        {/* Rad 3: FS + CS badges */}
-        {(starter.formscore != null || compScore != null) && (
-          <div className="flex items-center gap-2">
-            <FormBadge score={starter.formscore} />
+          <div className="flex items-center gap-1">
+            {starter.formscore != null && <FormBadge score={starter.formscore} />}
             {compScore != null && <FormBadge score={compScore} label="CS" />}
           </div>
-        )}
-      </div>
-
-      {/* Häst-info: ålder, kön, färg, far, hemmaplan */}
-      <div className="text-xs text-gray-500 dark:text-gray-400 space-y-0.5">
-        {(starter.horse_age || sex || starter.horse_color) && (
-          <p>
-            {[
-              starter.horse_age ? `${starter.horse_age} år` : null,
-              sex || null,
-              starter.horse_color || null,
-            ]
-              .filter(Boolean)
-              .join(" · ")}
-          </p>
-        )}
-        {starter.pedigree_father && (
-          <p>Far: <span className="text-gray-700 dark:text-gray-300">{starter.pedigree_father}</span></p>
-        )}
-        {starter.home_track && (
-          <p>Hemmaplan: <span className="text-gray-700 dark:text-gray-300">{starter.home_track}</span></p>
-        )}
-      </div>
-
-      {/* Skoinfo + sulky */}
-      {starter.shoes_reported && (
-        <div
-          className={`rounded p-2 text-xs border ${
-            shoesChanged
-              ? "border-amber-300 dark:border-amber-700/60 bg-amber-50/50 dark:bg-amber-900/20"
-              : "border-gray-200 dark:border-gray-700/50"
-          }`}
-        >
-          <div className="flex items-center justify-between gap-2">
-            <div className="flex items-center gap-4">
-              <ShoeBadge hasShoe={starter.shoes_front} changed={starter.shoes_front_changed} label="Fram" />
-              <ShoeBadge hasShoe={starter.shoes_back} changed={starter.shoes_back_changed} label="Bak" />
-            </div>
-            {starter.sulky_type && (
-              <span className="text-gray-500 dark:text-gray-400 ml-auto">Vagn: {starter.sulky_type}</span>
-            )}
-          </div>
-        </div>
-      )}
-
-      {/* Snabbstatistik: karriär */}
-      <div className="grid grid-cols-3 text-center text-xs border border-gray-200 dark:border-gray-700 rounded-lg divide-x divide-gray-200 dark:divide-gray-700">
-        <div className="p-2">
-          <p className="text-[10px] uppercase tracking-wide text-gray-400 dark:text-gray-500">Livs</p>
-          <p className="text-gray-900 dark:text-white font-semibold">
-            {starter.wins_total ?? "–"}-{starter.places_2nd ?? "–"}-{starter.places_3rd ?? "–"}
-          </p>
-          <p className="text-gray-400 dark:text-gray-500 text-[10px]">{starter.starts_total ?? "–"} st</p>
-        </div>
-        <div className="p-2">
-          <p className="text-[10px] uppercase tracking-wide text-gray-400 dark:text-gray-500">År</p>
-          <p className="text-gray-900 dark:text-white font-semibold">
-            {winRateYear != null ? `${winRateYear}%` : "–"}
-          </p>
-          <p className="text-gray-400 dark:text-gray-500 text-[10px]">{starter.starts_current_year ?? "–"} st</p>
-        </div>
-        <div className="p-2">
-          <p className="text-[10px] uppercase tracking-wide text-gray-400 dark:text-gray-500">Rekord</p>
-          <p className="text-gray-900 dark:text-white font-semibold">{starter.best_time || "–"}</p>
-          <p className="text-gray-400 dark:text-gray-500 text-[10px]">
-            {platsRate != null ? `Plats ${platsRate}%` : ""}
-          </p>
         </div>
       </div>
 
-      {/* Senaste 5 bubblor (om data finns) */}
+      {/* Senaste 5 resultat — alltid synliga */}
       {starter.last_5_results.length > 0 && (
-        <div className="flex gap-1">
+        <div className="flex gap-1 px-3 pb-2">
           {starter.last_5_results.map((r, i) => {
             const color =
-              r.place === "1" ? "bg-yellow-500 text-black" :
-              r.place === "2" ? "bg-gray-300 text-black" :
-              r.place === "3" ? "bg-orange-600 text-white" :
-              "bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300";
+              r.place === "1"
+                ? "bg-yellow-500 text-black"
+                : r.place === "2"
+                ? "bg-gray-300 text-black"
+                : r.place === "3"
+                ? "bg-orange-600 text-white"
+                : "bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300";
             return (
               <span
                 key={i}
-                className={`${color} text-xs font-bold w-6 h-6 flex items-center justify-center rounded`}
+                className={`${color} text-[10px] font-bold w-5 h-5 flex items-center justify-center rounded`}
                 title={`${r.date} · ${r.track} · ${r.time}`}
               >
                 {r.place || "–"}
               </span>
             );
           })}
+          {vi != null && (
+            <span
+              className={`ml-auto text-[10px] font-semibold ${
+                vi > 0 ? "text-green-600 dark:text-green-400" : "text-red-500 dark:text-red-400"
+              }`}
+              title="Värdeindex"
+            >
+              {vi > 0 ? "+" : ""}
+              {vi.toFixed(1)}%{vi > 0 ? "↑" : "↓"}
+            </span>
+          )}
         </div>
       )}
 
-      {/* Expand-knapp */}
-      <button
-        onClick={() => setExpanded(!expanded)}
-        className="text-xs text-indigo-600 dark:text-indigo-400 hover:text-indigo-800 dark:hover:text-indigo-200 flex items-center gap-1 self-start transition"
-      >
-        {expanded ? "▲ Dölj detaljer" : "▼ Visa detaljer"}
-      </button>
+      {/* Expand-indikator */}
+      <div className="px-3 pb-1.5 flex items-center justify-between">
+        <span className="text-[10px] text-gray-300 dark:text-gray-700">
+          {expanded ? "▲ Dölj" : "▼ Detaljer"}
+        </span>
+      </div>
 
-      {/* Expanderat innehåll */}
+      {/* ── Expanderat innehåll ── */}
       {expanded && (
-        <div className="flex flex-col gap-3 border-t border-gray-200 dark:border-gray-700 pt-3">
+        <div
+          className="border-t border-gray-200 dark:border-gray-700 px-3 pt-3 pb-3 flex flex-col gap-3"
+          onClick={(e) => e.stopPropagation()}
+        >
+          {/* Slutplacering (om resultat finns) */}
+          {starter.finish_position != null && (
+            <div className="flex items-center gap-2">
+              <span
+                className={`text-sm font-bold px-2.5 py-1 rounded-full ${
+                  starter.finish_position === 1
+                    ? "bg-yellow-400 text-black"
+                    : starter.finish_position === 2
+                    ? "bg-gray-300 text-black"
+                    : starter.finish_position === 3
+                    ? "bg-amber-600 text-white"
+                    : "bg-gray-500 text-white"
+                }`}
+              >
+                {starter.finish_position}:a
+                {starter.finish_time ? ` ${starter.finish_time}` : ""}
+              </span>
+            </div>
+          )}
+
+          {/* Häst-info */}
+          <div className="text-xs text-gray-500 dark:text-gray-400 space-y-0.5">
+            {(starter.horse_age || sex || starter.horse_color) && (
+              <p>
+                {[
+                  starter.horse_age ? `${starter.horse_age} år` : null,
+                  sex || null,
+                  starter.horse_color || null,
+                ]
+                  .filter(Boolean)
+                  .join(" · ")}
+              </p>
+            )}
+            {starter.pedigree_father && (
+              <p>
+                Far:{" "}
+                <span className="text-gray-700 dark:text-gray-300">
+                  {starter.pedigree_father}
+                </span>
+              </p>
+            )}
+            {starter.home_track && (
+              <p>
+                Hemmaplan:{" "}
+                <span className="text-gray-700 dark:text-gray-300">{starter.home_track}</span>
+              </p>
+            )}
+          </div>
+
+          {/* Skoinfo + sulky */}
+          {starter.shoes_reported && (
+            <div
+              className={`rounded p-2 text-xs border ${
+                shoesChanged
+                  ? "border-amber-300 dark:border-amber-700/60 bg-amber-50/50 dark:bg-amber-900/20"
+                  : "border-gray-200 dark:border-gray-700/50"
+              }`}
+            >
+              <div className="flex items-center justify-between gap-2">
+                <div className="flex items-center gap-4">
+                  <ShoeBadge
+                    hasShoe={starter.shoes_front}
+                    changed={starter.shoes_front_changed}
+                    label="Fram"
+                  />
+                  <ShoeBadge
+                    hasShoe={starter.shoes_back}
+                    changed={starter.shoes_back_changed}
+                    label="Bak"
+                  />
+                </div>
+                {starter.sulky_type && (
+                  <span className="text-gray-500 dark:text-gray-400 ml-auto">
+                    Vagn: {starter.sulky_type}
+                  </span>
+                )}
+              </div>
+            </div>
+          )}
+
+          {/* Snabbstatistik: karriär */}
+          <div className="grid grid-cols-3 text-center text-xs border border-gray-200 dark:border-gray-700 rounded-lg divide-x divide-gray-200 dark:divide-gray-700">
+            <div className="p-2">
+              <p className="text-[10px] uppercase tracking-wide text-gray-400 dark:text-gray-500">Livs</p>
+              <p className="text-gray-900 dark:text-white font-semibold">
+                {starter.wins_total ?? "–"}-{starter.places_2nd ?? "–"}-{starter.places_3rd ?? "–"}
+              </p>
+              <p className="text-gray-400 dark:text-gray-500 text-[10px]">
+                {starter.starts_total ?? "–"} st
+              </p>
+            </div>
+            <div className="p-2">
+              <p className="text-[10px] uppercase tracking-wide text-gray-400 dark:text-gray-500">År</p>
+              <p className="text-gray-900 dark:text-white font-semibold">
+                {winRateYear != null ? `${winRateYear}%` : "–"}
+              </p>
+              <p className="text-gray-400 dark:text-gray-500 text-[10px]">
+                {starter.starts_current_year ?? "–"} st
+              </p>
+            </div>
+            <div className="p-2">
+              <p className="text-[10px] uppercase tracking-wide text-gray-400 dark:text-gray-500">Rekord</p>
+              <p className="text-gray-900 dark:text-white font-semibold">
+                {starter.best_time || "–"}
+              </p>
+              <p className="text-gray-400 dark:text-gray-500 text-[10px]">
+                {platsRate != null ? `Plats ${platsRate}%` : ""}
+              </p>
+            </div>
+          </div>
 
           {/* Bästa tider per distans & startmetod */}
           {starter.life_records && starter.life_records.length > 0 && (
             <div>
-              <p className="text-xs font-semibold text-gray-700 dark:text-gray-300 mb-1">Bästa tider</p>
+              <p className="text-xs font-semibold text-gray-700 dark:text-gray-300 mb-1">
+                Bästa tider
+              </p>
               <LifeRecordsTable
                 records={starter.life_records}
                 currentMethod={currentMethod}
                 currentDistance={currentDistanceCategory}
               />
               <p className="text-[10px] text-gray-400 dark:text-gray-500 mt-0.5">
-                Markerat = dagens lopp ({currentMethod === "auto" ? "autostart" : "voltstart"}, {DIST_LABEL[currentDistanceCategory]?.toLowerCase()})
+                Markerat = dagens lopp (
+                {currentMethod === "auto" ? "autostart" : "voltstart"},{" "}
+                {DIST_LABEL[currentDistanceCategory]?.toLowerCase()})
               </p>
             </div>
           )}
@@ -553,24 +641,40 @@ export function HorseCard({
             <div className="border border-gray-200 dark:border-gray-700 rounded p-2 space-y-0.5">
               <StatRow
                 label="Starter livs"
-                value={PlacementStr(starter.starts_total, starter.wins_total, starter.places_2nd, starter.places_3rd)}
+                value={PlacementStr(
+                  starter.starts_total,
+                  starter.wins_total,
+                  starter.places_2nd,
+                  starter.places_3rd
+                )}
               />
               <StatRow
                 label="Innevarande år"
-                value={PlacementStr(starter.starts_current_year, starter.wins_current_year, starter.places_2nd_current_year, starter.places_3rd_current_year)}
+                value={PlacementStr(
+                  starter.starts_current_year,
+                  starter.wins_current_year,
+                  starter.places_2nd_current_year,
+                  starter.places_3rd_current_year
+                )}
               />
               <StatRow
                 label="Föregående år"
-                value={PlacementStr(starter.starts_prev_year, starter.wins_prev_year, starter.places_2nd_prev_year, starter.places_3rd_prev_year)}
+                value={PlacementStr(
+                  starter.starts_prev_year,
+                  starter.wins_prev_year,
+                  starter.places_2nd_prev_year,
+                  starter.places_3rd_prev_year
+                )}
               />
-              {platsRate != null && (
-                <StatRow label="Plats%" value={`${platsRate}%`} />
-              )}
+              {platsRate != null && <StatRow label="Plats%" value={`${platsRate}%`} />}
               {krPerStart != null && (
                 <StatRow label="Kr/start" value={krPerStart.toLocaleString("sv-SE")} />
               )}
               {starter.earnings_total != null && starter.earnings_total > 0 && (
-                <StatRow label="Total intjänat" value={starter.earnings_total.toLocaleString("sv-SE") + " kr"} />
+                <StatRow
+                  label="Total intjänat"
+                  value={starter.earnings_total.toLocaleString("sv-SE") + " kr"}
+                />
               )}
             </div>
           </div>
@@ -593,13 +697,17 @@ export function HorseCard({
           {/* Kusk & Tränare */}
           {(starter.driver || starter.trainer) && (
             <div>
-              <p className="text-xs font-semibold text-gray-700 dark:text-gray-300 mb-1">Kusk & Tränare</p>
-              <div className="bg-gray-200 dark:bg-gray-700/60 rounded p-2 space-y-1">
+              <p className="text-xs font-semibold text-gray-700 dark:text-gray-300 mb-1">
+                Kusk & Tränare
+              </p>
+              <div className="bg-gray-100 dark:bg-gray-800 rounded p-2 space-y-1">
                 {starter.driver && (
                   <div className="flex justify-between text-xs py-0.5">
                     <span className="text-gray-500 dark:text-gray-400">{starter.driver}</span>
                     <span className="text-gray-900 dark:text-white font-medium">
-                      {starter.driver_win_pct != null ? `${starter.driver_win_pct}% vinst (år)` : "–"}
+                      {starter.driver_win_pct != null
+                        ? `${starter.driver_win_pct}% vinst (år)`
+                        : "–"}
                     </span>
                   </div>
                 )}
@@ -607,7 +715,9 @@ export function HorseCard({
                   <div className="flex justify-between text-xs py-0.5">
                     <span className="text-gray-500 dark:text-gray-400">{starter.trainer}</span>
                     <span className="text-gray-900 dark:text-white font-medium">
-                      {starter.trainer_win_pct != null ? `${starter.trainer_win_pct}% vinst (år)` : "–"}
+                      {starter.trainer_win_pct != null
+                        ? `${starter.trainer_win_pct}% vinst (år)`
+                        : "–"}
                     </span>
                   </div>
                 )}
@@ -615,10 +725,12 @@ export function HorseCard({
             </div>
           )}
 
-          {/* Senaste 5 starter — detaljvy */}
+          {/* Senaste starter */}
           <div>
             <div className="flex items-center justify-between mb-1">
-              <p className="text-xs font-semibold text-gray-700 dark:text-gray-300">Senaste starter</p>
+              <p className="text-xs font-semibold text-gray-700 dark:text-gray-300">
+                Senaste starter
+              </p>
               {fetchedStarts === null && (
                 <button
                   onClick={handleFetchStarts}
@@ -650,8 +762,12 @@ export function HorseCard({
                       <tr key={i} className="border-t border-gray-200 dark:border-gray-700">
                         <td className="py-1 text-gray-500 dark:text-gray-400">{r.date}</td>
                         <td className="py-1 text-gray-700 dark:text-gray-300">{r.track}</td>
-                        <td className="py-1 text-center font-bold text-gray-900 dark:text-white">{r.place || "–"}</td>
-                        <td className="py-1 text-right text-gray-700 dark:text-gray-300">{r.time}</td>
+                        <td className="py-1 text-center font-bold text-gray-900 dark:text-white">
+                          {r.place || "–"}
+                        </td>
+                        <td className="py-1 text-right text-gray-700 dark:text-gray-300">
+                          {r.time}
+                        </td>
                       </tr>
                     ))}
                   </tbody>
@@ -659,7 +775,9 @@ export function HorseCard({
               </div>
             )}
             {fetchedStarts !== null && fetchedStarts.length === 0 && (
-              <p className="text-xs text-gray-400 dark:text-gray-500 italic">Inga starter hittades.</p>
+              <p className="text-xs text-gray-400 dark:text-gray-500 italic">
+                Inga starter hittades.
+              </p>
             )}
             {fetchedStarts === null && !fetchingStarts && !startsError && (
               <p className="text-xs text-gray-400 dark:text-gray-500 italic">
@@ -667,11 +785,11 @@ export function HorseCard({
               </p>
             )}
           </div>
+
+          {/* Anteckningar */}
+          {notesSection}
         </div>
       )}
-
-      {/* Anteckningar */}
-      {notesSection}
     </div>
   );
 }

--- a/components/MainPageClient.tsx
+++ b/components/MainPageClient.tsx
@@ -17,6 +17,7 @@ function computeTotalRows(selections: SystemSelection[]): number {
 
 interface MainPageClientProps {
   races: RaceListRaces
+  activeRaceNumber: number
   userGroups: Group[]
   currentUserId: string
   initialSystemMode?: boolean
@@ -27,6 +28,7 @@ interface MainPageClientProps {
 
 export function MainPageClient({
   races,
+  activeRaceNumber,
   userGroups,
   currentUserId,
   initialSystemMode = false,
@@ -104,6 +106,7 @@ export function MainPageClient({
         ) : (
           <RaceList
             races={races}
+            activeRaceNumber={activeRaceNumber}
             userGroups={userGroups}
             currentUserId={currentUserId}
             systemMode={systemMode}

--- a/components/RaceList.tsx
+++ b/components/RaceList.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { HorseCard } from "./HorseCard";
 import { AnalysisPanel } from "./AnalysisPanel";
 import { HorseNotes } from "./notes/HorseNotes";
@@ -74,6 +74,7 @@ interface Race {
 
 export function RaceList({
   races,
+  activeRaceNumber,
   userGroups,
   currentUserId,
   systemMode,
@@ -81,26 +82,33 @@ export function RaceList({
   onToggleHorse,
 }: {
   races: Race[];
+  activeRaceNumber: number;
   userGroups: Group[];
   currentUserId: string;
   systemMode?: boolean;
   systemSelections?: SystemSelection[];
   onToggleHorse?: (raceNumber: number, horse: SystemHorse) => void;
 }) {
-  const [openRace, setOpenRace] = useState<string | null>(races[0]?.id ?? null);
-  const [analysisRace, setAnalysisRace] = useState<string | null>(null);
+  const [showAnalysis, setShowAnalysis] = useState(false);
   const [sortKey, setSortKey] = useState<SortKey>("composite");
   const [filterValue, setFilterValue] = useState(false);
   const [hideOutsiders, setHideOutsiders] = useState(false);
   const [search, setSearch] = useState("");
 
-  const SORT_OPTIONS: { key: SortKey; label: string; title: string }[] = [
-    { key: "number", label: "Nr", title: "Startnummer" },
-    { key: "composite", label: "CS — sammansatt poäng", title: "Sammansatt poäng (CS): form, värde, konsistens och tid" },
-    { key: "formscore", label: "FS — formscore", title: "Formscore (FS): vinstprocent, odds och tid" },
-    { key: "odds", label: "Odds", title: "Vinnarodds (lägst först)" },
-    { key: "bet", label: "Streck%", title: "Streckprocent (högst först)" },
+  // Reset analysis panel when switching races
+  useEffect(() => {
+    setShowAnalysis(false);
+  }, [activeRaceNumber]);
+
+  const SORT_OPTIONS: { key: SortKey; label: string }[] = [
+    { key: "composite", label: "CS — sammansatt poäng" },
+    { key: "formscore", label: "FS — formscore" },
+    { key: "number", label: "Startnummer" },
+    { key: "odds", label: "Odds (lägst)" },
+    { key: "bet", label: "Streck% (högst)" },
   ];
+
+  const activeRace = races.find((r) => r.race_number === activeRaceNumber) ?? races[0];
 
   function sortStarters(
     starters: Starter[],
@@ -129,198 +137,177 @@ export function RaceList({
     });
   }
 
+  if (!activeRace) return null;
+
   const hasActiveFilter = filterValue || hideOutsiders || search.trim().length > 0;
 
+  const enhanced = analyzeRaceEnhanced(activeRace.starters);
+  const enhancedMap = Object.fromEntries(enhanced.map((h) => [h.startNumber, h]));
+  const compositeMap = Object.fromEntries(enhanced.map((h) => [h.startNumber, h.compositeScore]));
+
+  const q = search.trim().toLowerCase();
+  const filtered = activeRace.starters
+    .filter((s) => !filterValue || enhancedMap[s.start_number]?.isValue)
+    .filter((s) => !hideOutsiders || s.odds == null || s.odds <= 50)
+    .filter((s) => {
+      if (!q) return true;
+      return (
+        (s.horses?.name ?? "").toLowerCase().includes(q) ||
+        s.driver.toLowerCase().includes(q) ||
+        s.trainer.toLowerCase().includes(q)
+      );
+    });
+
+  const sorted = sortStarters(filtered, compositeMap);
+  const raceSelections = systemSelections?.find((s) => s.race_number === activeRace.race_number);
+
+  const startTimeStr = activeRace.start_time
+    ? new Date(activeRace.start_time).toLocaleTimeString("sv-SE", {
+        hour: "2-digit",
+        minute: "2-digit",
+      })
+    : null;
+
   return (
-    <div className="space-y-2">
+    <div className="space-y-3">
       <TopFiveRanking races={races} />
 
-      {/* Sorterings- och filterkontroller */}
-      <div className="space-y-2 px-1 pb-1">
-        {/* Rad 1: Sortering */}
-        <div className="flex items-center gap-2 flex-wrap">
-          <span className="text-xs text-gray-500 dark:text-gray-400 shrink-0">Sortera:</span>
+      {/* Toolbar: sortering + filter på en rad */}
+      <div className="flex items-center gap-2 flex-wrap px-1">
+        {/* Sort dropdown */}
+        <select
+          value={sortKey}
+          onChange={(e) => setSortKey(e.target.value as SortKey)}
+          className="text-xs px-2 py-1.5 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 focus:outline-none focus:border-indigo-400 cursor-pointer"
+        >
           {SORT_OPTIONS.map((opt) => (
-            <button
-              key={opt.key}
-              onClick={() => setSortKey(opt.key)}
-              title={opt.title}
-              className={`text-xs px-3 py-1 rounded-lg border transition font-medium ${
-                sortKey === opt.key
-                  ? "bg-indigo-700 border-indigo-600 text-white"
-                  : "bg-transparent border-gray-300 dark:border-gray-600 text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800"
-              }`}
-            >
+            <option key={opt.key} value={opt.key}>
               {opt.label}
-            </button>
+            </option>
           ))}
-        </div>
+        </select>
 
-        {/* Rad 2: Filter */}
-        <div className="flex items-center gap-2 flex-wrap">
-          <span className="text-xs text-gray-500 dark:text-gray-400 shrink-0">Filtrera:</span>
+        {/* Filter chips */}
+        <button
+          onClick={() => setFilterValue((v) => !v)}
+          className={`text-xs px-3 py-1.5 rounded-lg border transition font-medium ${
+            filterValue
+              ? "bg-green-600 border-green-500 text-white"
+              : "bg-transparent border-gray-300 dark:border-gray-600 text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800"
+          }`}
+        >
+          Värde
+        </button>
+        <button
+          onClick={() => setHideOutsiders((v) => !v)}
+          className={`text-xs px-3 py-1.5 rounded-lg border transition font-medium ${
+            hideOutsiders
+              ? "bg-indigo-700 border-indigo-600 text-white"
+              : "bg-transparent border-gray-300 dark:border-gray-600 text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800"
+          }`}
+        >
+          Dölj &gt;50x
+        </button>
+        {hasActiveFilter && (
           <button
-            onClick={() => setFilterValue((v) => !v)}
-            className={`text-xs px-3 py-1 rounded-lg border transition font-medium ${
-              filterValue
-                ? "bg-green-600 border-green-500 text-white"
-                : "bg-transparent border-gray-300 dark:border-gray-600 text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800"
-            }`}
+            onClick={() => {
+              setFilterValue(false);
+              setHideOutsiders(false);
+              setSearch("");
+            }}
+            className="text-xs px-2 py-1.5 text-gray-400 dark:text-gray-500 hover:text-red-500 transition"
           >
-            Värde
+            Rensa ✕
           </button>
-          <button
-            onClick={() => setHideOutsiders((v) => !v)}
-            className={`text-xs px-3 py-1 rounded-lg border transition font-medium ${
-              hideOutsiders
-                ? "bg-indigo-700 border-indigo-600 text-white"
-                : "bg-transparent border-gray-300 dark:border-gray-600 text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800"
-            }`}
-          >
-            Dölj &gt;50x
-          </button>
-          {hasActiveFilter && (
-            <button
-              onClick={() => { setFilterValue(false); setHideOutsiders(false); setSearch(""); }}
-              className="text-xs px-2 py-1 text-gray-400 dark:text-gray-500 hover:text-red-500 transition"
-            >
-              Rensa filter ✕
-            </button>
-          )}
-        </div>
-        {/* Rad 3: Sök (hel bredd på mobil) */}
-        <div>
-          <input
-            type="text"
-            value={search}
-            onChange={(e) => setSearch(e.target.value)}
-            placeholder="Sök häst, kusk, tränare…"
-            className="text-xs px-3 py-1.5 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:border-indigo-400 w-full sm:w-56"
-          />
-        </div>
+        )}
+
+        {/* Sök */}
+        <input
+          type="text"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder="Sök häst, kusk…"
+          className="text-xs px-3 py-1.5 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:border-indigo-400 w-full sm:w-44 ml-auto"
+        />
       </div>
 
-      {races.map((race, index) => {
-        const isOpen = openRace === race.id;
-        const showAnalysis = analysisRace === race.id;
+      {/* Loppinfo + analysknapp */}
+      <div className="flex items-center justify-between px-1 text-xs text-gray-500 dark:text-gray-400">
+        <span className="truncate">
+          {activeRace.race_name ?? `Avdelning ${activeRace.race_number}`}
+          {startTimeStr && <span className="ml-2">{startTimeStr}</span>}
+          <span className="ml-2">{activeRace.distance} m</span>
+          {activeRace.start_method && (
+            <span className="ml-2 capitalize">{activeRace.start_method}</span>
+          )}
+        </span>
+        <button
+          onClick={() => setShowAnalysis((v) => !v)}
+          className={`ml-3 shrink-0 text-xs px-3 py-1.5 rounded-lg border transition font-medium ${
+            showAnalysis
+              ? "bg-indigo-700 border-indigo-600 text-white"
+              : "bg-transparent border-indigo-700 text-indigo-600 dark:text-indigo-400 hover:bg-indigo-50 dark:hover:bg-indigo-900/30"
+          }`}
+        >
+          {showAnalysis ? "Dölj analys" : "Visa analys"}
+        </button>
+      </div>
 
-        // Beräkna utökad analys per lopp — indexeras på start_number
-        const enhanced = analyzeRaceEnhanced(race.starters);
-        const enhancedMap = Object.fromEntries(enhanced.map((h) => [h.startNumber, h]));
-        const compositeMap = Object.fromEntries(
-          enhanced.map((h) => [h.startNumber, h.compositeScore])
-        );
+      {/* Analysvy */}
+      {showAnalysis && (
+        <AnalysisPanel
+          starters={sorted}
+          raceMeters={activeRace.distance}
+          raceStartMethod={activeRace.start_method ?? "auto"}
+        />
+      )}
 
-        // Filtrera
-        const q = search.trim().toLowerCase();
-        const filtered = race.starters
-          .filter((s) => !filterValue || enhancedMap[s.start_number]?.isValue)
-          .filter((s) => !hideOutsiders || s.odds == null || s.odds <= 50)
-          .filter((s) => {
-            if (!q) return true;
-            return (
-              (s.horses?.name ?? "").toLowerCase().includes(q) ||
-              s.driver.toLowerCase().includes(q) ||
-              s.trainer.toLowerCase().includes(q)
-            );
-          });
+      {sorted.length === 0 && (
+        <p className="text-sm text-gray-400 dark:text-gray-500 text-center py-8">
+          Inga hästar matchar filtret.
+        </p>
+      )}
 
-        // Sortera
-        const sorted = sortStarters(filtered, compositeMap);
-
-        const raceSelections = systemSelections?.find(s => s.race_number === race.race_number);
-
-        return (
-          <div key={race.id} className="bg-gray-50 dark:bg-gray-900 rounded-xl overflow-hidden">
-            <button
-              onClick={() => setOpenRace(isOpen ? null : race.id)}
-              className="w-full flex items-center justify-between px-5 py-3 text-left hover:bg-gray-100 dark:hover:bg-gray-800 transition"
-            >
-              <div className="flex items-center gap-3 min-w-0">
-                <span className="text-gray-900 dark:text-white font-semibold shrink-0">
-                  Avd {index + 1}
-                </span>
-                {race.race_name && (
-                  <span className="text-gray-500 dark:text-gray-400 text-xs truncate hidden sm:block">
-                    {race.race_name}
-                  </span>
-                )}
-              </div>
-              <span className="text-gray-500 dark:text-gray-400 text-sm shrink-0 ml-2">
-                {race.start_time
-                  ? new Date(race.start_time).toLocaleTimeString("sv-SE", {
-                      hour: "2-digit",
-                      minute: "2-digit",
-                    }) + " · "
-                  : ""}
-                {race.distance} m &nbsp;{isOpen ? "▲" : "▼"}
-              </span>
-            </button>
-
-            {isOpen && (
-              <div className="px-4 pb-4">
-                <div className="flex justify-end mb-2">
-                  <button
-                    onClick={() => setAnalysisRace(showAnalysis ? null : race.id)}
-                    className={`text-xs px-3 py-1.5 rounded-lg border transition font-medium ${
-                      showAnalysis
-                        ? "bg-indigo-700 border-indigo-600 text-white"
-                        : "bg-transparent border-indigo-700 text-indigo-600 dark:text-indigo-400 hover:bg-indigo-50 dark:hover:bg-indigo-900/30"
-                    }`}
-                  >
-                    {showAnalysis ? "Dölj analys" : "Visa analys"}
-                  </button>
-                </div>
-
-                {showAnalysis && (
-                  <AnalysisPanel
-                    starters={sorted}
-                    raceMeters={race.distance}
-                    raceStartMethod={race.start_method ?? "auto"}
-                  />
-                )}
-
-                {sorted.length === 0 && (
-                  <p className="text-sm text-gray-400 dark:text-gray-500 text-center py-4">
-                    Inga hästar matchar filtret.
-                  </p>
-                )}
-
-                <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3 mt-3">
-                  {sorted.map((s, idx) => {
-                    const enh = enhancedMap[s.start_number];
-                    return (
-                      <HorseCard
-                        key={s.id}
-                        starter={s}
-                        raceDistance={race.distance}
-                        raceStartMethod={race.start_method ?? "auto"}
-                        compositeScore={enh?.compositeScore}
-                        valueIndex={enh?.valueIndex}
-                        isValue={enh?.isValue}
-                        sortRank={sortKey !== "number" ? idx + 1 : undefined}
-                        isSelected={systemMode ? raceSelections?.horses.some(h => h.horse_id === s.horse_id) ?? false : undefined}
-                        onSelect={systemMode && onToggleHorse ? () => onToggleHorse(race.race_number, {
-                          horse_id: s.horse_id,
-                          start_number: s.start_number,
-                          horse_name: s.horses?.name ?? '',
-                        }) : undefined}
-                        notesSection={
-                          <HorseNotes
-                            horseId={s.horse_id}
-                            userGroups={userGroups}
-                            currentUserId={currentUserId}
-                          />
-                        }
-                      />
-                    );
-                  })}
-                </div>
-              </div>
-            )}
-          </div>
-        );
-      })}
+      {/* Hästgrid: 1 → 2 → 3 → 4 kolumner */}
+      <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+        {sorted.map((s, idx) => {
+          const enh = enhancedMap[s.start_number];
+          return (
+            <HorseCard
+              key={s.id}
+              starter={s}
+              raceDistance={activeRace.distance}
+              raceStartMethod={activeRace.start_method ?? "auto"}
+              compositeScore={enh?.compositeScore}
+              valueIndex={enh?.valueIndex}
+              isValue={enh?.isValue}
+              sortRank={sortKey !== "number" ? idx + 1 : undefined}
+              isSelected={
+                systemMode
+                  ? (raceSelections?.horses.some((h) => h.horse_id === s.horse_id) ?? false)
+                  : undefined
+              }
+              onSelect={
+                systemMode && onToggleHorse
+                  ? () =>
+                      onToggleHorse(activeRace.race_number, {
+                        horse_id: s.horse_id,
+                        start_number: s.start_number,
+                        horse_name: s.horses?.name ?? "",
+                      })
+                  : undefined
+              }
+              notesSection={
+                <HorseNotes
+                  horseId={s.horse_id}
+                  userGroups={userGroups}
+                  currentUserId={currentUserId}
+                />
+              }
+            />
+          );
+        })}
+      </div>
     </div>
   );
 }

--- a/components/RaceTabBar.tsx
+++ b/components/RaceTabBar.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useRouter, useSearchParams } from "next/navigation";
+
+interface RaceTabBarProps {
+  races: { race_number: number; start_time: string | null }[];
+  activeRaceNumber: number;
+}
+
+export function RaceTabBar({ races, activeRaceNumber }: RaceTabBarProps) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  function handleTabClick(raceNumber: number) {
+    const params = new URLSearchParams(searchParams.toString());
+    params.set("avd", String(raceNumber));
+    router.replace(`?${params.toString()}`);
+  }
+
+  return (
+    <div className="border-t border-gray-200 dark:border-gray-800 overflow-x-auto scrollbar-none">
+      <div className="flex px-3 gap-0.5 py-1.5 min-w-max">
+        {races.map((race) => {
+          const isActive = race.race_number === activeRaceNumber;
+          const timeStr = race.start_time
+            ? new Date(race.start_time).toLocaleTimeString("sv-SE", {
+                hour: "2-digit",
+                minute: "2-digit",
+              })
+            : null;
+          return (
+            <button
+              key={race.race_number}
+              onClick={() => handleTabClick(race.race_number)}
+              className={`px-3 py-1.5 text-xs font-semibold rounded-md whitespace-nowrap transition-colors ${
+                isActive
+                  ? "bg-indigo-700 text-white"
+                  : "text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 hover:text-gray-900 dark:hover:text-white"
+              }`}
+            >
+              AVD {race.race_number}
+              {timeStr && (
+                <span className="ml-1 font-normal opacity-70">{timeStr}</span>
+              )}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
- New RaceTabBar component: sticky AVD 1-N tab navigation in the header,
  switches races via ?avd=N URL param without resetting system selections
- HorseCard: compact default view (number box, name, driver, bet%, odds,
  FS/CS badges, last-5 dots); all details hidden behind click-to-expand
- RaceList: single-race view (no accordion), sort dropdown replaces 5
  buttons, filter + sort on one toolbar row, xl:grid-cols-4 for large screens
- page.tsx: reads ?avd param, includes RaceTabBar in sticky header
- MainPageClient: forwards activeRaceNumber to RaceList

https://claude.ai/code/session_0184vgmNfbwV67LH31vXRXnr