### PR TITLE
Lägg till stöd för speltypen GS75

### DIFF
--- a/app/api/games/upcoming/route.ts
+++ b/app/api/games/upcoming/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import { fetchAvailableGames } from "@/lib/atg";
 
 // Prioritetsordning för speltyper vi vill auto-ladda
-const PRIORITY_TYPES = ["V86", "V85", "V75", "V65", "V64"];
+const PRIORITY_TYPES = ["V86", "V85", "V75", "GS75", "V65", "V64"];
 
 function todayLocal(): string {
   const d = new Date();

--- a/lib/atg.ts
+++ b/lib/atg.ts
@@ -8,7 +8,7 @@ export function getRowPrice(gameType: string): number {
     case 'V85': return 0.50
     case 'V65': return 0.50
     case 'V64': return 1.00
-    case 'GS75': return 0.50
+    case 'GS75': return 1.00
     default:    return 1.00
   }
 }

--- a/lib/atg.ts
+++ b/lib/atg.ts
@@ -8,6 +8,7 @@ export function getRowPrice(gameType: string): number {
     case 'V85': return 0.50
     case 'V65': return 0.50
     case 'V64': return 1.00
+    case 'GS75': return 0.50
     default:    return 1.00
   }
 }
@@ -106,7 +107,7 @@ export interface AtgGame {
   races: AtgRace[];
 }
 
-const SUPPORTED_GAME_TYPES = ["V75", "V86", "V85", "V64", "V65"] as const;
+const SUPPORTED_GAME_TYPES = ["V75", "V86", "V85", "V64", "V65", "GS75"] as const;
 
 export interface AtgStarterResult {
   race_index: number;        // 0-baserat, matchar races[]-arrayen


### PR DESCRIPTION
Lägger till GS75 i SUPPORTED_GAME_TYPES så att spelet visas i
tillgängliga spel via ATG-kalendern. Sätter radpris till 0,50 kr
och inkluderar GS75 i auto-laddningsprioritetslistan.

https://claude.ai/code/session_014mtyenfzxxf1wtuvwEJh7Q