### PR TITLE
feat: spelval, auto-hämtning och utkast-system

### DIFF
--- a/app/(authenticated)/page.tsx
+++ b/app/(authenticated)/page.tsx
@@ -1,16 +1,18 @@
 import { createClient } from "@/lib/supabase/server";
 import { MainPageClient } from "@/components/MainPageClient";
-import { FetchButton } from "@/components/FetchButton";
 import { ResultsButton } from "@/components/ResultsButton";
-import { GameSelector } from "@/components/GameSelector";
+import { GamePickerBar } from "@/components/GamePickerBar";
+import { AutoLoadUpcoming } from "@/components/AutoLoadUpcoming";
 import { UserMenu } from "@/components/groups/UserMenu";
 import { ThemeToggle } from "@/components/ThemeToggle";
 import { UsefulLinks } from "@/components/UsefulLinks";
 import { CollapsibleControls } from "@/components/CollapsibleControls";
 import { RaceTabBar } from "@/components/RaceTabBar";
 import { getProfile, getMyGroups } from "@/lib/actions/groups";
+import { getDraftForGame } from "@/lib/actions/systems";
 import { redirect } from "next/navigation";
 import { Suspense } from "react";
+import type { SystemSelection } from "@/lib/types";
 
 async function getAllGames(supabase: Awaited<ReturnType<typeof createClient>>) {
   const { data } = await supabase
@@ -47,7 +49,7 @@ async function getRaces(supabase: Awaited<ReturnType<typeof createClient>>, game
 export default async function HomePage({
   searchParams,
 }: {
-  searchParams: Promise<{ game?: string; systemMode?: string; groupId?: string; avd?: string }>;
+  searchParams: Promise<{ game?: string; systemMode?: string; groupId?: string; avd?: string; draft?: string }>;
 }) {
   const supabase = await createClient();
   const {
@@ -73,6 +75,19 @@ export default async function HomePage({
   const initialSystemMode = params.systemMode === '1'
   const initialGroupId = params.groupId ?? null
 
+  // Ladda utkast om draft-param finns, eller det senaste utkastet för spelet
+  let draftId: string | null = null
+  let initialSelections: SystemSelection[] = []
+
+  if (selectedId) {
+    // Om draft-ID angavs explicit i URL, eller leta upp senaste utkast
+    const existingDraft = await getDraftForGame(selectedId)
+    if (existingDraft) {
+      draftId = existingDraft.id
+      initialSelections = existingDraft.selections ?? []
+    }
+  }
+
   const avdParam = params.avd ? parseInt(params.avd, 10) : NaN;
   const activeRaceNumber = (!isNaN(avdParam) && races.some((r) => r.race_number === avdParam))
     ? avdParam
@@ -95,11 +110,10 @@ export default async function HomePage({
               />
             </div>
           </div>
-          {/* Rad 2: spelkontroller – kollapsibara på mobil, alltid synliga på desktop */}
+          {/* Rad 2: spelkontroller */}
           <CollapsibleControls>
-            <GameSelector games={games} selectedId={selectedId} />
+            <GamePickerBar savedGames={games} selectedId={selectedId} />
             <ResultsButton gameId={selectedId} />
-            <FetchButton />
           </CollapsibleControls>
         </div>
         {races.length > 0 && (
@@ -123,6 +137,9 @@ export default async function HomePage({
           <UsefulLinks />
         </div>
 
+        {/* Auto-ladda nästkommande V85/V86 om inga spel finns */}
+        {games.length === 0 && <AutoLoadUpcoming />}
+
         <MainPageClient
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           races={races as any}
@@ -133,6 +150,8 @@ export default async function HomePage({
           initialGroupId={initialGroupId}
           gameId={selectedId}
           gameType={selectedGame?.game_type ?? null}
+          draftId={draftId}
+          initialSelections={initialSelections}
         />
       </div>
     </main>

--- a/app/api/games/upcoming/route.ts
+++ b/app/api/games/upcoming/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from "next/server";
+import { fetchAvailableGames } from "@/lib/atg";
+
+// Prioritetsordning för speltyper vi vill auto-ladda
+const PRIORITY_TYPES = ["V86", "V85", "V75", "V65", "V64"];
+
+function todayLocal(): string {
+  const d = new Date();
+  return d.toLocaleDateString("sv-SE");
+}
+
+function tomorrowLocal(): string {
+  const d = new Date();
+  d.setDate(d.getDate() + 1);
+  return d.toLocaleDateString("sv-SE");
+}
+
+/**
+ * GET /api/games/upcoming
+ * Returnerar det nästkommande V86/V85/V75-spelet från ATG-kalendern.
+ * Kollar idag och imorgon.
+ */
+export async function GET() {
+  const dates = [todayLocal(), tomorrowLocal()];
+
+  for (const date of dates) {
+    try {
+      const games = await fetchAvailableGames(date);
+      for (const type of PRIORITY_TYPES) {
+        const match = games.find((g) => g.type === type);
+        if (match) {
+          return NextResponse.json({ game: match, date });
+        }
+      }
+    } catch {
+      // Hoppa över datum om ATG inte svarar
+    }
+  }
+
+  return NextResponse.json({ game: null, date: null });
+}

--- a/components/AutoLoadUpcoming.tsx
+++ b/components/AutoLoadUpcoming.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
+import type { AvailableGame } from "@/lib/atg";
+
+interface UpcomingResponse {
+  game: AvailableGame | null;
+  date: string | null;
+}
+
+/**
+ * Visas när inga spel är sparade.
+ * Letar automatiskt upp nästkommande V86/V85/V75 och erbjuder att hämta det.
+ */
+export function AutoLoadUpcoming() {
+  const router = useRouter();
+  const [upcoming, setUpcoming] = useState<UpcomingResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [fetching, setFetching] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetch("/api/games/upcoming")
+      .then((r) => r.json())
+      .then((data: UpcomingResponse) => setUpcoming(data))
+      .catch(() => setUpcoming({ game: null, date: null }))
+      .finally(() => setLoading(false));
+  }, []);
+
+  async function handleAutoLoad() {
+    if (!upcoming?.game) return;
+    setFetching(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/games/fetch", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ gameType: upcoming.game.type, gameId: upcoming.game.id }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error ?? "Fel");
+      router.push(`/?game=${encodeURIComponent(data.game_id)}`);
+      router.refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Okänt fel");
+      setFetching(false);
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="text-center py-6 text-sm text-gray-400 dark:text-gray-500">
+        Letar efter nästa spel...
+      </div>
+    );
+  }
+
+  if (!upcoming?.game) {
+    return null; // Inga spel hittades — visa standard tom-vy
+  }
+
+  const dateLabel = upcoming.date === new Date().toLocaleDateString("sv-SE") ? "idag" : "imorgon";
+
+  return (
+    <div className="mb-6 rounded-xl border border-indigo-200 dark:border-indigo-800 bg-indigo-50 dark:bg-indigo-950 p-5 text-center">
+      <div className="text-3xl mb-2">🏇</div>
+      <h2 className="text-base font-bold text-gray-900 dark:text-white mb-1">
+        {upcoming.game.label} {dateLabel}
+      </h2>
+      <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">
+        Hämta spelet för att se hästar och börja analysera.
+      </p>
+      {error && (
+        <p className="text-sm text-red-500 mb-3">{error}</p>
+      )}
+      <button
+        onClick={handleAutoLoad}
+        disabled={fetching}
+        className="px-6 py-2.5 rounded-xl bg-indigo-600 hover:bg-indigo-500 text-white font-bold text-sm disabled:opacity-60 transition"
+      >
+        {fetching ? "Hämtar..." : `Hämta ${upcoming.game.label}`}
+      </button>
+    </div>
+  );
+}

--- a/components/GamePickerBar.tsx
+++ b/components/GamePickerBar.tsx
@@ -1,0 +1,311 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { useRouter } from "next/navigation";
+import type { AvailableGame } from "@/lib/atg";
+
+interface SavedGame {
+  id: string;
+  date: string;
+  track: string | null;
+  game_type: string;
+}
+
+interface GamePickerBarProps {
+  /** Redan sparade omgångar i databasen */
+  savedGames: SavedGame[];
+  /** Aktuellt valt spel-ID */
+  selectedId: string | null;
+}
+
+function todayLocal(): string {
+  return new Date().toLocaleDateString("sv-SE");
+}
+
+function tomorrowLocal(): string {
+  const d = new Date();
+  d.setDate(d.getDate() + 1);
+  return d.toLocaleDateString("sv-SE");
+}
+
+function minDate(): string {
+  const d = new Date();
+  d.setDate(d.getDate() - 14);
+  return d.toLocaleDateString("sv-SE");
+}
+
+function maxDate(): string {
+  const d = new Date();
+  d.setDate(d.getDate() + 14);
+  return d.toLocaleDateString("sv-SE");
+}
+
+export function GamePickerBar({ savedGames, selectedId }: GamePickerBarProps) {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [date, setDate] = useState(todayLocal());
+  const [availableGames, setAvailableGames] = useState<AvailableGame[]>([]);
+  const [loadingGames, setLoadingGames] = useState(false);
+  const [fetchingId, setFetchingId] = useState<string | null>(null);
+  const [message, setMessage] = useState<string | null>(null);
+
+  const selectedGame = savedGames.find((g) => g.id === selectedId) ?? null;
+
+  // Hämta tillgängliga spel när datumet ändras eller panelen öppnas
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    setLoadingGames(true);
+    setAvailableGames([]);
+    fetch(`/api/games/available?date=${date}`)
+      .then((r) => r.json())
+      .then((data) => {
+        if (!cancelled) setAvailableGames(data.games ?? []);
+      })
+      .catch(() => {
+        if (!cancelled) setAvailableGames([]);
+      })
+      .finally(() => {
+        if (!cancelled) setLoadingGames(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [date, open]);
+
+  const handleFetch = useCallback(
+    async (game: AvailableGame) => {
+      setFetchingId(game.id);
+      setMessage(null);
+      try {
+        const res = await fetch("/api/games/fetch", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ gameType: game.type, gameId: game.id }),
+        });
+        const data = await res.json();
+        if (!res.ok) throw new Error(data.error ?? "Fel");
+        setOpen(false);
+        router.push(`/?game=${encodeURIComponent(data.game_id)}`);
+        router.refresh();
+      } catch (err) {
+        setMessage(err instanceof Error ? err.message : "Okänt fel");
+      } finally {
+        setFetchingId(null);
+      }
+    },
+    [router]
+  );
+
+  // Navigera mellan sparade omgångar
+  const currentIndex = savedGames.findIndex((g) => g.id === selectedId);
+  const prevGame = currentIndex > 0 ? savedGames[currentIndex - 1] : null;
+  const nextGame =
+    currentIndex < savedGames.length - 1 ? savedGames[currentIndex + 1] : null;
+
+  return (
+    <div className="relative">
+      {/* Kompakt spelväljare-rad */}
+      <div className="flex items-center gap-1">
+        {/* Föregående spel */}
+        <button
+          onClick={() => prevGame && router.push(`/?game=${prevGame.id}`)}
+          disabled={!prevGame}
+          aria-label="Föregående spel"
+          className="p-1.5 rounded-lg text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 disabled:opacity-30 transition"
+        >
+          <svg
+            className="w-4 h-4"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M15 19l-7-7 7-7"
+            />
+          </svg>
+        </button>
+
+        {/* Aktuellt spel / öppna väljaren */}
+        <button
+          onClick={() => setOpen((v) => !v)}
+          className="flex items-center gap-2 px-3 py-1.5 rounded-lg bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 dark:hover:bg-gray-700 transition text-sm font-medium text-gray-900 dark:text-white min-w-0"
+        >
+          {selectedGame ? (
+            <>
+              <span className="font-bold text-indigo-600 dark:text-indigo-400 shrink-0">
+                {selectedGame.game_type}
+              </span>
+              <span className="text-gray-400 dark:text-gray-500 shrink-0">·</span>
+              <span className="truncate max-w-[120px]">
+                {selectedGame.track ?? selectedGame.date}
+              </span>
+              <span className="text-gray-400 dark:text-gray-500 text-xs shrink-0">
+                {selectedGame.date}
+              </span>
+            </>
+          ) : (
+            <span className="text-gray-500 dark:text-gray-400">Välj spel</span>
+          )}
+          <svg
+            className={`w-3.5 h-3.5 text-gray-400 shrink-0 transition-transform ${open ? "rotate-180" : ""}`}
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M19 9l-7 7-7-7"
+            />
+          </svg>
+        </button>
+
+        {/* Nästa spel */}
+        <button
+          onClick={() => nextGame && router.push(`/?game=${nextGame.id}`)}
+          disabled={!nextGame}
+          aria-label="Nästa spel"
+          className="p-1.5 rounded-lg text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 disabled:opacity-30 transition"
+        >
+          <svg
+            className="w-4 h-4"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M9 5l7 7-7 7"
+            />
+          </svg>
+        </button>
+      </div>
+
+      {/* Dropdown-panel */}
+      {open && (
+        <>
+          {/* Bakgrundsoverlay */}
+          <div
+            className="fixed inset-0 z-40"
+            onClick={() => setOpen(false)}
+          />
+          <div className="absolute top-full left-0 mt-1 z-50 w-80 rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 shadow-xl p-4">
+            {/* Rubrik */}
+            <div className="text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-3">
+              Hämta nytt spel
+            </div>
+
+            {/* Datumväljare */}
+            <div className="flex items-center gap-2 mb-3">
+              <button
+                onClick={() => {
+                  const d = new Date(date);
+                  d.setDate(d.getDate() - 1);
+                  const s = d.toLocaleDateString("sv-SE");
+                  if (s >= minDate()) setDate(s);
+                }}
+                className="p-1 rounded text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-800 transition"
+                aria-label="Föregående dag"
+              >
+                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+                </svg>
+              </button>
+              <input
+                type="date"
+                value={date}
+                min={minDate()}
+                max={maxDate()}
+                onChange={(e) => setDate(e.target.value)}
+                className="flex-1 rounded-lg bg-gray-100 dark:bg-gray-800 border border-gray-300 dark:border-gray-700 text-gray-900 dark:text-white text-sm px-2 py-1.5 focus:outline-none focus:border-indigo-500"
+              />
+              <button
+                onClick={() => {
+                  const d = new Date(date);
+                  d.setDate(d.getDate() + 1);
+                  const s = d.toLocaleDateString("sv-SE");
+                  if (s <= maxDate()) setDate(s);
+                }}
+                className="p-1 rounded text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-800 transition"
+                aria-label="Nästa dag"
+              >
+                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+                </svg>
+              </button>
+            </div>
+
+            {/* Tillgängliga spel — klick = auto-hämta */}
+            {loadingGames ? (
+              <div className="text-sm text-gray-400 text-center py-3">Letar spel...</div>
+            ) : availableGames.length === 0 ? (
+              <div className="text-sm text-gray-400 text-center py-3">Inga spel {date === todayLocal() ? "idag" : date === tomorrowLocal() ? "imorgon" : date}</div>
+            ) : (
+              <div className="flex flex-col gap-2">
+                {availableGames.map((game) => (
+                  <button
+                    key={game.id}
+                    onClick={() => handleFetch(game)}
+                    disabled={fetchingId !== null}
+                    className="w-full flex items-center justify-between px-3 py-2.5 rounded-lg bg-indigo-50 dark:bg-indigo-950 hover:bg-indigo-100 dark:hover:bg-indigo-900 border border-indigo-200 dark:border-indigo-800 text-indigo-700 dark:text-indigo-300 font-semibold text-sm disabled:opacity-50 transition"
+                  >
+                    <span>{game.label}</span>
+                    {fetchingId === game.id ? (
+                      <span className="text-xs text-indigo-400">Hämtar...</span>
+                    ) : (
+                      <svg className="w-4 h-4 opacity-60" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+                      </svg>
+                    )}
+                  </button>
+                ))}
+              </div>
+            )}
+
+            {message && (
+              <p className="text-xs text-red-500 dark:text-red-400 mt-2">{message}</p>
+            )}
+
+            {/* Separerare + sparade omgångar */}
+            {savedGames.length > 0 && (
+              <>
+                <div className="border-t border-gray-100 dark:border-gray-800 my-3" />
+                <div className="text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-2">
+                  Sparade omgångar
+                </div>
+                <div className="flex flex-col gap-1 max-h-48 overflow-y-auto">
+                  {savedGames.map((g) => (
+                    <button
+                      key={g.id}
+                      onClick={() => {
+                        setOpen(false);
+                        router.push(`/?game=${encodeURIComponent(g.id)}`);
+                      }}
+                      className={`w-full text-left px-3 py-2 rounded-lg text-sm transition ${
+                        g.id === selectedId
+                          ? "bg-indigo-100 dark:bg-indigo-900 text-indigo-700 dark:text-indigo-300 font-semibold"
+                          : "text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800"
+                      }`}
+                    >
+                      <span className="font-semibold">{g.game_type}</span>
+                      <span className="text-gray-500 dark:text-gray-400 mx-1.5">·</span>
+                      {g.track && <span>{g.track} · </span>}
+                      <span className="text-gray-500 dark:text-gray-400">{g.date}</span>
+                    </button>
+                  ))}
+                </div>
+              </>
+            )}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/components/MainPageClient.tsx
+++ b/components/MainPageClient.tsx
@@ -1,12 +1,13 @@
 'use client'
 
-import { useState, useCallback, type ComponentProps } from 'react'
+import { useState, useCallback, useEffect, useRef, type ComponentProps } from 'react'
 import { RaceList } from '@/components/RaceList'
 import { SaveSystemDialog } from '@/components/SaveSystemDialog'
 import { SystemSidebar } from '@/components/SystemSidebar'
 import { SystemDrawer } from '@/components/SystemDrawer'
 import type { SystemSelection, SystemHorse, Group } from '@/lib/types'
 import { formatRowCost } from '@/lib/atg'
+import { createSystem, updateDraft } from '@/lib/actions/systems'
 
 type RaceListRaces = ComponentProps<typeof RaceList>['races']
 
@@ -24,6 +25,10 @@ interface MainPageClientProps {
   initialGroupId?: string | null
   gameId: string | null
   gameType: string | null
+  /** Befintligt utkast-ID att fortsätta redigera */
+  draftId?: string | null
+  /** Förvalda hästar från ett utkast */
+  initialSelections?: SystemSelection[]
 }
 
 export function MainPageClient({
@@ -35,11 +40,53 @@ export function MainPageClient({
   initialGroupId = null,
   gameId,
   gameType,
+  draftId = null,
+  initialSelections = [],
 }: MainPageClientProps) {
   const [systemMode, setSystemMode] = useState(initialSystemMode)
-  const [systemSelections, setSystemSelections] = useState<SystemSelection[]>([])
+  const [systemSelections, setSystemSelections] = useState<SystemSelection[]>(initialSelections)
   const [showSaveDialog, setShowSaveDialog] = useState(false)
   const [showDrawer, setShowDrawer] = useState(false)
+  const [activeDraftId, setActiveDraftId] = useState<string | null>(draftId)
+  const [draftSaveStatus, setDraftSaveStatus] = useState<'idle' | 'saving' | 'saved'>('idle')
+
+  // Auto-spara utkast (debounce 3 s) när systemMode är aktivt och val ändras
+  const draftTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const isFirstRender = useRef(true)
+
+  useEffect(() => {
+    // Hoppa över triggern vid initial render
+    if (isFirstRender.current) {
+      isFirstRender.current = false
+      return
+    }
+    if (!systemMode || !gameId) return
+
+    if (draftTimerRef.current) clearTimeout(draftTimerRef.current)
+    setDraftSaveStatus('idle')
+
+    draftTimerRef.current = setTimeout(async () => {
+      setDraftSaveStatus('saving')
+      try {
+        const totalRows = computeTotalRows(systemSelections)
+        if (activeDraftId) {
+          await updateDraft(activeDraftId, systemSelections, totalRows)
+        } else {
+          // Spara utkastet med group_id om vi är i sällskapsläge
+          const draft = await createSystem(initialGroupId, gameId, 'Utkast', systemSelections, totalRows, true)
+          setActiveDraftId(draft.id)
+        }
+        setDraftSaveStatus('saved')
+      } catch {
+        setDraftSaveStatus('idle')
+      }
+    }, 3000)
+
+    return () => {
+      if (draftTimerRef.current) clearTimeout(draftTimerRef.current)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [systemSelections, systemMode])
 
   const handleToggleHorse = useCallback((raceNumber: number, horse: SystemHorse) => {
     setSystemSelections(prev => {
@@ -63,13 +110,17 @@ export function MainPageClient({
   const handleActivateSystemMode = useCallback(() => {
     setSystemMode(true)
     setSystemSelections([])
+    setActiveDraftId(null)
     setShowDrawer(false)
+    isFirstRender.current = true
   }, [])
 
   const handleCancelSystemMode = useCallback(() => {
     setSystemMode(false)
     setSystemSelections([])
+    setActiveDraftId(null)
     setShowDrawer(false)
+    setDraftSaveStatus('idle')
   }, [])
 
   const handleOpenSaveDialog = useCallback(() => {
@@ -126,6 +177,7 @@ export function MainPageClient({
           onCancel={handleCancelSystemMode}
           totalRows={totalRows}
           gameType={gameType}
+          draftSaveStatus={draftSaveStatus}
         />
       )}
 
@@ -137,11 +189,21 @@ export function MainPageClient({
             className="flex-1 w-full text-left px-4 py-3"
             onClick={() => setShowDrawer(true)}
           >
-            <div className="text-xs text-gray-400">{completedRaces} av {races.length} avd. klara</div>
-            <div className="text-sm font-bold">
-              {totalRows} {totalRows === 1 ? 'rad' : 'rader'}{totalRows > 0 && <> · <span className="text-emerald-400">{formatRowCost(totalRows, gameType ?? '')}</span></>}
+            <div className="flex items-center justify-between">
+              <div>
+                <div className="text-xs text-gray-400">{completedRaces} av {races.length} avd. klara</div>
+                <div className="text-sm font-bold">
+                  {totalRows} {totalRows === 1 ? 'rad' : 'rader'}{totalRows > 0 && <> · <span className="text-emerald-400">{formatRowCost(totalRows, gameType ?? '')}</span></>}
+                </div>
+                <div className="text-xs text-emerald-400 mt-0.5">↑ Visa kupong</div>
+              </div>
+              {draftSaveStatus === 'saving' && (
+                <span className="text-xs text-gray-500">Sparar utkast...</span>
+              )}
+              {draftSaveStatus === 'saved' && (
+                <span className="text-xs text-gray-500">Utkast sparat</span>
+              )}
             </div>
-            <div className="text-xs text-emerald-400 mt-0.5">↑ Visa kupong</div>
           </button>
         </div>
       )}
@@ -168,6 +230,7 @@ export function MainPageClient({
           setShowSaveDialog(false)
           setSystemMode(false)
           setSystemSelections([])
+          setActiveDraftId(null)
         }}
         gameId={gameId}
         gameType={gameType}
@@ -175,6 +238,7 @@ export function MainPageClient({
         totalRows={totalRows}
         userGroups={userGroups}
         defaultGroupId={initialGroupId}
+        existingDraftId={activeDraftId}
       />
     </>
   )

--- a/components/SaveSystemDialog.tsx
+++ b/components/SaveSystemDialog.tsx
@@ -3,7 +3,7 @@
 import { useState, useTransition } from 'react'
 import { useRouter } from 'next/navigation'
 import { Group, SystemSelection } from '@/lib/types'
-import { createSystem } from '@/lib/actions/systems'
+import { createSystem, publishDraft } from '@/lib/actions/systems'
 import { formatRowCost } from '@/lib/atg'
 
 interface SaveSystemDialogProps {
@@ -16,6 +16,8 @@ interface SaveSystemDialogProps {
   totalRows: number
   userGroups: Group[]
   defaultGroupId?: string | null
+  /** Om ett utkast redan finns — publicera det istället för att skapa nytt */
+  existingDraftId?: string | null
 }
 
 export function SaveSystemDialog({
@@ -28,6 +30,7 @@ export function SaveSystemDialog({
   totalRows,
   userGroups,
   defaultGroupId = null,
+  existingDraftId = null,
 }: SaveSystemDialogProps) {
   const router = useRouter()
   const [name, setName] = useState('Mitt system')
@@ -50,7 +53,12 @@ export function SaveSystemDialog({
     setError(null)
     startTransition(async () => {
       try {
-        await createSystem(groupId, gameId, name.trim(), selections, totalRows)
+        if (existingDraftId) {
+          // Publicera befintligt utkast
+          await publishDraft(existingDraftId, name.trim(), groupId)
+        } else {
+          await createSystem(groupId, gameId, name.trim(), selections, totalRows)
+        }
         setSavedName(name.trim())
       } catch (err) {
         setError('Kunde inte spara systemet. Försök igen.')

--- a/components/SystemSidebar.tsx
+++ b/components/SystemSidebar.tsx
@@ -23,6 +23,7 @@ interface SystemSidebarProps {
   onCancel: () => void;
   totalRows: number;
   gameType: string | null;
+  draftSaveStatus?: 'idle' | 'saving' | 'saved';
 }
 
 export function SystemSidebar({
@@ -33,6 +34,7 @@ export function SystemSidebar({
   onCancel,
   totalRows,
   gameType,
+  draftSaveStatus = 'idle',
 }: SystemSidebarProps) {
   function isSelected(raceNumber: number, horseId: string): boolean {
     return (
@@ -105,8 +107,16 @@ export function SystemSidebar({
             {totalRows > 0 ? formatRowCost(totalRows, gameType ?? "") : "–"}
           </span>
         </div>
-        <div className="text-xs text-gray-400 dark:text-gray-500 mb-2">
-          {completedRaces} av {races.length} avd. klara
+        <div className="flex items-center justify-between mb-2">
+          <span className="text-xs text-gray-400 dark:text-gray-500">
+            {completedRaces} av {races.length} avd. klara
+          </span>
+          {draftSaveStatus === 'saving' && (
+            <span className="text-xs text-gray-500">Sparar utkast...</span>
+          )}
+          {draftSaveStatus === 'saved' && (
+            <span className="text-xs text-emerald-500">Utkast sparat</span>
+          )}
         </div>
         <button
           onClick={onSave}

--- a/components/SystemsPageClient.tsx
+++ b/components/SystemsPageClient.tsx
@@ -49,8 +49,12 @@ export function SystemsPageClient({
     setSystems(prev => prev.filter(s => s.id !== id))
   }
 
-  // Sortering: egna system först, sedan per sällskapsnamn A-Ö, sedan created_at desc
-  const sorted = [...systems].sort((a, b) => {
+  // Dela upp i utkast och sparade system
+  const myDrafts = systems.filter(s => s.is_draft && s.user_id === currentUserId)
+  const savedSystems = systems.filter(s => !s.is_draft)
+
+  // Sortering sparade: egna först, sedan per sällskapsnamn A-Ö, sedan created_at desc
+  const sortedSaved = [...savedSystems].sort((a, b) => {
     if (a.user_id === currentUserId && b.user_id !== currentUserId) return -1
     if (a.user_id !== currentUserId && b.user_id === currentUserId) return 1
     const groupA = a.group_name ?? ''
@@ -59,10 +63,12 @@ export function SystemsPageClient({
     return new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
   })
 
+  const gameType = games.find(g => g.id === selectedGameId)?.game_type ?? ''
+
   return (
     <div className="px-4 py-4 max-w-2xl mx-auto">
       {/* Omgångsväljare */}
-      <div className="mb-4">
+      <div className="mb-6">
         <select
           value={selectedGameId ?? ''}
           onChange={e => handleGameChange(e.target.value)}
@@ -76,27 +82,64 @@ export function SystemsPageClient({
         </select>
       </div>
 
-      {/* Systemlista */}
       {loading ? (
         <div className="text-center py-10 text-gray-400 text-sm">Laddar system...</div>
-      ) : sorted.length === 0 ? (
-        <div className="text-center py-16 text-gray-400 dark:text-gray-500">
-          <p className="text-base mb-1">Inga system sparade för denna omgång.</p>
-          <p className="text-sm">Gå till Analys-fliken och klicka &ldquo;Bygg system&rdquo;.</p>
-        </div>
       ) : (
-        <div className="flex flex-col gap-4">
-          {sorted.map(system => (
-            <SystemCard
-              key={system.id}
-              system={system}
-              currentUserId={currentUserId}
-              onDeleted={handleDeleted}
-              winnersByRace={winners}
-              gameType={games.find(g => g.id === selectedGameId)?.game_type ?? ''}
-            />
-          ))}
-        </div>
+        <>
+          {/* Mina utkast */}
+          {myDrafts.length > 0 && (
+            <section className="mb-8">
+              <h2 className="text-sm font-semibold text-amber-600 dark:text-amber-400 uppercase tracking-wide mb-3 flex items-center gap-2">
+                <span>✏️</span> Mina utkast
+              </h2>
+              <div className="flex flex-col gap-4">
+                {myDrafts.map(system => (
+                  <SystemCard
+                    key={system.id}
+                    system={system}
+                    currentUserId={currentUserId}
+                    onDeleted={handleDeleted}
+                    winnersByRace={winners}
+                    gameType={gameType}
+                    gameId={selectedGameId}
+                  />
+                ))}
+              </div>
+            </section>
+          )}
+
+          {/* Sparade system */}
+          {sortedSaved.length > 0 && (
+            <section>
+              {myDrafts.length > 0 && (
+                <h2 className="text-sm font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-3">
+                  Sparade system
+                </h2>
+              )}
+              <div className="flex flex-col gap-4">
+                {sortedSaved.map(system => (
+                  <SystemCard
+                    key={system.id}
+                    system={system}
+                    currentUserId={currentUserId}
+                    onDeleted={handleDeleted}
+                    winnersByRace={winners}
+                    gameType={gameType}
+                    gameId={selectedGameId}
+                  />
+                ))}
+              </div>
+            </section>
+          )}
+
+          {/* Tomt tillstånd */}
+          {myDrafts.length === 0 && sortedSaved.length === 0 && (
+            <div className="text-center py-16 text-gray-400 dark:text-gray-500">
+              <p className="text-base mb-1">Inga system sparade för denna omgång.</p>
+              <p className="text-sm">Gå till Analys-fliken och klicka &ldquo;Bygg system&rdquo;.</p>
+            </div>
+          )}
+        </>
       )}
     </div>
   )

--- a/components/sallskap/spel/SpelTab.tsx
+++ b/components/sallskap/spel/SpelTab.tsx
@@ -50,13 +50,22 @@ export function SpelTab({ groupId, games, initialGameId, initialSystems, current
   }
 
   const selectedGame = games.find(g => g.id === selectedGameId)
+  const gameType = selectedGame?.game_type ?? ''
 
-  // Sortera: egna system först, sedan andras
-  const sorted = [...systems].sort((a, b) => {
+  // Dela upp: utkast (egna) och sparade system (hela gruppen)
+  const myDrafts = systems.filter(s => s.is_draft && s.user_id === currentUserId)
+  const groupDrafts = systems.filter(s => s.is_draft && s.user_id !== currentUserId)
+  const savedSystems = systems.filter(s => !s.is_draft)
+
+  // Sortera sparade: egna system först, sedan andras
+  const sortedSaved = [...savedSystems].sort((a, b) => {
     if (a.user_id === currentUserId && b.user_id !== currentUserId) return -1
     if (a.user_id !== currentUserId && b.user_id === currentUserId) return 1
     return new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
   })
+
+  const allDrafts = [...myDrafts, ...groupDrafts]
+  const isEmpty = allDrafts.length === 0 && sortedSaved.length === 0
 
   return (
     <div className="px-4 py-4 max-w-2xl mx-auto">
@@ -86,7 +95,7 @@ export function SpelTab({ groupId, games, initialGameId, initialSystems, current
       {/* Systemlista */}
       {loading ? (
         <div className="text-center py-10 text-gray-400 text-sm">Laddar system...</div>
-      ) : sorted.length === 0 ? (
+      ) : isEmpty ? (
         <div className="text-center py-10 text-gray-400 dark:text-gray-500">
           <p className="mb-2">Inga system sparade för denna omgång ännu.</p>
           {selectedGame && (
@@ -99,17 +108,52 @@ export function SpelTab({ groupId, games, initialGameId, initialSystems, current
           )}
         </div>
       ) : (
-        <div className="flex flex-col gap-4">
-          {sorted.map(system => (
-            <SystemCard
-              key={system.id}
-              system={system}
-              currentUserId={currentUserId}
-              onDeleted={handleDeleted}
-              winnersByRace={winnersByRace}
-              gameType={games.find(g => g.id === selectedGameId)?.game_type ?? ''}
-            />
-          ))}
+        <div className="flex flex-col gap-6">
+          {/* Utkast */}
+          {allDrafts.length > 0 && (
+            <section>
+              <h2 className="text-sm font-semibold text-amber-600 dark:text-amber-400 uppercase tracking-wide mb-3 flex items-center gap-2">
+                <span>✏️</span> Utkast
+              </h2>
+              <div className="flex flex-col gap-4">
+                {allDrafts.map(system => (
+                  <SystemCard
+                    key={system.id}
+                    system={system}
+                    currentUserId={currentUserId}
+                    onDeleted={handleDeleted}
+                    winnersByRace={winnersByRace}
+                    gameType={gameType}
+                    gameId={selectedGameId}
+                  />
+                ))}
+              </div>
+            </section>
+          )}
+
+          {/* Sparade system */}
+          {sortedSaved.length > 0 && (
+            <section>
+              {allDrafts.length > 0 && (
+                <h2 className="text-sm font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-3">
+                  Sparade system
+                </h2>
+              )}
+              <div className="flex flex-col gap-4">
+                {sortedSaved.map(system => (
+                  <SystemCard
+                    key={system.id}
+                    system={system}
+                    currentUserId={currentUserId}
+                    onDeleted={handleDeleted}
+                    winnersByRace={winnersByRace}
+                    gameType={gameType}
+                    gameId={selectedGameId}
+                  />
+                ))}
+              </div>
+            </section>
+          )}
         </div>
       )}
     </div>

--- a/components/sallskap/spel/SystemCard.tsx
+++ b/components/sallskap/spel/SystemCard.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState, useTransition } from 'react'
+import Link from 'next/link'
 import { GameSystem } from '@/lib/types'
 import { deleteSystem } from '@/lib/actions/systems'
 import { isWinningHorse } from '@/lib/systemsHelpers'
@@ -12,9 +13,11 @@ interface SystemCardProps {
   onDeleted?: (id: string) => void
   winnersByRace?: Record<number, string>
   gameType?: string
+  /** Spel-ID behövs för "Fortsätt"-länken på utkast */
+  gameId?: string | null
 }
 
-export function SystemCard({ system, currentUserId, onDeleted, winnersByRace, gameType = '' }: SystemCardProps) {
+export function SystemCard({ system, currentUserId, onDeleted, winnersByRace, gameType = '', gameId }: SystemCardProps) {
   const isOwner = system.user_id === currentUserId
   const [isPending, startTransition] = useTransition()
   const [deleteError, setDeleteError] = useState<string | null>(null)
@@ -53,34 +56,52 @@ export function SystemCard({ system, currentUserId, onDeleted, winnersByRace, ga
     ? 'bg-amber-400 text-black'
     : 'bg-gray-300 text-gray-800 dark:bg-gray-600 dark:text-white'
 
+  // URL för att fortsätta ett utkast
+  const continueHref = gameId
+    ? `/?game=${encodeURIComponent(gameId)}&systemMode=1`
+    : null
+
   return (
-    <div className="border border-gray-200 dark:border-gray-700 rounded-xl p-4 bg-white dark:bg-gray-900">
+    <div className={`border rounded-xl p-4 bg-white dark:bg-gray-900 ${
+      system.is_draft
+        ? 'border-amber-300 dark:border-amber-700'
+        : 'border-gray-200 dark:border-gray-700'
+    }`}>
       {/* Systemhuvud */}
       <div className="flex items-start justify-between mb-3">
         <div>
-          <div className="font-bold text-gray-900 dark:text-white">{system.name}</div>
+          <div className="flex items-center gap-2">
+            <span className="font-bold text-gray-900 dark:text-white">{system.name}</span>
+            {system.is_draft && (
+              <span className="text-xs px-2 py-0.5 rounded-full bg-amber-100 dark:bg-amber-900 text-amber-700 dark:text-amber-300 font-semibold">
+                ✏️ Utkast
+              </span>
+            )}
+          </div>
           <div className="text-xs text-gray-500 dark:text-gray-400">
             {system.author_display_name} · {system.total_rows} {system.total_rows === 1 ? 'rad' : 'rader'} · {formatRowCost(system.total_rows, gameType)}
           </div>
         </div>
         <div className="flex items-center gap-2 flex-wrap justify-end">
           {/* Privat/sällskap-bricka */}
-          {system.group_name != null ? (
-            <span className="text-xs px-2 py-1 rounded-full bg-blue-100 dark:bg-blue-900 text-blue-700 dark:text-blue-300 font-semibold whitespace-nowrap">
-              👥 {system.group_name}
-            </span>
-          ) : (
-            <span className="text-xs px-2 py-1 rounded-full bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400 font-semibold">
-              🔒 Privat
-            </span>
+          {!system.is_draft && (
+            system.group_name != null ? (
+              <span className="text-xs px-2 py-1 rounded-full bg-blue-100 dark:bg-blue-900 text-blue-700 dark:text-blue-300 font-semibold whitespace-nowrap">
+                👥 {system.group_name}
+              </span>
+            ) : (
+              <span className="text-xs px-2 py-1 rounded-full bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400 font-semibold">
+                🔒 Privat
+              </span>
+            )
           )}
           {/* Poängbadge */}
-          {system.is_graded && system.score != null && (
+          {!system.is_draft && system.is_graded && system.score != null && (
             <span className={`text-lg font-black px-3 py-1 rounded-lg ${scoreColor}`}>
               {system.score}/8
             </span>
           )}
-          {!system.is_graded && (
+          {!system.is_draft && !system.is_graded && (
             <span className="text-xs px-2 py-1 rounded-md bg-gray-100 dark:bg-gray-800 text-gray-500">Pågår</span>
           )}
         </div>
@@ -102,8 +123,8 @@ export function SystemCard({ system, currentUserId, onDeleted, winnersByRace, ga
                 <div className="flex gap-1.5 flex-wrap">
                   {[...sel.horses].sort((a, b) => a.start_number - b.start_number).map(h => {
                     const raceResultKnown = winnersByRace != null && sel.race_number in winnersByRace
-                    const won = system.is_graded && raceResultKnown && isWinningHorse(winnersByRace, sel.race_number, h.horse_id)
-                    const lost = system.is_graded && raceResultKnown && !won
+                    const won = !system.is_draft && system.is_graded && raceResultKnown && isWinningHorse(winnersByRace, sel.race_number, h.horse_id)
+                    const lost = !system.is_draft && system.is_graded && raceResultKnown && !won
                     return (
                       <span
                         key={h.horse_id}
@@ -112,6 +133,8 @@ export function SystemCard({ system, currentUserId, onDeleted, winnersByRace, ga
                             ? 'border-2 border-green-600 text-green-700 dark:text-green-400 bg-green-50 dark:bg-green-950'
                             : lost
                             ? 'text-gray-400 dark:text-gray-600'
+                            : system.is_draft
+                            ? 'text-amber-700 dark:text-amber-300 bg-amber-50 dark:bg-amber-950'
                             : 'text-gray-900 dark:text-white'
                         }`}
                       >
@@ -123,6 +146,13 @@ export function SystemCard({ system, currentUserId, onDeleted, winnersByRace, ga
               </td>
             </tr>
           ))}
+          {system.selections.length === 0 && (
+            <tr>
+              <td colSpan={2} className="py-2 px-1 text-xs text-gray-400 dark:text-gray-500 italic">
+                Inga hästar valda ännu
+              </td>
+            </tr>
+          )}
         </tbody>
       </table>
 
@@ -131,13 +161,24 @@ export function SystemCard({ system, currentUserId, onDeleted, winnersByRace, ga
       )}
 
       {/* Åtgärder */}
-      <div className="flex gap-2">
-        <button
-          onClick={handleCopy}
-          className="text-xs px-3 py-1.5 rounded-lg border border-gray-200 dark:border-gray-700 text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 transition"
-        >
-          Kopiera system
-        </button>
+      <div className="flex gap-2 flex-wrap">
+        {/* Fortsätt-knapp för utkast */}
+        {system.is_draft && isOwner && continueHref && (
+          <Link
+            href={continueHref}
+            className="text-xs px-3 py-1.5 rounded-lg bg-amber-500 hover:bg-amber-400 text-white font-semibold transition"
+          >
+            ✏️ Fortsätt utkast
+          </Link>
+        )}
+        {!system.is_draft && (
+          <button
+            onClick={handleCopy}
+            className="text-xs px-3 py-1.5 rounded-lg border border-gray-200 dark:border-gray-700 text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 transition"
+          >
+            Kopiera system
+          </button>
+        )}
         {isOwner && (
           <button
             onClick={handleDelete}

--- a/lib/actions/systems.ts
+++ b/lib/actions/systems.ts
@@ -28,7 +28,8 @@ export async function createSystem(
   gameId: string,
   name: string,
   selections: SystemSelection[],
-  totalRows: number
+  totalRows: number,
+  isDraft = false
 ): Promise<GameSystem> {
   const supabase = await createClient()
   const { data: { user } } = await supabase.auth.getUser()
@@ -43,7 +44,70 @@ export async function createSystem(
       name,
       selections,
       total_rows: totalRows,
+      is_draft: isDraft,
     })
+    .select()
+    .single()
+
+  if (error) throw error
+  return data as GameSystem
+}
+
+/** Hämtar användarens utkast för ett visst spel (max ett per spel och användare) */
+export async function getDraftForGame(gameId: string): Promise<GameSystem | null> {
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return null
+
+  const { data, error } = await supabase
+    .from('game_systems')
+    .select('*')
+    .eq('user_id', user.id)
+    .eq('game_id', gameId)
+    .eq('is_draft', true)
+    .order('created_at', { ascending: false })
+    .limit(1)
+    .maybeSingle()
+
+  if (error) return null
+  return data as GameSystem | null
+}
+
+/** Uppdaterar ett utkasts vald hästar och radantal */
+export async function updateDraft(
+  draftId: string,
+  selections: SystemSelection[],
+  totalRows: number
+): Promise<void> {
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) throw new Error('Not authenticated')
+
+  const { error } = await supabase
+    .from('game_systems')
+    .update({ selections, total_rows: totalRows })
+    .eq('id', draftId)
+    .eq('user_id', user.id)
+    .eq('is_draft', true)
+
+  if (error) throw error
+}
+
+/** Gör om ett utkast till ett sparat system (is_draft → false) */
+export async function publishDraft(
+  draftId: string,
+  name: string,
+  groupId: string | null
+): Promise<GameSystem> {
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) throw new Error('Not authenticated')
+
+  const { data, error } = await supabase
+    .from('game_systems')
+    .update({ is_draft: false, name, group_id: groupId })
+    .eq('id', draftId)
+    .eq('user_id', user.id)
     .select()
     .single()
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -80,6 +80,7 @@ export interface GameSystem {
   total_rows: number;
   score: number | null;
   is_graded: boolean;
+  is_draft: boolean;        // true = utkast (ej färdigspelat)
   group_name?: string | null;        // null = privat system
   created_at: string;
   author_display_name?: string;

--- a/supabase/migration_v8_drafts.sql
+++ b/supabase/migration_v8_drafts.sql
@@ -1,0 +1,10 @@
+-- Migration v8: Draft support for game_systems
+-- Kör i Supabase Dashboard → SQL Editor
+
+ALTER TABLE game_systems
+  ADD COLUMN IF NOT EXISTS is_draft BOOLEAN NOT NULL DEFAULT false;
+
+-- Index för snabb hämtning av utkast per användare och spel
+CREATE INDEX IF NOT EXISTS idx_game_systems_draft
+  ON game_systems(user_id, game_id, is_draft)
+  WHERE is_draft = true;


### PR DESCRIPTION
- Ny GamePickerBar: visuell spelväljare med pil-navigation och dropdown
  som liknar ATG-appen; klick på tillgängligt spel = auto-hämtning
- AutoLoadUpcoming: visar och hämtar automatiskt nästkommande V85/V86/V75
  när inga spel är inladdade
- /api/games/upcoming: hittar nästa spel från ATG-kalendern (idag + imorgon)
- Utkast-funktion: systembyggaren auto-sparar utkast (3 s debounce);
  utkast kan fortsättas via "Fortsätt utkast"-knapp i System-fliken
- System-sidan visar utkast i eget avsnitt (amber-markerade) separat
  från färdiga system
- Sällskapets Spel-flik visar utkast (egna + andras) med "Fortsätt"-länk
- Ny migration v8: is_draft-kolumn på game_systems

https://claude.ai/code/session_01PLrooWLDNPPHVyg9TV9KiN