### PR TITLE
Migrera hela UI till --tn-* designtokensystem (Travappen-redesign)

### DIFF
--- a/app/(authenticated)/admin/page.tsx
+++ b/app/(authenticated)/admin/page.tsx
@@ -4,7 +4,6 @@ import { getAllTrackConfigs } from "@/lib/actions/tracks";
 import { TrackConfigRow } from "@/components/admin/TrackConfigRow";
 
 export default async function AdminPage() {
-  // Auth gate: check ADMIN_USER_IDS env var server-side (per D-13, security requirement)
   const supabase = await createClient();
   const {
     data: { user },
@@ -22,16 +21,16 @@ export default async function AdminPage() {
   return (
     <main className="px-4 py-5 max-w-2xl mx-auto space-y-6">
       <div>
-        <h1 className="text-lg font-bold text-gray-900 dark:text-white mb-1">
+        <h1 className="text-lg font-bold mb-1" style={{ color: "var(--tn-text)" }}>
           Bankonfiguration
         </h1>
-        <p className="text-sm text-gray-500 dark:text-gray-400 mb-6">
+        <p className="text-sm mb-6" style={{ color: "var(--tn-text-faint)" }}>
           Redigera spårfaktorer per bana.
         </p>
       </div>
 
       {configs.length === 0 ? (
-        <p className="text-sm text-gray-500 dark:text-gray-400 text-center py-8">
+        <p className="text-sm text-center py-8" style={{ color: "var(--tn-text-faint)" }}>
           Inga banor konfigurerade.
         </p>
       ) : (

--- a/app/(authenticated)/evaluation/page.tsx
+++ b/app/(authenticated)/evaluation/page.tsx
@@ -8,7 +8,7 @@ interface GameSummary {
   date: string;
   game_type: string;
   track: string;
-  has_results: boolean; // true only when ALL races in the game have at least one finish_position
+  has_results: boolean;
 }
 
 interface StarterRow {
@@ -49,7 +49,6 @@ interface GameEval {
 }
 
 function computeEvaluation(rows: StarterRow[]) {
-  // Gruppera per lopp
   const byRace = new Map<string, StarterRow[]>();
   for (const row of rows) {
     const key = row.race_id;
@@ -57,7 +56,6 @@ function computeEvaluation(rows: StarterRow[]) {
     byRace.get(key)!.push(row);
   }
 
-  // Gruppera per spel
   const byGame = new Map<string, { game: GameEval["game_id"] extends string ? Pick<GameEval, "game_id" | "date" | "game_type" | "track"> : never; races: Map<string, StarterRow[]> }>();
   for (const [raceId, starters] of byRace) {
     const first = starters[0];
@@ -89,7 +87,7 @@ function computeEvaluation(rows: StarterRow[]) {
 
     for (const [, starters] of races) {
       const winner = starters.find((s) => s.finish_position === 1);
-      if (!winner) continue; // lopp utan vinnare hoppas över
+      if (!winner) continue;
 
       const ranked = [...starters]
         .filter((s) => s.formscore != null)
@@ -153,14 +151,12 @@ export default async function EvaluationPage() {
   } = await supabase.auth.getUser();
   if (!user) redirect("/login");
 
-  // Query A — all games ordered by date descending (limit 100 to prevent unbounded results)
   const { data: allGamesData } = await supabase
     .from("games")
     .select("id, date, game_type, track")
     .order("date", { ascending: false })
     .limit(100);
 
-  // Query B — starters with finish_position to determine which games have results
   const { data } = await supabase
     .from("starters")
     .select(`
@@ -171,13 +167,10 @@ export default async function EvaluationPage() {
     .not("formscore", "is", null)
     .not("finish_position", "is", null);
 
-  // Query C — all races to know total race count per game (needed for completeness check)
   const { data: allRacesData } = await supabase
     .from("races")
     .select("id, game_id");
 
-  // Query D — races with any finish result, no formscore filter (covers V65/V64/V75 where
-  // starters may lack formscores but results are fully fetched)
   const { data: resultedRacesData } = await supabase
     .from("starters")
     .select("race_id, races(game_id)")
@@ -186,7 +179,6 @@ export default async function EvaluationPage() {
   const rows = (data ?? []) as unknown as StarterRow[];
   const { overall, games } = computeEvaluation(rows);
 
-  // Races with at least one result per game (from Query D — finish_position only, no formscore)
   const racesWithResultsByGame = new Map<string, Set<string>>();
   for (const row of (resultedRacesData ?? []) as unknown as { race_id: string; races: { game_id: string } | null }[]) {
     const gameId = row.races?.game_id;
@@ -197,7 +189,6 @@ export default async function EvaluationPage() {
     }
   }
 
-  // Total races per game (from Query C)
   const totalRacesByGame = new Map<string, number>();
   for (const race of (allRacesData ?? [])) {
     totalRacesByGame.set(race.game_id, (totalRacesByGame.get(race.game_id) ?? 0) + 1);
@@ -216,8 +207,11 @@ export default async function EvaluationPage() {
   });
 
   return (
-    <main className="min-h-screen bg-white dark:bg-gray-950 text-gray-900 dark:text-white">
-      <header className="sticky top-0 z-30 bg-white dark:bg-gray-950 border-b border-gray-200 dark:border-gray-800 px-4 py-3 flex items-center justify-between gap-4">
+    <main className="min-h-screen" style={{ background: "var(--tn-bg)", color: "var(--tn-text)" }}>
+      <header
+        className="sticky top-0 z-30 px-4 py-3 flex items-center justify-between gap-4"
+        style={{ background: "var(--tn-bg)", borderBottom: "1px solid var(--tn-border)" }}
+      >
         <h1 className="text-lg font-bold">Modell-utvärdering</h1>
         <ThemeToggle />
       </header>

--- a/app/(authenticated)/manual/page.tsx
+++ b/app/(authenticated)/manual/page.tsx
@@ -1,37 +1,43 @@
 export default function ManualPage() {
   return (
-    <main className="min-h-screen bg-white dark:bg-gray-950 text-gray-900 dark:text-white">
-      <header className="sticky top-0 z-30 bg-white dark:bg-gray-950 border-b border-gray-200 dark:border-gray-800 px-4 py-3">
+    <main className="min-h-screen" style={{ background: "var(--tn-bg)", color: "var(--tn-text)" }}>
+      <header
+        className="sticky top-0 z-30 px-4 py-3"
+        style={{ background: "var(--tn-bg)", borderBottom: "1px solid var(--tn-border)" }}
+      >
         <h1 className="text-lg font-bold">Användarmanual</h1>
       </header>
 
       <div className="max-w-3xl mx-auto px-4 py-10 space-y-12">
 
         {/* TOC */}
-        <nav className="bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-800 rounded-xl p-6">
-          <h2 className="text-lg font-semibold mb-3 text-gray-900 dark:text-white">Innehåll</h2>
-          <ol className="space-y-1 text-sm text-indigo-600 dark:text-indigo-400 list-decimal list-inside">
-            <li><a href="#intro" className="hover:text-indigo-700 dark:hover:text-indigo-300 transition">Introduktion</a></li>
-            <li><a href="#login" className="hover:text-indigo-700 dark:hover:text-indigo-300 transition">Komma igång – inloggning</a></li>
-            <li><a href="#hamta" className="hover:text-indigo-700 dark:hover:text-indigo-300 transition">Hämta V85-omgång</a></li>
-            <li><a href="#navigera" className="hover:text-indigo-700 dark:hover:text-indigo-300 transition">Navigera bland omgångar</a></li>
-            <li><a href="#hastkort" className="hover:text-indigo-700 dark:hover:text-indigo-300 transition">Hästarnas informationskort</a></li>
-            <li><a href="#analys" className="hover:text-indigo-700 dark:hover:text-indigo-300 transition">Analysverktyget</a></li>
-            <li><a href="#grupper" className="hover:text-indigo-700 dark:hover:text-indigo-300 transition">Grupper och samarbete</a></li>
-            <li><a href="#anteckningar" className="hover:text-indigo-700 dark:hover:text-indigo-300 transition">Anteckningar på hästar</a></li>
-            <li><a href="#ordlista" className="hover:text-indigo-700 dark:hover:text-indigo-300 transition">Ordlista</a></li>
+        <nav
+          className="rounded-xl p-6"
+          style={{ background: "var(--tn-bg-card)", border: "1px solid var(--tn-border)" }}
+        >
+          <h2 className="text-lg font-semibold mb-3" style={{ color: "var(--tn-text)" }}>Innehåll</h2>
+          <ol className="space-y-1 text-sm list-decimal list-inside">
+            <li><a href="#intro" className="hover:underline transition" style={{ color: "var(--tn-accent)" }}>Introduktion</a></li>
+            <li><a href="#login" className="hover:underline transition" style={{ color: "var(--tn-accent)" }}>Komma igång – inloggning</a></li>
+            <li><a href="#hamta" className="hover:underline transition" style={{ color: "var(--tn-accent)" }}>Hämta V85-omgång</a></li>
+            <li><a href="#navigera" className="hover:underline transition" style={{ color: "var(--tn-accent)" }}>Navigera bland omgångar</a></li>
+            <li><a href="#hastkort" className="hover:underline transition" style={{ color: "var(--tn-accent)" }}>Hästarnas informationskort</a></li>
+            <li><a href="#analys" className="hover:underline transition" style={{ color: "var(--tn-accent)" }}>Analysverktyget</a></li>
+            <li><a href="#grupper" className="hover:underline transition" style={{ color: "var(--tn-accent)" }}>Grupper och samarbete</a></li>
+            <li><a href="#anteckningar" className="hover:underline transition" style={{ color: "var(--tn-accent)" }}>Anteckningar på hästar</a></li>
+            <li><a href="#ordlista" className="hover:underline transition" style={{ color: "var(--tn-accent)" }}>Ordlista</a></li>
           </ol>
         </nav>
 
         {/* 1 Introduktion */}
         <section id="intro">
           <SectionHeading number="1" title="Introduktion" />
-          <p className="text-gray-700 dark:text-gray-300 leading-relaxed">
-            <strong className="text-gray-900 dark:text-white">V85 Analys</strong> är ett verktyg för dig som spelar V85 på ATG.
+          <p className="leading-relaxed" style={{ color: "var(--tn-text-dim)" }}>
+            <strong style={{ color: "var(--tn-text)" }}>V85 Analys</strong> är ett verktyg för dig som spelar V85 på ATG.
             Systemet hämtar aktuell tävlingsdata direkt från ATG, räknar ut sannolikheter baserat på
             form, odds och statistik, och låter dig dela anteckningar med dina spelvänner i en gemensam grupp.
           </p>
-          <p className="text-gray-700 dark:text-gray-300 leading-relaxed mt-3">
+          <p className="leading-relaxed mt-3" style={{ color: "var(--tn-text-dim)" }}>
             Appen är byggd för att ge dig ett bättre beslutsunderlag – den ersätter inte din egen bedömning,
             men hjälper dig hitta hästar vars oddsvärde kan vara bättre än marknadens.
           </p>
@@ -40,13 +46,13 @@ export default function ManualPage() {
         {/* 2 Inloggning */}
         <section id="login">
           <SectionHeading number="2" title="Komma igång – inloggning" />
-          <p className="text-gray-700 dark:text-gray-300 leading-relaxed mb-4">
+          <p className="leading-relaxed mb-4" style={{ color: "var(--tn-text-dim)" }}>
             Du möts av inloggningssidan om du inte redan är inloggad.
           </p>
           <Steps>
             <Step>Öppna appen i webbläsaren.</Step>
-            <Step><strong className="text-gray-900 dark:text-white">Ny användare?</strong> Ange din e-postadress och ett lösenord och klicka på <Kbd>Registrera</Kbd>.</Step>
-            <Step><strong className="text-gray-900 dark:text-white">Redan registrerad?</strong> Ange dina uppgifter och klicka på <Kbd>Logga in</Kbd>.</Step>
+            <Step><strong style={{ color: "var(--tn-text)" }}>Ny användare?</strong> Ange din e-postadress och ett lösenord och klicka på <Kbd>Registrera</Kbd>.</Step>
+            <Step><strong style={{ color: "var(--tn-text)" }}>Redan registrerad?</strong> Ange dina uppgifter och klicka på <Kbd>Logga in</Kbd>.</Step>
             <Step>Efter lyckad inloggning hamnar du på huvudsidan.</Step>
           </Steps>
           <Tip>Ditt visningsnamn kan ändras via din profil och syns för övriga medlemmar i dina grupper.</Tip>
@@ -55,12 +61,12 @@ export default function ManualPage() {
         {/* 3 Hämta */}
         <section id="hamta">
           <SectionHeading number="3" title="Hämta V85-omgång" />
-          <p className="text-gray-700 dark:text-gray-300 leading-relaxed mb-4">
+          <p className="leading-relaxed mb-4" style={{ color: "var(--tn-text-dim)" }}>
             Innan du kan analysera en omgång måste du hämta data från ATG.
           </p>
           <Steps>
             <Step>Klicka på knappen <Kbd>Hämta V85</Kbd> högst upp på sidan.</Step>
-            <Step>En datumväljare visas. Du kan välja datum upp till <strong className="text-gray-900 dark:text-white">14 dagar bakåt eller framåt</strong> från dagens datum.</Step>
+            <Step>En datumväljare visas. Du kan välja datum upp till <strong style={{ color: "var(--tn-text)" }}>14 dagar bakåt eller framåt</strong> från dagens datum.</Step>
             <Step>Välj det datum då V85-omgången körs.</Step>
             <Step>Klicka på <Kbd>Hämta</Kbd> för att ladda ner alla lopp och hästar.</Step>
             <Step>Om hämtningen lyckas dyker omgången upp i listan omedelbart.</Step>
@@ -71,32 +77,35 @@ export default function ManualPage() {
         {/* 4 Navigera */}
         <section id="navigera">
           <SectionHeading number="4" title="Navigera bland omgångar" />
-          <p className="text-gray-700 dark:text-gray-300 leading-relaxed mb-4">
+          <p className="leading-relaxed mb-4" style={{ color: "var(--tn-text-dim)" }}>
             På huvudsidan ser du alla hämtade omgångar.
           </p>
-          <ul className="space-y-2 text-gray-700 dark:text-gray-300 text-sm">
-            <li className="flex gap-2"><span className="text-indigo-600 dark:text-indigo-400 mt-0.5">▸</span>Välj omgång via <strong className="text-gray-900 dark:text-white">rullgardinsmenyn</strong> längst upp.</li>
-            <li className="flex gap-2"><span className="text-indigo-600 dark:text-indigo-400 mt-0.5">▸</span>Omgångens <strong className="text-gray-900 dark:text-white">åtta lopp</strong> visas under varandra.</li>
-            <li className="flex gap-2"><span className="text-indigo-600 dark:text-indigo-400 mt-0.5">▸</span>Klicka på ett lopp för att <strong className="text-gray-900 dark:text-white">expandera</strong> det och se alla startande hästar.</li>
-            <li className="flex gap-2"><span className="text-indigo-600 dark:text-indigo-400 mt-0.5">▸</span>Klicka igen för att fälla ihop loppet.</li>
+          <ul className="space-y-2 text-sm" style={{ color: "var(--tn-text-dim)" }}>
+            <li className="flex gap-2"><span className="mt-0.5" style={{ color: "var(--tn-accent)" }}>▸</span>Välj omgång via <strong style={{ color: "var(--tn-text)" }}>rullgardinsmenyn</strong> längst upp.</li>
+            <li className="flex gap-2"><span className="mt-0.5" style={{ color: "var(--tn-accent)" }}>▸</span>Omgångens <strong style={{ color: "var(--tn-text)" }}>åtta lopp</strong> visas under varandra.</li>
+            <li className="flex gap-2"><span className="mt-0.5" style={{ color: "var(--tn-accent)" }}>▸</span>Klicka på ett lopp för att <strong style={{ color: "var(--tn-text)" }}>expandera</strong> det och se alla startande hästar.</li>
+            <li className="flex gap-2"><span className="mt-0.5" style={{ color: "var(--tn-accent)" }}>▸</span>Klicka igen för att fälla ihop loppet.</li>
           </ul>
         </section>
 
         {/* 5 Hästkort */}
         <section id="hastkort">
           <SectionHeading number="5" title="Hästarnas informationskort" />
-          <p className="text-gray-700 dark:text-gray-300 leading-relaxed mb-4">
+          <p className="leading-relaxed mb-4" style={{ color: "var(--tn-text-dim)" }}>
             När ett lopp är expanderat visas ett kort per häst. Varje kort innehåller:
           </p>
           <div className="overflow-x-auto">
-            <table className="w-full text-sm border border-gray-200 dark:border-gray-800 rounded-xl overflow-hidden">
+            <table
+              className="w-full text-sm rounded-xl overflow-hidden"
+              style={{ border: "1px solid var(--tn-border)" }}
+            >
               <thead>
-                <tr className="bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300">
+                <tr style={{ background: "var(--tn-bg-chip)", color: "var(--tn-text-dim)" }}>
                   <th className="text-left px-4 py-2 font-semibold">Fält</th>
                   <th className="text-left px-4 py-2 font-semibold">Förklaring</th>
                 </tr>
               </thead>
-              <tbody className="divide-y divide-gray-200 dark:divide-gray-800">
+              <tbody>
                 {[
                   ["Namn", "Hästens namn"],
                   ["Nr", "Startnummer"],
@@ -111,17 +120,17 @@ export default function ManualPage() {
                   ["Vinst % per år", "Vinstprocent för innevarande och föregående år"],
                   ["Senaste 5 lopp", "Placeringar: guld = 1:a, silver = 2:a, brons = 3:a"],
                 ].map(([field, desc]) => (
-                  <tr key={field} className="text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-900 transition">
-                    <td className="px-4 py-2 font-medium text-gray-900 dark:text-white whitespace-nowrap">{field}</td>
-                    <td className="px-4 py-2">{desc}</td>
+                  <tr key={field} style={{ borderTop: "1px solid var(--tn-border)" }}>
+                    <td className="px-4 py-2 font-medium whitespace-nowrap" style={{ color: "var(--tn-text)" }}>{field}</td>
+                    <td className="px-4 py-2" style={{ color: "var(--tn-text-dim)" }}>{desc}</td>
                   </tr>
                 ))}
               </tbody>
             </table>
           </div>
 
-          <h3 className="text-gray-900 dark:text-white font-semibold mt-6 mb-2">Formscore – hur räknas det?</h3>
-          <p className="text-gray-700 dark:text-gray-300 text-sm leading-relaxed mb-3">
+          <h3 className="font-semibold mt-6 mb-2" style={{ color: "var(--tn-text)" }}>Formscore – hur räknas det?</h3>
+          <p className="text-sm leading-relaxed mb-3" style={{ color: "var(--tn-text-dim)" }}>
             Formscoren är ett samlat mått (0–100) som väger ihop fyra faktorer:
           </p>
           <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
@@ -131,9 +140,13 @@ export default function ManualPage() {
               ["20 %", "Oddsindex"],
               ["20 %", "Bästa tid relativt fältet"],
             ].map(([pct, label]) => (
-              <div key={pct} className="bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-800 rounded-lg p-3 text-center">
-                <p className="text-indigo-600 dark:text-indigo-400 font-bold text-lg">{pct}</p>
-                <p className="text-gray-500 dark:text-gray-400 text-xs mt-1">{label}</p>
+              <div
+                key={pct}
+                className="rounded-lg p-3 text-center"
+                style={{ background: "var(--tn-bg-card)", border: "1px solid var(--tn-border)" }}
+              >
+                <p className="font-bold text-lg" style={{ color: "var(--tn-accent)" }}>{pct}</p>
+                <p className="text-xs mt-1" style={{ color: "var(--tn-text-faint)" }}>{label}</p>
               </div>
             ))}
           </div>
@@ -142,18 +155,21 @@ export default function ManualPage() {
         {/* 6 Analys */}
         <section id="analys">
           <SectionHeading number="6" title="Analysverktyget" />
-          <p className="text-gray-700 dark:text-gray-300 leading-relaxed mb-4">
+          <p className="leading-relaxed mb-4" style={{ color: "var(--tn-text-dim)" }}>
             Klicka på <Kbd>Visa analys</Kbd> inuti ett lopp för att öppna analyspanelen. Du ser en tabell med alla hästar:
           </p>
           <div className="overflow-x-auto mb-6">
-            <table className="w-full text-sm border border-gray-200 dark:border-gray-800 rounded-xl overflow-hidden">
+            <table
+              className="w-full text-sm rounded-xl overflow-hidden"
+              style={{ border: "1px solid var(--tn-border)" }}
+            >
               <thead>
-                <tr className="bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300">
+                <tr style={{ background: "var(--tn-bg-chip)", color: "var(--tn-text-dim)" }}>
                   <th className="text-left px-4 py-2 font-semibold">Kolumn</th>
                   <th className="text-left px-4 py-2 font-semibold">Förklaring</th>
                 </tr>
               </thead>
-              <tbody className="divide-y divide-gray-200 dark:divide-gray-800">
+              <tbody>
                 {[
                   ["Häst", "Hästens namn och startnummer"],
                   ["Beräknad vinstchans", "Systemets estimerade sannolikhet att hästen vinner"],
@@ -161,35 +177,44 @@ export default function ManualPage() {
                   ["Differens", "Skillnaden mellan beräknad och odds-impliserad chans"],
                   ["Värde?", "Indikator om hästen verkar undervärderad av marknaden"],
                 ].map(([col, desc]) => (
-                  <tr key={col} className="text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-900 transition">
-                    <td className="px-4 py-2 font-medium text-gray-900 dark:text-white whitespace-nowrap">{col}</td>
-                    <td className="px-4 py-2">{desc}</td>
+                  <tr key={col} style={{ borderTop: "1px solid var(--tn-border)" }}>
+                    <td className="px-4 py-2 font-medium whitespace-nowrap" style={{ color: "var(--tn-text)" }}>{col}</td>
+                    <td className="px-4 py-2" style={{ color: "var(--tn-text-dim)" }}>{desc}</td>
                   </tr>
                 ))}
               </tbody>
             </table>
           </div>
 
-          <h3 className="text-gray-900 dark:text-white font-semibold mb-2">Beräkningsformel</h3>
-          <div className="bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-800 rounded-xl p-4 font-mono text-sm text-gray-700 dark:text-gray-300 space-y-1">
+          <h3 className="font-semibold mb-2" style={{ color: "var(--tn-text)" }}>Beräkningsformel</h3>
+          <div
+            className="rounded-xl p-4 tn-mono text-sm space-y-1"
+            style={{ background: "var(--tn-bg-chip)", border: "1px solid var(--tn-border)", color: "var(--tn-text-dim)" }}
+          >
             <p>Vinstchans =</p>
             <p className="pl-4">40% × karriärvinstprocent</p>
             <p className="pl-4">+ 40% × senaste form-procent</p>
             <p className="pl-4">+ 20% × odds-impliserad sannolikhet</p>
           </div>
-          <p className="text-gray-500 dark:text-gray-400 text-sm mt-2">
-            Resultatet justeras med en <strong className="text-gray-900 dark:text-white">distansfaktor</strong> baserad på hästens historiska prestation på aktuell distans och startmetod.
+          <p className="text-sm mt-2" style={{ color: "var(--tn-text-faint)" }}>
+            Resultatet justeras med en <strong style={{ color: "var(--tn-text)" }}>distansfaktor</strong> baserad på hästens historiska prestation på aktuell distans och startmetod.
           </p>
 
-          <h3 className="text-gray-900 dark:text-white font-semibold mt-6 mb-2">Tolka resultatet</h3>
+          <h3 className="font-semibold mt-6 mb-2" style={{ color: "var(--tn-text)" }}>Tolka resultatet</h3>
           <div className="space-y-2">
-            <div className="flex gap-3 items-start bg-green-950 border border-green-800 rounded-lg p-3 text-sm">
-              <span className="text-green-400 font-bold shrink-0">+</span>
-              <p className="text-green-200"><strong>Positiv differens</strong> – beräknad chans är högre än marknadens chans → hästen kan vara ett värdebet.</p>
+            <div
+              className="flex gap-3 items-start rounded-lg p-3 text-sm"
+              style={{ background: "rgba(52,211,153,0.08)", border: "1px solid rgba(52,211,153,0.25)" }}
+            >
+              <span className="font-bold shrink-0" style={{ color: "var(--tn-value-high)" }}>+</span>
+              <p style={{ color: "var(--tn-text-dim)" }}><strong style={{ color: "var(--tn-text)" }}>Positiv differens</strong> – beräknad chans är högre än marknadens chans → hästen kan vara ett värdebet.</p>
             </div>
-            <div className="flex gap-3 items-start bg-red-950 border border-red-800 rounded-lg p-3 text-sm">
-              <span className="text-red-400 font-bold shrink-0">–</span>
-              <p className="text-red-200"><strong>Negativ differens</strong> – hästen verkar övervärderad av marknaden.</p>
+            <div
+              className="flex gap-3 items-start rounded-lg p-3 text-sm"
+              style={{ background: "rgba(248,113,113,0.08)", border: "1px solid rgba(248,113,113,0.25)" }}
+            >
+              <span className="font-bold shrink-0" style={{ color: "var(--tn-value-low)" }}>–</span>
+              <p style={{ color: "var(--tn-text-dim)" }}><strong style={{ color: "var(--tn-text)" }}>Negativ differens</strong> – hästen verkar övervärderad av marknaden.</p>
             </div>
           </div>
           <Tip>Analysen är ett komplement till din egen bedömning. Ta alltid hänsyn till faktorer som stallkänsla, tränarform och väder.</Tip>
@@ -198,78 +223,82 @@ export default function ManualPage() {
         {/* 7 Grupper */}
         <section id="grupper">
           <SectionHeading number="7" title="Grupper och samarbete" />
-          <p className="text-gray-700 dark:text-gray-300 leading-relaxed mb-6">
+          <p className="leading-relaxed mb-6" style={{ color: "var(--tn-text-dim)" }}>
             Grupper låter dig och dina spelvänner dela anteckningar och analyser om enskilda hästar.
             Klicka på ditt användarnamn (avataren uppe till höger) för att hantera grupper.
           </p>
 
-          <h3 className="text-gray-900 dark:text-white font-semibold mb-2">Skapa en grupp</h3>
+          <h3 className="font-semibold mb-2" style={{ color: "var(--tn-text)" }}>Skapa en grupp</h3>
           <Steps>
             <Step>Klicka på din avatar uppe till höger och välj <Kbd>Hantera sällskap</Kbd>.</Step>
             <Step>Välj <Kbd>Skapa ny grupp</Kbd> och ange ett namn.</Step>
             <Step>Klicka på <Kbd>Skapa</Kbd>. Du blir automatiskt gruppens admin.</Step>
-            <Step>En unik <strong className="text-gray-900 dark:text-white">inbjudningskod</strong> genereras – dela den med de du vill bjuda in.</Step>
+            <Step>En unik <strong style={{ color: "var(--tn-text)" }}>inbjudningskod</strong> genereras – dela den med de du vill bjuda in.</Step>
           </Steps>
 
-          <h3 className="text-gray-900 dark:text-white font-semibold mt-6 mb-2">Gå med i en grupp</h3>
+          <h3 className="font-semibold mt-6 mb-2" style={{ color: "var(--tn-text)" }}>Gå med i en grupp</h3>
           <Steps>
             <Step>Klicka på din avatar och välj <Kbd>Hantera sällskap</Kbd>.</Step>
-            <Step>Välj <Kbd>Gå med i grupp</Kbd> och ange <strong className="text-gray-900 dark:text-white">inbjudningskoden</strong> du fått.</Step>
+            <Step>Välj <Kbd>Gå med i grupp</Kbd> och ange <strong style={{ color: "var(--tn-text)" }}>inbjudningskoden</strong> du fått.</Step>
             <Step>Klicka på <Kbd>Gå med</Kbd>. Du kan nu se och skriva anteckningar i gruppen.</Step>
           </Steps>
 
-          <h3 className="text-gray-900 dark:text-white font-semibold mt-6 mb-2">Administrera din grupp (admin)</h3>
-          <ul className="space-y-2 text-gray-700 dark:text-gray-300 text-sm">
-            <li className="flex gap-2"><span className="text-indigo-600 dark:text-indigo-400 mt-0.5">▸</span>Se alla <strong className="text-gray-900 dark:text-white">medlemmar</strong> i gruppen.</li>
-            <li className="flex gap-2"><span className="text-indigo-600 dark:text-indigo-400 mt-0.5">▸</span><strong className="text-gray-900 dark:text-white">Ta bort medlemmar</strong> om det behövs.</li>
-            <li className="flex gap-2"><span className="text-indigo-600 dark:text-indigo-400 mt-0.5">▸</span>Se och dela den aktiva <strong className="text-gray-900 dark:text-white">inbjudningskoden</strong>.</li>
+          <h3 className="font-semibold mt-6 mb-2" style={{ color: "var(--tn-text)" }}>Administrera din grupp (admin)</h3>
+          <ul className="space-y-2 text-sm" style={{ color: "var(--tn-text-dim)" }}>
+            <li className="flex gap-2"><span className="mt-0.5" style={{ color: "var(--tn-accent)" }}>▸</span>Se alla <strong style={{ color: "var(--tn-text)" }}>medlemmar</strong> i gruppen.</li>
+            <li className="flex gap-2"><span className="mt-0.5" style={{ color: "var(--tn-accent)" }}>▸</span><strong style={{ color: "var(--tn-text)" }}>Ta bort medlemmar</strong> om det behövs.</li>
+            <li className="flex gap-2"><span className="mt-0.5" style={{ color: "var(--tn-accent)" }}>▸</span>Se och dela den aktiva <strong style={{ color: "var(--tn-text)" }}>inbjudningskoden</strong>.</li>
           </ul>
         </section>
 
         {/* 8 Anteckningar */}
         <section id="anteckningar">
           <SectionHeading number="8" title="Anteckningar på hästar" />
-          <p className="text-gray-700 dark:text-gray-300 leading-relaxed mb-4">
+          <p className="leading-relaxed mb-4" style={{ color: "var(--tn-text-dim)" }}>
             Anteckningar är kopplade till en specifik häst (inte ett lopp) och visas för alla i gruppen,
             oavsett vilket lopp hästen startar i.
           </p>
 
-          <h3 className="text-gray-900 dark:text-white font-semibold mb-2">Skriva en anteckning</h3>
+          <h3 className="font-semibold mb-2" style={{ color: "var(--tn-text)" }}>Skriva en anteckning</h3>
           <Steps>
             <Step>Öppna ett lopp och hitta hästen du vill kommentera.</Step>
             <Step>Klicka på <Kbd>Lägg till anteckning</Kbd> på hästkortet.</Step>
-            <Step>Välj en <strong className="text-gray-900 dark:text-white">etikett</strong> (färgkod) för att kategorisera din notering.</Step>
+            <Step>Välj en <strong style={{ color: "var(--tn-text)" }}>etikett</strong> (färgkod) för att kategorisera din notering.</Step>
             <Step>Skriv din text och klicka på <Kbd>Spara</Kbd>.</Step>
           </Steps>
 
           <div className="grid grid-cols-2 gap-2 sm:grid-cols-4 mt-4">
             {[
-              { color: "bg-green-500", label: "Grön", desc: "Favorit / stark chans" },
-              { color: "bg-yellow-400", label: "Gul", desc: "Intressant / osäker" },
-              { color: "bg-red-500", label: "Röd", desc: "Tveksam / stryk" },
-              { color: "bg-gray-400", label: "Grå", desc: "Neutral notering" },
-            ].map(({ color, label, desc }) => (
-              <div key={label} className="bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-800 rounded-lg p-3 flex items-start gap-2">
-                <span className={`w-3 h-3 rounded-full mt-0.5 shrink-0 ${color}`} />
+              { hex: "#22c55e", label: "Grön", desc: "Favorit / stark chans" },
+              { hex: "#eab308", label: "Gul", desc: "Intressant / osäker" },
+              { hex: "#ef4444", label: "Röd", desc: "Tveksam / stryk" },
+              { hex: "#6b7280", label: "Grå", desc: "Neutral notering" },
+            ].map(({ hex, label, desc }) => (
+              <div
+                key={label}
+                className="rounded-lg p-3 flex items-start gap-2"
+                style={{ background: "var(--tn-bg-card)", border: "1px solid var(--tn-border)" }}
+              >
+                <span className="w-3 h-3 rounded-full mt-0.5 shrink-0" style={{ background: hex }} />
                 <div>
-                  <p className="text-gray-900 dark:text-white text-sm font-medium">{label}</p>
-                  <p className="text-gray-500 dark:text-gray-400 text-xs">{desc}</p>
+                  <p className="text-sm font-medium" style={{ color: "var(--tn-text)" }}>{label}</p>
+                  <p className="text-xs" style={{ color: "var(--tn-text-faint)" }}>{desc}</p>
                 </div>
               </div>
             ))}
           </div>
 
-          <h3 className="text-gray-900 dark:text-white font-semibold mt-6 mb-2">Svara på en anteckning</h3>
-          <p className="text-gray-700 dark:text-gray-300 text-sm">
+          <h3 className="font-semibold mt-6 mb-2" style={{ color: "var(--tn-text)" }}>Svara på en anteckning</h3>
+          <p className="text-sm" style={{ color: "var(--tn-text-dim)" }}>
             Klicka på <Kbd>Svara</Kbd> under en befintlig anteckning för att skriva ett svar i tråden.
             Svar visas indragna under originalanteckningen.
           </p>
 
-          <h3 className="text-gray-900 dark:text-white font-semibold mt-6 mb-2">Viktigt att veta</h3>
-          <ul className="space-y-2 text-gray-700 dark:text-gray-300 text-sm">
-            <li className="flex gap-2"><span className="text-indigo-600 dark:text-indigo-400 mt-0.5">▸</span>Anteckningar är synliga för <strong className="text-gray-900 dark:text-white">alla i din grupp</strong>.</li>
-            <li className="flex gap-2"><span className="text-indigo-600 dark:text-indigo-400 mt-0.5">▸</span>En anteckning på en häst följer med om samma häst dyker upp i en annan omgång.</li>
-            <li className="flex gap-2"><span className="text-indigo-600 dark:text-indigo-400 mt-0.5">▸</span>Du kan bara redigera/ta bort dina <strong className="text-gray-900 dark:text-white">egna</strong> anteckningar.</li>
+          <h3 className="font-semibold mt-6 mb-2" style={{ color: "var(--tn-text)" }}>Viktigt att veta</h3>
+          <ul className="space-y-2 text-sm" style={{ color: "var(--tn-text-dim)" }}>
+            <li className="flex gap-2"><span className="mt-0.5" style={{ color: "var(--tn-accent)" }}>▸</span>Anteckningar är synliga för <strong style={{ color: "var(--tn-text)" }}>alla i din grupp</strong>.</li>
+            <li className="flex gap-2"><span className="mt-0.5" style={{ color: "var(--tn-accent)" }}>▸</span>En anteckning på en häst följer med om samma häst dyker upp i en annan omgång.</li>
+            <li className="flex gap-2"><span className="mt-0.5" style={{ color: "var(--tn-accent)" }}>▸</span>Du kan bara redigera/ta bort dina <strong style={{ color: "var(--tn-text)" }}>egna</strong> anteckningar.</li>
           </ul>
         </section>
 
@@ -277,14 +306,17 @@ export default function ManualPage() {
         <section id="ordlista">
           <SectionHeading number="9" title="Ordlista" />
           <div className="overflow-x-auto">
-            <table className="w-full text-sm border border-gray-200 dark:border-gray-800 rounded-xl overflow-hidden">
+            <table
+              className="w-full text-sm rounded-xl overflow-hidden"
+              style={{ border: "1px solid var(--tn-border)" }}
+            >
               <thead>
-                <tr className="bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300">
+                <tr style={{ background: "var(--tn-bg-chip)", color: "var(--tn-text-dim)" }}>
                   <th className="text-left px-4 py-2 font-semibold">Term</th>
                   <th className="text-left px-4 py-2 font-semibold">Förklaring</th>
                 </tr>
               </thead>
-              <tbody className="divide-y divide-gray-200 dark:divide-gray-800">
+              <tbody>
                 {[
                   ["V85", "Spelform på ATG där du ska pricka vinnaren i 8 lopp"],
                   ["ATG", "AB Trav och Galopp – den svenska speloperatören för travsport"],
@@ -297,9 +329,9 @@ export default function ManualPage() {
                   ["Inbjudningskod", "Unik kod för att gå med i en grupp"],
                   ["Admin", "Gruppens skapare med extra rättigheter att hantera medlemmar"],
                 ].map(([term, desc]) => (
-                  <tr key={term} className="text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-900 transition">
-                    <td className="px-4 py-2 font-medium text-gray-900 dark:text-white whitespace-nowrap">{term}</td>
-                    <td className="px-4 py-2">{desc}</td>
+                  <tr key={term} style={{ borderTop: "1px solid var(--tn-border)" }}>
+                    <td className="px-4 py-2 font-medium whitespace-nowrap" style={{ color: "var(--tn-text)" }}>{term}</td>
+                    <td className="px-4 py-2" style={{ color: "var(--tn-text-dim)" }}>{desc}</td>
                   </tr>
                 ))}
               </tbody>
@@ -307,8 +339,11 @@ export default function ManualPage() {
           </div>
         </section>
 
-        <p className="text-center text-gray-500 dark:text-gray-600 text-xs pt-4 border-t border-gray-200 dark:border-gray-800">
-          Manual version 1.0 – V85 Analys
+        <p
+          className="text-center text-xs pt-4"
+          style={{ color: "var(--tn-text-faint)", borderTop: "1px solid var(--tn-border)" }}
+        >
+          Manual version 1.0 – Travappen
         </p>
       </div>
     </main>
@@ -320,16 +355,23 @@ export default function ManualPage() {
 function SectionHeading({ number, title }: { number: string; title: string }) {
   return (
     <div className="flex items-center gap-3 mb-4">
-      <span className="w-8 h-8 rounded-full bg-indigo-700 flex items-center justify-center text-sm font-bold shrink-0">
+      <span
+        className="w-8 h-8 rounded-full flex items-center justify-center text-sm font-bold shrink-0"
+        style={{ background: "var(--tn-accent)", color: "#fff" }}
+      >
         {number}
       </span>
-      <h2 className="text-xl font-bold text-gray-900 dark:text-white">{title}</h2>
+      <h2 className="text-xl font-bold" style={{ color: "var(--tn-text)" }}>{title}</h2>
     </div>
   );
 }
 
 function Steps({ children }: { children: React.ReactNode }) {
-  return <ol className="space-y-2 text-sm text-gray-700 dark:text-gray-300 list-decimal list-inside">{children}</ol>;
+  return (
+    <ol className="space-y-2 text-sm list-decimal list-inside" style={{ color: "var(--tn-text-dim)" }}>
+      {children}
+    </ol>
+  );
 }
 
 function Step({ children }: { children: React.ReactNode }) {
@@ -338,21 +380,32 @@ function Step({ children }: { children: React.ReactNode }) {
 
 function Kbd({ children }: { children: React.ReactNode }) {
   return (
-    <kbd className="px-1.5 py-0.5 text-xs bg-gray-100 dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded text-gray-800 dark:text-gray-200 font-mono">
+    <kbd
+      className="px-1.5 py-0.5 text-xs rounded tn-mono"
+      style={{
+        background: "var(--tn-bg-chip)",
+        border: "1px solid var(--tn-border)",
+        color: "var(--tn-text)",
+      }}
+    >
       {children}
     </kbd>
   );
 }
 
 function Tip({ children, type = "info" }: { children: React.ReactNode; type?: "info" | "warning" }) {
-  const styles =
-    type === "warning"
-      ? "bg-yellow-950 border-yellow-800 text-yellow-200"
-      : "bg-indigo-950 border-indigo-800 text-indigo-200";
+  const isWarning = type === "warning";
   return (
-    <div className={`mt-4 border rounded-lg px-4 py-3 text-sm ${styles}`}>
-      <span className="font-semibold">{type === "warning" ? "OBS! " : "Tips: "}</span>
-      {children}
+    <div
+      className="mt-4 rounded-lg px-4 py-3 text-sm"
+      style={{
+        background: isWarning ? "rgba(251,191,36,0.08)" : "rgba(59,130,246,0.08)",
+        border: isWarning ? "1px solid rgba(251,191,36,0.3)" : "1px solid rgba(59,130,246,0.3)",
+        color: isWarning ? "var(--tn-warn)" : "var(--tn-accent)",
+      }}
+    >
+      <span className="font-semibold">{isWarning ? "OBS! " : "Tips: "}</span>
+      <span style={{ color: "var(--tn-text-dim)" }}>{children}</span>
     </div>
   );
 }

--- a/app/(authenticated)/page.tsx
+++ b/app/(authenticated)/page.tsx
@@ -101,14 +101,36 @@ export default async function HomePage({
 
   return (
     <RaceTabProvider initialRaceNumber={activeRaceNumber}>
-    <main className="min-h-screen bg-white dark:bg-gray-950 text-gray-900 dark:text-white">
-      {/* Header: mobilanpassad med 2 rader på små skärmar */}
-      <header className="sticky top-0 z-30 bg-white/90 dark:bg-gray-950/90 backdrop-blur-sm border-b border-gray-200 dark:border-gray-800">
-        <div className="px-4 py-4">
-          {/* Rad 1: titel + avatar/tema */}
-          <div className="flex items-center justify-between">
-            <h1 className="text-base font-semibold tracking-tight shrink-0">Streckspel Analys</h1>
-            <div className="flex items-center gap-2 md:hidden">
+    <main className="min-h-screen" style={{ background: "var(--tn-bg)", color: "var(--tn-text)" }}>
+      {/* Sticky header */}
+      <header
+        className="sticky top-0 z-30"
+        style={{
+          background: "color-mix(in oklab, var(--tn-bg) 88%, transparent)",
+          backdropFilter: "blur(20px)",
+          WebkitBackdropFilter: "blur(20px)",
+          borderBottom: "1px solid var(--tn-border)",
+        }}
+      >
+        <div className="px-4 pt-3 pb-2">
+          {/* Brand row (mobile only — desktop has TopNav) */}
+          <div className="flex items-center justify-between md:hidden">
+            <div className="flex items-baseline gap-2">
+              <span className="tn-brand-mark text-xl">Travappen</span>
+              <span
+                className="inline-block w-1.5 h-1.5 rounded-full"
+                style={{ background: "var(--tn-accent)", transform: "translateY(-3px)" }}
+              />
+              {selectedGame && (
+                <span
+                  className="tn-mono text-xs ml-1"
+                  style={{ color: "var(--tn-text-faint)" }}
+                >
+                  {selectedGame.game_type}
+                </span>
+              )}
+            </div>
+            <div className="flex items-center gap-2">
               <ThemeToggle />
               <UserMenu
                 profile={profile}
@@ -117,14 +139,31 @@ export default async function HomePage({
               />
             </div>
           </div>
-          {/* Rad 2: spelkontroller */}
-          <CollapsibleControls>
-            <GamePickerBar savedGames={games} selectedId={selectedId} />
-            <ResultsButton gameId={selectedId} />
-          </CollapsibleControls>
+          {/* Game controls */}
+          <div className="mt-2 md:mt-0">
+            <CollapsibleControls>
+              <GamePickerBar savedGames={games} selectedId={selectedId} />
+              <ResultsButton gameId={selectedId} />
+            </CollapsibleControls>
+          </div>
         </div>
+
+        {/* Game meta bar */}
+        {selectedGame && (
+          <div
+            className="px-4 py-1.5 tn-mono text-xs flex items-center gap-2"
+            style={{ color: "var(--tn-text-faint)", borderTop: "1px solid var(--tn-border)" }}
+          >
+            <span>{selectedGame.date}</span>
+            <span style={{ color: "var(--tn-border-strong)" }}>·</span>
+            <span style={{ color: "var(--tn-accent)", fontWeight: 600 }}>{selectedGame.game_type}</span>
+            <span style={{ color: "var(--tn-border-strong)" }}>·</span>
+            <span>{selectedGame.track}</span>
+          </div>
+        )}
+
         {races.length > 0 && (
-          <Suspense fallback={<div className="h-10 border-t border-gray-200 dark:border-gray-800" />}>
+          <Suspense fallback={<div className="h-10" style={{ borderTop: "1px solid var(--tn-border)" }} />}>
             <RaceTabBar
               races={races.map((r) => ({ race_number: r.race_number, start_time: r.start_time }))}
             />
@@ -132,18 +171,11 @@ export default async function HomePage({
         )}
       </header>
 
-      {selectedGame && (
-        <div className="px-4 py-2 text-xs text-gray-400 dark:text-gray-500 border-b border-gray-200 dark:border-gray-800 tracking-wide">
-          {selectedGame.date} &middot; {selectedGame.game_type} &middot; {selectedGame.track}
-        </div>
-      )}
-
       <div className="px-4 lg:px-[5%] xl:px-[8%] py-6">
         <div className="mb-6">
           <UsefulLinks />
         </div>
 
-        {/* Auto-ladda nästkommande V85/V86 om inga spel finns */}
         {games.length === 0 && <AutoLoadUpcoming />}
 
         <MainPageClient

--- a/app/(authenticated)/sallskap/[groupId]/SallskapPageClient.tsx
+++ b/app/(authenticated)/sallskap/[groupId]/SallskapPageClient.tsx
@@ -37,12 +37,15 @@ export function SallskapPageClient({
   const [activeTab, setActiveTab] = useState<SallskapTab>("forum");
 
   return (
-    <div className="min-h-screen bg-white dark:bg-gray-950 text-gray-900 dark:text-white flex flex-col">
-      {/* Header */}
-      <header className="border-b border-gray-200 dark:border-gray-800 px-4 py-3 flex items-center gap-3 sticky top-0 z-30 bg-white dark:bg-gray-950">
+    <div className="min-h-screen flex flex-col" style={{ background: "var(--tn-bg)", color: "var(--tn-text)" }}>
+      <header
+        className="px-4 py-3 flex items-center gap-3 sticky top-0 z-30"
+        style={{ background: "var(--tn-bg)", borderBottom: "1px solid var(--tn-border)" }}
+      >
         <Link
           href="/"
-          className="text-gray-500 hover:text-gray-900 dark:hover:text-white transition text-lg w-8 text-center shrink-0"
+          className="text-lg w-8 text-center shrink-0 transition"
+          style={{ color: "var(--tn-text-faint)" }}
           aria-label="Tillbaka"
         >
           ←
@@ -51,10 +54,8 @@ export function SallskapPageClient({
         <ThemeToggle />
       </header>
 
-      {/* Tab bar */}
       <TabBar activeTab={activeTab} onChange={setActiveTab} />
 
-      {/* Tab content — alltid monterade för att bevara state vid fliktbyte */}
       <div className="flex-1">
         <div className={activeTab === "forum" ? undefined : "hidden"}>
           <ForumTab

--- a/app/(authenticated)/system/page.tsx
+++ b/app/(authenticated)/system/page.tsx
@@ -25,12 +25,12 @@ export default async function SystemPage({
 
   if (games.length === 0) {
     return (
-      <main className="min-h-screen bg-white dark:bg-gray-950 text-gray-900 dark:text-white">
+      <main className="min-h-screen" style={{ background: "var(--tn-bg)", color: "var(--tn-text)" }}>
         <div className="px-4 py-6 max-w-2xl mx-auto">
           <h1 className="text-xl font-bold mb-6">Mina system</h1>
-          <div className="text-center py-16 text-gray-400 dark:text-gray-500">
-            <p className="text-base mb-1">Ingen omgång inladdad ännu.</p>
-            <p className="text-sm">Gå till Analys-fliken för att hämta ett spel.</p>
+          <div className="text-center py-16">
+            <p className="text-base mb-1" style={{ color: "var(--tn-text-faint)" }}>Ingen omgång inladdad ännu.</p>
+            <p className="text-sm" style={{ color: "var(--tn-text-faint)" }}>Gå till Analys-fliken för att hämta ett spel.</p>
           </div>
         </div>
       </main>
@@ -47,7 +47,7 @@ export default async function SystemPage({
   ])
 
   return (
-    <main className="min-h-screen bg-white dark:bg-gray-950 text-gray-900 dark:text-white">
+    <main className="min-h-screen" style={{ background: "var(--tn-bg)", color: "var(--tn-text)" }}>
       <div className="px-4 pt-6 max-w-2xl mx-auto">
         <h1 className="text-xl font-bold mb-4">Mina system</h1>
       </div>

--- a/app/globals.css
+++ b/app/globals.css
@@ -2,6 +2,240 @@
 
 @custom-variant dark (&:where(.dark, .dark *));
 
-body {
-  font-family: var(--font-geist-sans), sans-serif;
+/* ─── Design tokens ─────────────────────────────────────────── */
+:root {
+  /* Dark palette (default) */
+  --tn-bg: #0a0e14;
+  --tn-bg-raised: #0f141c;
+  --tn-bg-card: #131a24;
+  --tn-bg-card-hover: #182030;
+  --tn-bg-chip: #1a2130;
+  --tn-border: #1f2937;
+  --tn-border-strong: #2a3647;
+  --tn-text: #e6ecf5;
+  --tn-text-dim: #8a95a8;
+  --tn-text-faint: #5a6577;
+
+  /* Accent — cobalt-electric */
+  --tn-accent: #3b82f6;
+  --tn-accent-soft: #1e3a8a;
+  --tn-accent-faint: rgba(59, 130, 246, 0.12);
+  --tn-accent-glow: rgba(59, 130, 246, 0.22);
+
+  /* Semantic */
+  --tn-value-high: #34d399;
+  --tn-value-high-bg: rgba(52, 211, 153, 0.12);
+  --tn-value-low: #f87171;
+  --tn-value-low-bg: rgba(248, 113, 113, 0.10);
+  --tn-warn: #fbbf24;
+  --tn-warn-bg: rgba(251, 191, 36, 0.10);
+
+  /* Form heat */
+  --tn-heat-hot: #f97316;
+  --tn-heat-warm: #fbbf24;
+  --tn-heat-cool: #475569;
+
+  /* Note label colors */
+  --tn-label-red: #ef4444;
+  --tn-label-orange: #f97316;
+  --tn-label-yellow: #eab308;
+  --tn-label-green: #10b981;
+  --tn-label-blue: #3b82f6;
+  --tn-label-purple: #a855f7;
+
+  /* Result badges */
+  --tn-p1: #fbbf24;
+  --tn-p2: #94a3b8;
+  --tn-p3: #b45309;
 }
+
+/* Light theme override via data-theme or .light class */
+[data-theme="light"],
+:root.light {
+  --tn-bg: #f5f3ef;
+  --tn-bg-raised: #ffffff;
+  --tn-bg-card: #ffffff;
+  --tn-bg-card-hover: #fafaf7;
+  --tn-bg-chip: #efece6;
+  --tn-border: #e6e2d9;
+  --tn-border-strong: #d6d1c4;
+  --tn-text: #14171c;
+  --tn-text-dim: #5b6474;
+  --tn-text-faint: #8b93a2;
+
+  --tn-accent: #1d4ed8;
+  --tn-accent-soft: #dbeafe;
+  --tn-accent-faint: rgba(29, 78, 216, 0.08);
+  --tn-accent-glow: rgba(29, 78, 216, 0.15);
+
+  --tn-value-high: #047857;
+  --tn-value-high-bg: rgba(4, 120, 87, 0.10);
+  --tn-value-low: #b91c1c;
+  --tn-value-low-bg: rgba(185, 28, 28, 0.08);
+  --tn-warn: #b45309;
+  --tn-warn-bg: rgba(180, 83, 9, 0.10);
+
+  --tn-heat-hot: #c2410c;
+  --tn-heat-warm: #b45309;
+  --tn-heat-cool: #94a3b8;
+
+  --tn-p1: #d97706;
+  --tn-p2: #64748b;
+  --tn-p3: #92400e;
+}
+
+/* ─── Base ───────────────────────────────────────────────────── */
+*, *::before, *::after {
+  box-sizing: border-box;
+  -webkit-tap-highlight-color: transparent;
+}
+
+html {
+  background: var(--tn-bg);
+}
+
+body {
+  font-family: var(--font-geist-sans), var(--font-instrument-serif), -apple-system, system-ui, sans-serif;
+  background: var(--tn-bg);
+  color: var(--tn-text);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  overflow-x: hidden;
+}
+
+/* ─── Typography helpers ─────────────────────────────────────── */
+.tn-serif {
+  font-family: var(--font-instrument-serif), Georgia, serif;
+}
+
+.tn-mono {
+  font-family: var(--font-geist-mono), ui-monospace, monospace;
+  font-feature-settings: "tnum";
+}
+
+.tn-eyebrow {
+  font-family: var(--font-geist-mono), ui-monospace, monospace;
+  font-size: 10px;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: var(--tn-text-faint);
+  font-weight: 500;
+}
+
+/* ─── Brand mark ─────────────────────────────────────────────── */
+.tn-brand-mark {
+  font-family: var(--font-instrument-serif), Georgia, serif;
+  font-style: italic;
+  letter-spacing: -0.02em;
+  color: var(--tn-text);
+}
+
+/* ─── Chip ───────────────────────────────────────────────────── */
+.tn-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 3px 8px;
+  background: var(--tn-bg-chip);
+  border: 1px solid var(--tn-border);
+  border-radius: 6px;
+  font-size: 11px;
+  font-family: var(--font-geist-mono), ui-monospace, monospace;
+  color: var(--tn-text-dim);
+  white-space: nowrap;
+}
+
+.tn-chip-accent {
+  background: var(--tn-accent-faint);
+  border-color: transparent;
+  color: var(--tn-accent);
+}
+
+.tn-chip-value {
+  background: var(--tn-value-high-bg);
+  color: var(--tn-value-high);
+  border-color: transparent;
+  font-weight: 600;
+}
+
+/* ─── Delta badge ────────────────────────────────────────────── */
+.tn-delta {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  font-family: var(--font-geist-mono), ui-monospace, monospace;
+  font-size: 11px;
+  padding: 2px 6px;
+  border-radius: 4px;
+  white-space: nowrap;
+}
+.tn-delta-pos { background: var(--tn-value-high-bg); color: var(--tn-value-high); }
+.tn-delta-neg { background: var(--tn-value-low-bg); color: var(--tn-value-low); }
+.tn-delta-neu { color: var(--tn-text-faint); }
+
+/* ─── Form score ring ────────────────────────────────────────── */
+.tn-form-ring {
+  position: relative;
+  display: grid;
+  place-items: center;
+}
+.tn-form-ring svg {
+  position: absolute;
+  inset: 0;
+  transform: rotate(-90deg);
+}
+.tn-form-ring .ring-track {
+  stroke: var(--tn-border);
+  stroke-width: 3;
+  fill: none;
+}
+.tn-form-ring .ring-bar {
+  fill: none;
+  stroke-width: 3;
+  stroke-linecap: round;
+}
+.tn-form-ring .ring-val {
+  font-family: var(--font-geist-mono), ui-monospace, monospace;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--tn-text);
+}
+
+/* ─── Last-5 result pills ────────────────────────────────────── */
+.tn-last5 {
+  display: flex;
+  gap: 3px;
+}
+.tn-last5 span {
+  width: 18px;
+  height: 18px;
+  border-radius: 4px;
+  display: grid;
+  place-items: center;
+  font-family: var(--font-geist-mono), ui-monospace, monospace;
+  font-size: 10px;
+  font-weight: 600;
+  background: var(--tn-bg-chip);
+  color: var(--tn-text-dim);
+}
+.tn-last5 .r1 { background: var(--tn-p1); color: #0a0e14; }
+.tn-last5 .r2 { background: var(--tn-p2); color: #0a0e14; }
+.tn-last5 .r3 { background: var(--tn-p3); color: #fff; }
+.tn-last5 .rdq { background: transparent; color: var(--tn-text-faint); border: 1px solid var(--tn-border); }
+
+/* ─── Scrollbar hide ─────────────────────────────────────────── */
+.scrollbar-none::-webkit-scrollbar { display: none; }
+.scrollbar-none { -ms-overflow-style: none; scrollbar-width: none; }
+
+/* ─── Sheet animation ────────────────────────────────────────── */
+@keyframes tn-sheet-up {
+  from { transform: translateY(100%); }
+  to { transform: translateY(0); }
+}
+@keyframes tn-fade-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+.tn-sheet-enter { animation: tn-sheet-up 0.25s cubic-bezier(0.22, 1, 0.36, 1); }
+.tn-backdrop-enter { animation: tn-fade-in 0.18s ease-out; }

--- a/app/join/[inviteCode]/JoinPage.tsx
+++ b/app/join/[inviteCode]/JoinPage.tsx
@@ -38,14 +38,12 @@ export function JoinPage({ group, inviteCode }: Props) {
     }
 
     if (data.session) {
-      // E-postbekräftelse ej aktiverad — direkt inloggad
       const nameParam = displayName.trim()
         ? `?setupName=${encodeURIComponent(displayName.trim())}`
         : "";
       router.push(`/join/${inviteCode}${nameParam}`);
       router.refresh();
     } else {
-      // E-postbekräftelse krävs
       setInfo(
         "Vi har skickat ett bekräftelsemejl till " +
           email +
@@ -75,50 +73,65 @@ export function JoinPage({ group, inviteCode }: Props) {
     router.refresh();
   }
 
+  const inputStyle = {
+    width: "100%",
+    padding: "0.5rem 1rem",
+    borderRadius: "0.5rem",
+    background: "var(--tn-bg-chip)",
+    border: "1px solid var(--tn-border)",
+    color: "var(--tn-text)",
+    fontSize: "0.875rem",
+    outline: "none",
+  };
+
   return (
-    <div className="min-h-screen flex items-center justify-center bg-white dark:bg-gray-950">
-      <div className="w-full max-w-sm bg-gray-50 dark:bg-gray-900 rounded-xl p-8 shadow-xl">
-        {/* Inbjudnings-header */}
+    <div className="min-h-screen flex items-center justify-center" style={{ background: "var(--tn-bg)" }}>
+      <div
+        className="w-full max-w-sm rounded-xl p-8"
+        style={{ background: "var(--tn-bg-card)", border: "1px solid var(--tn-border)" }}
+      >
         <div className="text-center mb-6">
-          <p className="text-3xl mb-2">🏇</p>
-          <h1 className="text-xl font-bold text-gray-900 dark:text-white">
+          <h1 className="text-xl font-bold" style={{ color: "var(--tn-text)" }}>
             Du är inbjuden till
           </h1>
-          <p className="text-indigo-600 dark:text-indigo-400 font-semibold text-lg mt-1">
+          <p className="font-semibold text-lg mt-1" style={{ color: "var(--tn-accent)" }}>
             {group.name}
           </p>
-          <p className="text-gray-500 dark:text-gray-400 text-sm mt-1">
+          <p className="text-sm mt-1" style={{ color: "var(--tn-text-faint)" }}>
             {tab === "register"
               ? "Skapa ett konto för att gå med."
               : "Logga in för att gå med."}
           </p>
         </div>
 
-        {/* Flik-switcher */}
-        <div className="flex rounded-lg overflow-hidden border border-gray-300 dark:border-gray-700 mb-5">
+        <div
+          className="flex rounded-lg overflow-hidden mb-5"
+          style={{ border: "1px solid var(--tn-border)" }}
+        >
           <button
             onClick={() => { setTab("register"); setError(null); setInfo(null); }}
-            className={`flex-1 py-2 text-sm font-medium transition ${
+            className="flex-1 py-2 text-sm font-medium transition"
+            style={
               tab === "register"
-                ? "bg-indigo-600 text-white"
-                : "text-gray-600 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-800"
-            }`}
+                ? { background: "var(--tn-accent)", color: "#fff", border: "none", cursor: "pointer" }
+                : { background: "none", color: "var(--tn-text-faint)", border: "none", cursor: "pointer" }
+            }
           >
             Registrera
           </button>
           <button
             onClick={() => { setTab("login"); setError(null); setInfo(null); }}
-            className={`flex-1 py-2 text-sm font-medium transition ${
+            className="flex-1 py-2 text-sm font-medium transition"
+            style={
               tab === "login"
-                ? "bg-indigo-600 text-white"
-                : "text-gray-600 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-800"
-            }`}
+                ? { background: "var(--tn-accent)", color: "#fff", border: "none", cursor: "pointer" }
+                : { background: "none", color: "var(--tn-text-faint)", border: "none", cursor: "pointer" }
+            }
           >
             Logga in
           </button>
         </div>
 
-        {/* Formulär */}
         {tab === "register" ? (
           <form onSubmit={handleRegister} className="space-y-3">
             <input
@@ -127,14 +140,14 @@ export function JoinPage({ group, inviteCode }: Props) {
               value={email}
               onChange={(e) => setEmail(e.target.value)}
               required
-              className="w-full px-4 py-2 rounded-lg bg-gray-100 dark:bg-gray-800 text-gray-900 dark:text-white border border-gray-300 dark:border-gray-700 focus:outline-none focus:border-indigo-500"
+              style={inputStyle}
             />
             <input
               type="text"
               placeholder="Visningsnamn (valfritt)"
               value={displayName}
               onChange={(e) => setDisplayName(e.target.value)}
-              className="w-full px-4 py-2 rounded-lg bg-gray-100 dark:bg-gray-800 text-gray-900 dark:text-white border border-gray-300 dark:border-gray-700 focus:outline-none focus:border-indigo-500"
+              style={inputStyle}
             />
             <input
               type="password"
@@ -143,14 +156,15 @@ export function JoinPage({ group, inviteCode }: Props) {
               onChange={(e) => setPassword(e.target.value)}
               required
               minLength={6}
-              className="w-full px-4 py-2 rounded-lg bg-gray-100 dark:bg-gray-800 text-gray-900 dark:text-white border border-gray-300 dark:border-gray-700 focus:outline-none focus:border-indigo-500"
+              style={inputStyle}
             />
-            {error && <p className="text-red-400 text-sm">{error}</p>}
-            {info && <p className="text-blue-400 text-sm">{info}</p>}
+            {error && <p className="text-sm" style={{ color: "var(--tn-value-low)" }}>{error}</p>}
+            {info && <p className="text-sm" style={{ color: "var(--tn-accent)" }}>{info}</p>}
             <button
               type="submit"
               disabled={loading}
-              className="w-full py-2 rounded-lg bg-indigo-600 hover:bg-indigo-500 text-white font-semibold disabled:opacity-50 transition"
+              className="w-full py-2 rounded-lg font-semibold disabled:opacity-50 transition"
+              style={{ background: "var(--tn-accent)", color: "#fff", border: "none", cursor: "pointer" }}
             >
               {loading ? "Skapar konto…" : "Skapa konto och gå med"}
             </button>
@@ -163,7 +177,7 @@ export function JoinPage({ group, inviteCode }: Props) {
               value={email}
               onChange={(e) => setEmail(e.target.value)}
               required
-              className="w-full px-4 py-2 rounded-lg bg-gray-100 dark:bg-gray-800 text-gray-900 dark:text-white border border-gray-300 dark:border-gray-700 focus:outline-none focus:border-indigo-500"
+              style={inputStyle}
             />
             <input
               type="password"
@@ -171,13 +185,14 @@ export function JoinPage({ group, inviteCode }: Props) {
               value={password}
               onChange={(e) => setPassword(e.target.value)}
               required
-              className="w-full px-4 py-2 rounded-lg bg-gray-100 dark:bg-gray-800 text-gray-900 dark:text-white border border-gray-300 dark:border-gray-700 focus:outline-none focus:border-indigo-500"
+              style={inputStyle}
             />
-            {error && <p className="text-red-400 text-sm">{error}</p>}
+            {error && <p className="text-sm" style={{ color: "var(--tn-value-low)" }}>{error}</p>}
             <button
               type="submit"
               disabled={loading}
-              className="w-full py-2 rounded-lg bg-indigo-600 hover:bg-indigo-500 text-white font-semibold disabled:opacity-50 transition"
+              className="w-full py-2 rounded-lg font-semibold disabled:opacity-50 transition"
+              style={{ background: "var(--tn-accent)", color: "#fff", border: "none", cursor: "pointer" }}
             >
               {loading ? "Loggar in…" : "Logga in och gå med"}
             </button>

--- a/app/join/[inviteCode]/page.tsx
+++ b/app/join/[inviteCode]/page.tsx
@@ -15,7 +15,6 @@ export default async function InvitePage({ params, searchParams }: Props) {
   const { inviteCode } = await params;
   const { setupName } = await searchParams;
 
-  // Hämta grupp-info med service client (ingen auth behövs för att visa info)
   const db = createServiceClient();
   const { data: group } = await db
     .from("groups")
@@ -25,13 +24,15 @@ export default async function InvitePage({ params, searchParams }: Props) {
 
   if (!group) {
     return (
-      <div className="min-h-screen flex items-center justify-center bg-white dark:bg-gray-950">
-        <div className="w-full max-w-sm bg-gray-50 dark:bg-gray-900 rounded-xl p-8 shadow-xl text-center">
-          <p className="text-2xl mb-2">🔗</p>
-          <h1 className="text-xl font-bold text-gray-900 dark:text-white mb-2">
+      <div className="min-h-screen flex items-center justify-center" style={{ background: "var(--tn-bg)" }}>
+        <div
+          className="w-full max-w-sm rounded-xl p-8 text-center"
+          style={{ background: "var(--tn-bg-card)", border: "1px solid var(--tn-border)" }}
+        >
+          <h1 className="text-xl font-bold mb-2" style={{ color: "var(--tn-text)" }}>
             Ogiltig inbjudningslänk
           </h1>
-          <p className="text-gray-500 dark:text-gray-400 text-sm">
+          <p className="text-sm" style={{ color: "var(--tn-text-faint)" }}>
             Länken fungerar inte. Be om en ny länk av den som bjöd in dig.
           </p>
         </div>
@@ -39,22 +40,18 @@ export default async function InvitePage({ params, searchParams }: Props) {
     );
   }
 
-  // Kolla om användaren redan är inloggad
   const supabase = await createClient();
   const {
     data: { user },
   } = await supabase.auth.getUser();
 
   if (user) {
-    // Sätt visningsnamn om det skickades med (t.ex. efter nyregistrering)
     if (setupName) {
       await updateProfile(decodeURIComponent(setupName));
     }
-    // Gå med i gruppen automatiskt (ignorera fel om redan med)
     await joinGroup(inviteCode);
     redirect("/");
   }
 
-  // Visa registrerings-/login-sida
   return <JoinPage group={group as Group} inviteCode={inviteCode} />;
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata, Viewport } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Geist, Geist_Mono, Instrument_Serif } from "next/font/google";
 import "./globals.css";
 import { ThemeProvider } from "@/components/ThemeProvider";
 
@@ -13,13 +13,20 @@ const geistMono = Geist_Mono({
   subsets: ["latin"],
 });
 
+const instrumentSerif = Instrument_Serif({
+  variable: "--font-instrument-serif",
+  subsets: ["latin"],
+  weight: "400",
+  style: ["normal", "italic"],
+});
+
 export const metadata: Metadata = {
-  title: "V85 Analys",
-  description: "Startlistor och formscore för V85",
+  title: "Travappen",
+  description: "Matematisk analys för svenska travspel — V75, V85, V64, V86, GS75",
   appleWebApp: {
     capable: true,
     statusBarStyle: "black-translucent",
-    title: "V85 Analys",
+    title: "Travappen",
   },
   formatDetection: {
     telephone: false,
@@ -27,7 +34,7 @@ export const metadata: Metadata = {
 };
 
 export const viewport: Viewport = {
-  themeColor: "#030712",
+  themeColor: "#0a0e14",
   width: "device-width",
   initialScale: 1,
   maximumScale: 1,
@@ -40,12 +47,12 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="sv" className="dark">
+    <html lang="sv">
       <head>
         <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
       </head>
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased bg-white dark:bg-gray-950 overflow-x-hidden`}
+        className={`${geistSans.variable} ${geistMono.variable} ${instrumentSerif.variable} antialiased overflow-x-hidden`}
       >
         <ThemeProvider>{children}</ThemeProvider>
         <script

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -27,36 +27,94 @@ export default function LoginPage() {
   }
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-white dark:bg-gray-950">
-      <div className="w-full max-w-sm bg-gray-50 dark:bg-gray-900 rounded-xl p-8 shadow-xl">
-        <h1 className="text-2xl font-bold text-gray-900 dark:text-white mb-2">V85 Analys</h1>
-        <p className="text-gray-500 dark:text-gray-400 text-sm mb-6">Logga in för att fortsätta</p>
-        <form onSubmit={handleLogin} className="space-y-4">
-          <input
-            type="email"
-            placeholder="E-post"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            required
-            className="w-full px-4 py-2 rounded-lg bg-gray-100 dark:bg-gray-800 text-gray-900 dark:text-white border border-gray-300 dark:border-gray-700 focus:outline-none focus:border-blue-500"
+    <div
+      className="min-h-screen flex flex-col"
+      style={{ background: "var(--tn-bg)", color: "var(--tn-text)" }}
+    >
+      <div className="flex flex-col flex-1 px-7 py-10 max-w-sm mx-auto w-full">
+        {/* Brand */}
+        <div className="flex items-center gap-2 mt-6">
+          <span
+            className="inline-block w-2.5 h-2.5 rounded-full"
+            style={{ background: "var(--tn-accent)" }}
           />
-          <input
-            type="password"
-            placeholder="Lösenord"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            required
-            className="w-full px-4 py-2 rounded-lg bg-gray-100 dark:bg-gray-800 text-gray-900 dark:text-white border border-gray-300 dark:border-gray-700 focus:outline-none focus:border-blue-500"
-          />
-          {error && <p className="text-red-400 text-sm">{error}</p>}
-          <button
-            type="submit"
-            disabled={loading}
-            className="w-full py-2 rounded-lg bg-blue-600 hover:bg-blue-500 text-white font-semibold disabled:opacity-50 transition"
+          <span className="tn-eyebrow">TRAVAPPEN · V75 V85 V64 V86 GS75</span>
+        </div>
+
+        {/* Hero */}
+        <div className="flex-1 flex flex-col justify-center py-12">
+          <h1
+            className="tn-serif"
+            style={{ fontSize: 52, lineHeight: 1, letterSpacing: "-0.02em", color: "var(--tn-text)" }}
           >
-            {loading ? "Loggar in..." : "Logga in"}
-          </button>
-        </form>
+            Analys.<br />
+            <em style={{ color: "var(--tn-accent)" }}>Inte</em> tips.
+          </h1>
+          <p
+            className="mt-4 text-sm leading-relaxed"
+            style={{ color: "var(--tn-text-dim)", maxWidth: "88%" }}
+          >
+            Matematisk vinstchans vs streckning. Delade noter med ditt spelgäng. Ett verktyg, alla svenska travspel.
+          </p>
+        </div>
+
+        {/* Form */}
+        <div className="pb-10 space-y-3">
+          <form onSubmit={handleLogin} className="space-y-3">
+            <input
+              type="email"
+              placeholder="du@exempel.se"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+              className="w-full px-4 py-3 rounded-xl text-sm outline-none transition-colors"
+              style={{
+                background: "var(--tn-bg-chip)",
+                border: "1px solid var(--tn-border)",
+                color: "var(--tn-text)",
+                fontFamily: "var(--font-geist-sans)",
+              }}
+              onFocus={(e) => (e.currentTarget.style.borderColor = "var(--tn-accent)")}
+              onBlur={(e) => (e.currentTarget.style.borderColor = "var(--tn-border)")}
+            />
+            <input
+              type="password"
+              placeholder="Lösenord"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+              className="w-full px-4 py-3 rounded-xl text-sm outline-none transition-colors"
+              style={{
+                background: "var(--tn-bg-chip)",
+                border: "1px solid var(--tn-border)",
+                color: "var(--tn-text)",
+                fontFamily: "var(--font-geist-sans)",
+              }}
+              onFocus={(e) => (e.currentTarget.style.borderColor = "var(--tn-accent)")}
+              onBlur={(e) => (e.currentTarget.style.borderColor = "var(--tn-border)")}
+            />
+            {error && (
+              <p
+                className="text-sm rounded-lg px-3 py-2"
+                style={{ color: "var(--tn-value-low)", background: "var(--tn-value-low-bg)" }}
+              >
+                {error}
+              </p>
+            )}
+            <button
+              type="submit"
+              disabled={loading}
+              className="w-full py-3.5 rounded-xl text-sm font-semibold transition-opacity disabled:opacity-50"
+              style={{
+                background: "var(--tn-accent)",
+                color: "#fff",
+                marginTop: 4,
+              }}
+            >
+              {loading ? "Loggar in..." : "Logga in"}
+            </button>
+          </form>
+        </div>
       </div>
     </div>
   );

--- a/components/AnalysisPanel.tsx
+++ b/components/AnalysisPanel.tsx
@@ -22,46 +22,48 @@ interface AnalysisPanelProps {
 }
 
 function DistBadge({ factor, label }: { factor: number; label: string }) {
-  let color: string;
   let icon: string;
-  if (factor >= 1.3) {
-    color = "text-green-400 bg-green-100 dark:bg-green-900/40";
-    icon = "↑↑";
-  } else if (factor >= 1.1) {
-    color = "text-green-400 bg-green-50 dark:bg-green-900/30";
-    icon = "↑";
-  } else if (factor >= 0.95) {
-    color = "text-gray-500 dark:text-gray-400 bg-gray-200 dark:bg-gray-700";
-    icon = "→";
-  } else if (factor >= 0.7) {
-    color = "text-orange-400 bg-orange-50 dark:bg-orange-900/30";
-    icon = "↓";
-  } else {
-    color = "text-red-400 bg-red-50 dark:bg-red-900/30";
-    icon = "↓↓";
-  }
+  let color: string;
+  let bg: string;
+  if (factor >= 1.3) { icon = "↑↑"; color = "var(--tn-value-high)"; bg = "var(--tn-value-high-bg)"; }
+  else if (factor >= 1.1) { icon = "↑"; color = "var(--tn-value-high)"; bg = "var(--tn-value-high-bg)"; }
+  else if (factor >= 0.95) { icon = "→"; color = "var(--tn-text-faint)"; bg = "var(--tn-bg-chip)"; }
+  else if (factor >= 0.7) { icon = "↓"; color = "var(--tn-warn)"; bg = "var(--tn-warn-bg)"; }
+  else { icon = "↓↓"; color = "var(--tn-value-low)"; bg = "var(--tn-value-low-bg)"; }
+
   return (
     <span
-      className={`inline-flex items-center gap-1 text-xs px-1.5 py-0.5 rounded ${color}`}
+      className="inline-flex items-center gap-1 tn-mono text-xs px-1.5 py-0.5 rounded"
+      style={{ color, background: bg }}
       title={label}
     >
       <span className="font-bold">{icon}</span>
-      <span className="hidden sm:inline truncate max-w-[180px]">{label}</span>
+      <span className="hidden sm:inline truncate max-w-[160px]">{label}</span>
     </span>
   );
 }
 
-function ScoreBadge({ score }: { score: number }) {
-  const color =
-    score >= 70
-      ? "bg-green-100 dark:bg-green-900/40 text-green-700 dark:text-green-400"
-      : score >= 40
-      ? "bg-yellow-100 dark:bg-yellow-900/40 text-yellow-700 dark:text-yellow-400"
-      : "bg-red-100 dark:bg-red-900/40 text-red-600 dark:text-red-400";
+function DeltaChip({ value, hasStreck }: { value: number; hasStreck: boolean }) {
+  if (!hasStreck) {
+    return <span className="text-xs italic" style={{ color: "var(--tn-text-faint)" }}>—</span>;
+  }
+  if (value >= 5) {
+    return (
+      <span className="tn-delta tn-delta-pos font-bold">+{value} pp</span>
+    );
+  }
+  if (value >= 2) {
+    return (
+      <span className="tn-delta tn-delta-pos">+{value} pp</span>
+    );
+  }
+  if (value <= -5) {
+    return (
+      <span className="tn-delta tn-delta-neg">{value} pp</span>
+    );
+  }
   return (
-    <span className={`inline-block text-xs font-bold px-1.5 py-0.5 rounded ${color}`}>
-      {score}
-    </span>
+    <span className="tn-delta tn-delta-neu">{value > 0 ? `+${value}` : value} pp</span>
   );
 }
 
@@ -85,23 +87,16 @@ function rankStarters(
   raceStartMethod: string,
   trackConfig?: TrackConfig
 ): RankedStarter[] {
-  // Beräkna distanssignal per häst (för visning)
   const withDist = starters.map((s) => {
     const records: LifeRecord[] = Array.isArray(s.life_records) ? s.life_records : [];
     const distSignal = computeDistanceSignal(records, raceMeters, raceStartMethod);
     const cs = s.formscore ?? 0;
-
     const betDist = s.bet_distribution;
     const streckPct = betDist != null && isFinite(Number(betDist)) ? Number(betDist) : 0;
-
-    // Beräknad chans baserad på CS relativt fältet
     const totalCS = starters.reduce((sum, st) => sum + (st.formscore ?? 0), 0);
     const calcPct = totalCS > 0 ? Math.round(((cs / totalCS) * 100) * 10) / 10 : 0;
-
     const value = streckPct > 0 ? Math.round((calcPct - streckPct) * 10) / 10 : 0;
     const isValue = cs > 55 && value > 0;
-
-    // Beräkna spårfaktordelta (base vs. banspecifikt justerad)
     const postPos = (s as { post_position?: number | null }).post_position ?? 1;
     const horseHistory = (s as { horse_starts_history?: unknown[] }).horse_starts_history ?? [];
     const trackFactorBase = computeTrackFactor(postPos, raceStartMethod, horseHistory as never[]);
@@ -109,10 +104,8 @@ function rankStarters(
       ? computeTrackFactor(postPos, raceStartMethod, horseHistory as never[], trackConfig, raceMeters)
       : trackFactorBase;
     const trackFactorDelta = Math.round((trackFactorAdjusted - trackFactorBase) * 100) / 100;
-
     return { starter: s, cs, distSignal, calcPct, streckPct, value, rank: 0, isValue, trackFactorBase, trackFactorAdjusted, trackFactorDelta };
   });
-
   withDist.sort((a, b) => b.cs - a.cs);
   withDist.forEach((r, i) => (r.rank = i + 1));
   return withDist;
@@ -121,158 +114,163 @@ function rankStarters(
 export function AnalysisPanel({ starters, raceMeters, raceStartMethod, trackConfig }: AnalysisPanelProps) {
   const ranked = rankStarters(starters, raceMeters, raceStartMethod, trackConfig);
   const hasStreckning = ranked.some((r) => r.streckPct > 0);
-
-  const distLabel =
-    raceMeters <= 1800 ? "kort" : raceMeters <= 2400 ? "medel" : "lång";
+  const distLabel = raceMeters <= 1800 ? "kort" : raceMeters <= 2400 ? "medel" : "lång";
 
   return (
-    <div className="mt-3 bg-indigo-50 dark:bg-indigo-950/50 border border-indigo-200 dark:border-indigo-800/50 rounded-xl p-4">
-      <h3 className="text-sm font-bold text-indigo-700 dark:text-indigo-300 mb-1">
-        Analys — Composite Score
-      </h3>
-      <p className="text-xs text-indigo-600 dark:text-indigo-400/80 mb-2">
-        CS (0–100) = form (30%) + vinstprocent (20%) + odds (15%) + tid (15%) + konsistens (10%) + distans (5%) + spår (5%).
-        {" "}Distans: {distLabel} ({raceMeters} m, {raceStartMethod}start).
-        {" "}Spelvärde = CS-andel − streckning.
-      </p>
-
-      {!hasStreckning && (
-        <p className="text-xs text-amber-400 bg-amber-50 dark:bg-amber-900/20 rounded px-2 py-1 mb-2">
-          Streckningsdata saknas — hämta om spelet när poolen är öppen.
+    <div
+      className="mt-3 rounded-xl overflow-hidden"
+      style={{
+        border: "1px solid var(--tn-border)",
+        background: `linear-gradient(180deg, color-mix(in oklab, var(--tn-accent) 4%, var(--tn-bg-card)), var(--tn-bg-card) 60%)`,
+      }}
+    >
+      {/* Header */}
+      <div className="px-4 pt-4 pb-3" style={{ borderBottom: "1px solid var(--tn-border)" }}>
+        <h3 className="tn-serif text-lg" style={{ color: "var(--tn-text)", letterSpacing: "-0.01em" }}>
+          Matematisk analys
+        </h3>
+        <p className="text-xs mt-1" style={{ color: "var(--tn-text-dim)", lineHeight: 1.5 }}>
+          CS (0–100) = form (30%) + vinstprocent (20%) + odds (15%) + tid (15%) + konsistens (10%) + distans (5%) + spår (5%).
+          {" "}Distans: {distLabel} ({raceMeters} m, {raceStartMethod}start).
+          {" "}Spelvärde = CS-andel − streckning.
         </p>
-      )}
+        {!hasStreckning && (
+          <p
+            className="text-xs mt-2 rounded-lg px-3 py-2"
+            style={{ color: "var(--tn-warn)", background: "var(--tn-warn-bg)" }}
+          >
+            Streckningsdata saknas — hämta om spelet när poolen är öppen.
+          </p>
+        )}
+      </div>
 
+      {/* Table */}
       <div className="overflow-x-auto">
         <table className="w-full text-sm">
           <thead>
-            <tr className="text-xs text-indigo-500 dark:text-indigo-400/60 border-b border-indigo-200 dark:border-indigo-800/40">
-              <th className="text-left py-1 pr-2 font-medium w-8">Rank</th>
-              <th className="text-left py-1 pr-2 font-medium">Häst</th>
-              <th className="text-center py-1 pr-2 font-medium w-14">CS</th>
-              <th className="text-right py-1 pr-2 font-medium w-16">Odds</th>
-              <th className="text-right py-1 pr-2 font-medium w-20">Beräknad</th>
-              <th className="text-right py-1 pr-2 font-medium w-20">Streckning</th>
-              <th className="text-left py-1 pr-2 font-medium min-w-[100px]">Distans</th>
-              {trackConfig && <th className="text-right py-1 pr-2 font-medium w-20">Spårfaktor</th>}
-              <th className="text-right py-1 pr-2 font-medium min-w-[90px]">Spelvärde</th>
-              <th className="text-right py-1 font-medium w-20">Resultat</th>
+            <tr style={{ borderBottom: "1px solid var(--tn-border)" }}>
+              {["#", "Häst", "CS", "Odds", "Ber.", "Strk.", "Distans", ...(trackConfig ? ["Spår"] : []), "Värde", "Res."].map((h) => (
+                <th
+                  key={h}
+                  className="tn-eyebrow py-2.5 px-2 first:pl-4 last:pr-4 font-normal"
+                  style={{ textAlign: h === "Häst" || h === "Distans" ? "left" : h === "#" ? "left" : "right" }}
+                >
+                  {h}
+                </th>
+              ))}
             </tr>
           </thead>
           <tbody>
-            {ranked.map((r) => (
-              <tr
-                key={r.starter.start_number}
-                className={`border-b border-indigo-100 dark:border-indigo-800/20 ${
-                  r.isValue ? "border-l-2 border-l-green-500 bg-green-50 dark:bg-green-900/10" : ""
-                }`}
-              >
-                <td className="py-1.5 pr-2 tabular-nums">
-                  {r.rank === 1 ? (
-                    <span className="font-bold text-yellow-600 dark:text-yellow-400">#1</span>
-                  ) : (
-                    <span className="text-gray-400 dark:text-gray-500 text-xs">#{r.rank}</span>
-                  )}
-                </td>
-                <td className="py-1.5 pr-2 font-medium text-gray-900 dark:text-gray-100">
-                  <span className="text-gray-400 dark:text-gray-500 text-xs mr-1">{r.starter.start_number}.</span>
-                  {r.starter.horses?.name ?? "–"}
-                  {r.isValue && (
-                    <span className="ml-1.5 text-[10px] font-bold bg-green-600 text-white px-1 py-0.5 rounded uppercase tracking-wide">
-                      Värde
-                    </span>
-                  )}
-                </td>
-                <td className="py-1.5 pr-2 text-center">
-                  <ScoreBadge score={r.cs} />
-                </td>
-                <td className="py-1.5 pr-2 text-right text-gray-500 dark:text-gray-400 tabular-nums">
-                  {r.starter.odds != null ? `${r.starter.odds.toFixed(1)}x` : "–"}
-                </td>
-                <td className="py-1.5 pr-2 text-right font-mono text-indigo-700 dark:text-indigo-300 tabular-nums">
-                  {r.calcPct}%
-                </td>
-                <td className="py-1.5 pr-2 text-right font-mono tabular-nums">
-                  {r.streckPct > 0 ? (
-                    <span className="text-purple-600 dark:text-purple-400">{r.streckPct}%</span>
-                  ) : (
-                    <span className="text-gray-500 dark:text-gray-600">–</span>
-                  )}
-                </td>
-                <td className="py-1.5 pr-2">
-                  <DistBadge factor={r.distSignal.factor} label={r.distSignal.label} />
-                </td>
-                {trackConfig && (
-                  <td className="py-1.5 pr-2 text-right tabular-nums">
-                    {Math.abs(r.trackFactorDelta) >= 0.01 ? (
+            {ranked.map((r) => {
+              const finishStyle: React.CSSProperties =
+                r.starter.finish_position === 1 ? { background: "var(--tn-p1)", color: "#0a0e14" }
+                : r.starter.finish_position === 2 ? { background: "var(--tn-p2)", color: "#0a0e14" }
+                : r.starter.finish_position === 3 ? { background: "var(--tn-p3)", color: "#fff" }
+                : r.starter.finish_position != null ? { background: "var(--tn-bg-chip)", color: "var(--tn-text-dim)" }
+                : {};
+
+              return (
+                <tr
+                  key={r.starter.start_number}
+                  style={{
+                    borderBottom: "1px solid var(--tn-border)",
+                    background: r.isValue ? "var(--tn-value-high-bg)" : "transparent",
+                    ...(r.isValue ? { boxShadow: "inset 3px 0 0 var(--tn-value-high)" } : {}),
+                  }}
+                >
+                  {/* Rank */}
+                  <td className="py-2.5 pl-4 pr-2 tn-mono text-xs" style={{ color: r.rank === 1 ? "var(--tn-warn)" : "var(--tn-text-faint)" }}>
+                    #{r.rank}
+                  </td>
+                  {/* Name */}
+                  <td className="py-2.5 pr-2 text-sm" style={{ color: "var(--tn-text)", fontWeight: 500 }}>
+                    <span className="tn-mono text-xs mr-1" style={{ color: "var(--tn-text-faint)" }}>{r.starter.start_number}.</span>
+                    {r.starter.horses?.name ?? "–"}
+                    {r.isValue && (
                       <span
-                        className={`text-xs font-bold px-1.5 py-0.5 rounded ${
-                          r.trackFactorDelta > 0
-                            ? "bg-green-100 dark:bg-green-900/40 text-green-600 dark:text-green-400"
-                            : "bg-red-100 dark:bg-red-900/30 text-red-500 dark:text-red-400"
-                        }`}
-                        title={`Spårfaktor: ${r.trackFactorAdjusted.toFixed(2)} (${r.trackFactorDelta >= 0 ? "+" : ""}${r.trackFactorDelta.toFixed(2)})`}
+                        className="ml-2 tn-mono text-[9px] font-bold px-1.5 py-0.5 rounded"
+                        style={{ background: "var(--tn-value-high-bg)", color: "var(--tn-value-high)", letterSpacing: "0.08em" }}
                       >
-                        {r.trackFactorAdjusted.toFixed(2)}{" "}
-                        <span className="opacity-70">
-                          ({r.trackFactorDelta >= 0 ? "+" : ""}{r.trackFactorDelta.toFixed(2)})
-                        </span>
-                      </span>
-                    ) : (
-                      <span className="text-xs text-gray-400 dark:text-gray-500">
-                        {r.trackFactorBase.toFixed(2)}
+                        VÄRDE
                       </span>
                     )}
                   </td>
-                )}
-                <td className="py-1.5 pr-2 text-right">
-                  {r.streckPct > 0 ? (
-                    r.value >= 5 ? (
-                      <span className="text-xs font-bold text-green-400 bg-green-100 dark:bg-green-900/40 px-1.5 py-0.5 rounded whitespace-nowrap">
-                        +{r.value} pp
-                      </span>
-                    ) : r.value >= 2 ? (
-                      <span className="text-xs font-semibold text-green-400 bg-green-50 dark:bg-green-900/20 px-1.5 py-0.5 rounded whitespace-nowrap">
-                        +{r.value} pp
-                      </span>
-                    ) : r.value <= -5 ? (
-                      <span className="text-xs text-red-400 bg-red-50 dark:bg-red-900/20 px-1.5 py-0.5 rounded whitespace-nowrap">
-                        {r.value} pp
+                  {/* CS */}
+                  <td className="py-2.5 pr-2 text-right">
+                    <span
+                      className="tn-mono text-xs font-bold px-1.5 py-0.5 rounded"
+                      style={{
+                        color: r.cs >= 70 ? "var(--tn-value-high)" : r.cs >= 40 ? "var(--tn-accent)" : "var(--tn-text-faint)",
+                        background: r.cs >= 70 ? "var(--tn-value-high-bg)" : r.cs >= 40 ? "var(--tn-accent-faint)" : "var(--tn-bg-chip)",
+                      }}
+                    >
+                      {r.cs}
+                    </span>
+                  </td>
+                  {/* Odds */}
+                  <td className="py-2.5 pr-2 text-right tn-mono text-xs" style={{ color: "var(--tn-text-dim)" }}>
+                    {r.starter.odds != null ? `${r.starter.odds.toFixed(1)}x` : "–"}
+                  </td>
+                  {/* Calculated % */}
+                  <td className="py-2.5 pr-2 text-right tn-mono text-xs font-semibold" style={{ color: "var(--tn-accent)" }}>
+                    {r.calcPct}%
+                  </td>
+                  {/* Streck % */}
+                  <td className="py-2.5 pr-2 text-right tn-mono text-xs" style={{ color: "var(--tn-text-dim)" }}>
+                    {r.streckPct > 0 ? `${r.streckPct}%` : "–"}
+                  </td>
+                  {/* Distance signal */}
+                  <td className="py-2.5 pr-2">
+                    <DistBadge factor={r.distSignal.factor} label={r.distSignal.label} />
+                  </td>
+                  {/* Track factor */}
+                  {trackConfig && (
+                    <td className="py-2.5 pr-2 text-right tn-mono text-xs">
+                      {Math.abs(r.trackFactorDelta) >= 0.01 ? (
+                        <span
+                          className="font-bold px-1.5 py-0.5 rounded"
+                          style={{
+                            color: r.trackFactorDelta > 0 ? "var(--tn-value-high)" : "var(--tn-value-low)",
+                            background: r.trackFactorDelta > 0 ? "var(--tn-value-high-bg)" : "var(--tn-value-low-bg)",
+                          }}
+                          title={`Spårfaktor: ${r.trackFactorAdjusted.toFixed(2)} (${r.trackFactorDelta >= 0 ? "+" : ""}${r.trackFactorDelta.toFixed(2)})`}
+                        >
+                          {r.trackFactorAdjusted.toFixed(2)}{" "}
+                          <span style={{ opacity: 0.7 }}>
+                            ({r.trackFactorDelta >= 0 ? "+" : ""}{r.trackFactorDelta.toFixed(2)})
+                          </span>
+                        </span>
+                      ) : (
+                        <span style={{ color: "var(--tn-text-faint)" }}>{r.trackFactorBase.toFixed(2)}</span>
+                      )}
+                    </td>
+                  )}
+                  {/* Value */}
+                  <td className="py-2.5 pr-2 text-right">
+                    <DeltaChip value={r.value} hasStreck={r.streckPct > 0} />
+                  </td>
+                  {/* Result */}
+                  <td className="py-2.5 pr-4 text-right">
+                    {r.starter.finish_position != null ? (
+                      <span
+                        className="tn-mono text-xs font-bold px-2 py-0.5 rounded-full"
+                        style={finishStyle}
+                      >
+                        {r.starter.finish_position}:a{r.starter.finish_time ? ` ${r.starter.finish_time}` : ""}
                       </span>
                     ) : (
-                      <span className="text-xs text-gray-500 dark:text-gray-400 whitespace-nowrap">
-                        {r.value > 0 ? `+${r.value}` : r.value} pp
-                      </span>
-                    )
-                  ) : (
-                    <span className="text-xs text-gray-400 dark:text-gray-500 italic">inväntar streckning</span>
-                  )}
-                </td>
-                <td className="py-1.5 text-right">
-                  {r.starter.finish_position != null ? (
-                    <span
-                      className={`text-xs font-bold px-1.5 py-0.5 rounded-full ${
-                        r.starter.finish_position === 1
-                          ? "bg-yellow-400 text-black"
-                          : r.starter.finish_position === 2
-                          ? "bg-gray-300 text-black"
-                          : r.starter.finish_position === 3
-                          ? "bg-amber-600 text-white"
-                          : "bg-gray-500 text-white"
-                      }`}
-                    >
-                      {r.starter.finish_position}:a{r.starter.finish_time ? ` ${r.starter.finish_time}` : ""}
-                    </span>
-                  ) : (
-                    <span className="text-gray-400 dark:text-gray-600 text-xs">–</span>
-                  )}
-                </td>
-              </tr>
-            ))}
+                      <span style={{ color: "var(--tn-text-faint)" }}>–</span>
+                    )}
+                  </td>
+                </tr>
+              );
+            })}
           </tbody>
         </table>
       </div>
 
-      <div className="mt-3 flex flex-wrap gap-x-4 gap-y-1 text-xs text-indigo-500 dark:text-indigo-400/60">
+      {/* Legend */}
+      <div className="px-4 py-3 flex flex-wrap gap-x-4 gap-y-1 tn-mono text-[10px]" style={{ color: "var(--tn-text-faint)" }}>
         <span>↑↑ Vunnit på distansen (×1.35)</span>
         <span>↑ Placerat (×1.1)</span>
         <span>→ Sprungit utan placering</span>

--- a/components/AutoLoadUpcoming.tsx
+++ b/components/AutoLoadUpcoming.tsx
@@ -9,10 +9,6 @@ interface UpcomingResponse {
   date: string | null;
 }
 
-/**
- * Visas när inga spel är sparade.
- * Letar automatiskt upp nästkommande V86/V85/V75 och erbjuder att hämta det.
- */
 export function AutoLoadUpcoming() {
   const router = useRouter();
   const [upcoming, setUpcoming] = useState<UpcomingResponse | null>(null);
@@ -50,34 +46,42 @@ export function AutoLoadUpcoming() {
 
   if (loading) {
     return (
-      <div className="text-center py-6 text-sm text-gray-400 dark:text-gray-500">
+      <div className="text-center py-6 text-sm" style={{ color: "var(--tn-text-faint)" }}>
         Letar efter nästa spel...
       </div>
     );
   }
 
-  if (!upcoming?.game) {
-    return null; // Inga spel hittades — visa standard tom-vy
-  }
+  if (!upcoming?.game) return null;
 
   const dateLabel = upcoming.date === new Date().toLocaleDateString("sv-SE") ? "idag" : "imorgon";
 
   return (
-    <div className="mb-6 rounded-xl border border-indigo-200 dark:border-indigo-800 bg-indigo-50 dark:bg-indigo-950 p-5 text-center">
-      <div className="text-3xl mb-2">🏇</div>
-      <h2 className="text-base font-bold text-gray-900 dark:text-white mb-1">
+    <div
+      className="mb-6 rounded-xl p-5 text-center"
+      style={{ background: "var(--tn-bg-card)", border: "1px solid var(--tn-border)" }}
+    >
+      <p className="tn-eyebrow mb-3">Nästa spel</p>
+      <h2 className="text-base font-bold mb-1" style={{ color: "var(--tn-text)" }}>
         {upcoming.game.label} {dateLabel}
       </h2>
-      <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">
+      <p className="text-sm mb-4" style={{ color: "var(--tn-text-faint)" }}>
         Hämta spelet för att se hästar och börja analysera.
       </p>
       {error && (
-        <p className="text-sm text-red-500 mb-3">{error}</p>
+        <p className="text-sm mb-3" style={{ color: "var(--tn-value-low)" }}>{error}</p>
       )}
       <button
         onClick={handleAutoLoad}
         disabled={fetching}
-        className="px-6 py-2.5 rounded-xl bg-indigo-600 hover:bg-indigo-500 text-white font-bold text-sm disabled:opacity-60 transition"
+        className="text-sm font-bold rounded-xl transition disabled:opacity-60"
+        style={{
+          padding: "10px 24px",
+          background: "var(--tn-accent)",
+          color: "#fff",
+          border: "none",
+          cursor: "pointer",
+        }}
       >
         {fetching ? "Hämtar..." : `Hämta ${upcoming.game.label}`}
       </button>

--- a/components/BottomNav.tsx
+++ b/components/BottomNav.tsx
@@ -5,39 +5,40 @@ import { usePathname } from "next/navigation";
 
 const tabs = [
   {
-    label: 'Analys',
-    href: '/',
+    label: "Lopp",
+    href: "/",
     icon: (
-      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" className="w-6 h-6">
-        <path d="M11.47 3.84a.75.75 0 011.06 0l8.69 8.69a.75.75 0 101.06-1.06l-8.689-8.69a2.25 2.25 0 00-3.182 0l-8.69 8.69a.75.75 0 001.061 1.06l8.69-8.69z" />
-        <path d="M12 5.432l8.159 8.159c.03.03.06.058.091.086v6.198c0 1.035-.84 1.875-1.875 1.875H15a.75.75 0 01-.75-.75v-4.5a.75.75 0 00-.75-.75h-3a.75.75 0 00-.75.75V21a.75.75 0 01-.75.75H5.625a1.875 1.875 0 01-1.875-1.875v-6.198a2.29 2.29 0 00.091-.086L12 5.43z" />
+      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M3 18h18M5 14l2-4h10l2 4M8 14v4M16 14v4M9 10V6h6v4" />
       </svg>
     ),
   },
   {
-    label: 'Utvärdering',
-    href: '/evaluation',
+    label: "Analys",
+    href: "/evaluation",
     icon: (
-      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" className="w-6 h-6">
-        <path d="M18.375 2.25c-1.035 0-1.875.84-1.875 1.875v15.75c0 1.035.84 1.875 1.875 1.875h.75c1.035 0 1.875-.84 1.875-1.875V4.125c0-1.036-.84-1.875-1.875-1.875h-.75zM9.75 8.625c0-1.036.84-1.875 1.875-1.875h.75c1.036 0 1.875.84 1.875 1.875v11.25c0 1.035-.84 1.875-1.875 1.875h-.75a1.875 1.875 0 01-1.875-1.875V8.625zM3 13.125c0-1.036.84-1.875 1.875-1.875h.75c1.036 0 1.875.84 1.875 1.875v6.75c0 1.035-.84 1.875-1.875 1.875h-.75A1.875 1.875 0 013 19.875v-6.75z" />
+      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M4 20V6M4 20h16M8 16V10M12 16V8M16 16V12M20 20V4" />
       </svg>
     ),
   },
   {
-    label: 'System',
-    href: '/system',
+    label: "System",
+    href: "/system",
     icon: (
-      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" className="w-6 h-6">
-        <path fillRule="evenodd" d="M12 2.25c-5.385 0-9.75 4.365-9.75 9.75s4.365 9.75 9.75 9.75 9.75-4.365 9.75-9.75S17.385 2.25 12 2.25zm0 8.625a1.125 1.125 0 100 2.25 1.125 1.125 0 000-2.25zM15.375 12a1.125 1.125 0 112.25 0 1.125 1.125 0 01-2.25 0zM7.5 10.875a1.125 1.125 0 100 2.25 1.125 1.125 0 000-2.25z" clipRule="evenodd" />
+      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
+        <circle cx="12" cy="12" r="3" />
+        <path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4" />
       </svg>
     ),
   },
   {
-    label: 'Manual',
-    href: '/manual',
+    label: "Profil",
+    href: "/sallskap",
     icon: (
-      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" className="w-6 h-6">
-        <path d="M11.25 4.533A9.707 9.707 0 006 3a9.735 9.735 0 00-3.25.555.75.75 0 00-.5.707v14.25a.75.75 0 001 .707A8.237 8.237 0 016 18.75c1.995 0 3.823.707 5.25 1.886V4.533zM12.75 20.636A8.214 8.214 0 0118 18.75c.966 0 1.89.166 2.75.47a.75.75 0 001-.708V4.262a.75.75 0 00-.5-.707A9.735 9.735 0 0018 3a9.707 9.707 0 00-5.25 1.533v16.103z" />
+      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
+        <circle cx="12" cy="8" r="4" />
+        <path d="M4 21c0-4 4-6 8-6s8 2 8 6" />
       </svg>
     ),
   },
@@ -47,22 +48,37 @@ export function BottomNav({ isAdmin = false }: { isAdmin?: boolean }) {
   const pathname = usePathname();
 
   return (
-    <nav className="fixed bottom-0 left-0 right-0 z-50 bg-white/90 dark:bg-gray-950/90 backdrop-blur-sm border-t border-gray-200 dark:border-gray-800 md:hidden">
-      <div className="flex items-stretch h-16">
+    <nav
+      className="fixed bottom-0 left-0 right-0 z-50 md:hidden"
+      style={{
+        background: "color-mix(in oklab, var(--tn-bg-raised) 92%, transparent)",
+        backdropFilter: "blur(24px)",
+        WebkitBackdropFilter: "blur(24px)",
+        borderTop: "1px solid var(--tn-border)",
+      }}
+    >
+      <div
+        className="grid"
+        style={{
+          gridTemplateColumns: `repeat(${isAdmin ? 5 : 4}, 1fr)`,
+          padding: "8px 8px 22px",
+        }}
+      >
         {tabs.map((tab) => {
           const isActive =
-            tab.href === "/"
-              ? pathname === "/"
-              : pathname.startsWith(tab.href);
+            tab.href === "/" ? pathname === "/" : pathname.startsWith(tab.href);
           return (
             <Link
               key={tab.href}
               href={tab.href}
-              className={`flex-1 flex flex-col items-center justify-center gap-0.5 text-xs font-medium transition-colors ${
-                isActive
-                  ? "text-indigo-600 dark:text-indigo-500"
-                  : "text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white"
-              }`}
+              className="flex flex-col items-center gap-1 py-1.5 px-1 rounded-lg transition-colors"
+              style={{
+                color: isActive ? "var(--tn-accent)" : "var(--tn-text-faint)",
+                fontSize: "10px",
+                fontFamily: "var(--font-geist-mono), ui-monospace, monospace",
+                letterSpacing: "0.05em",
+                textTransform: "uppercase",
+              }}
             >
               {tab.icon}
               {tab.label}
@@ -72,18 +88,18 @@ export function BottomNav({ isAdmin = false }: { isAdmin?: boolean }) {
         {isAdmin && (
           <Link
             href="/admin"
-            className={`flex-1 flex flex-col items-center justify-center gap-0.5 text-xs font-medium transition-colors ${
-              pathname === "/admin" || pathname.startsWith("/admin/")
-                ? "text-indigo-600 dark:text-indigo-500"
-                : "text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white"
-            }`}
+            className="flex flex-col items-center gap-1 py-1.5 px-1 rounded-lg transition-colors"
+            style={{
+              color: pathname.startsWith("/admin") ? "var(--tn-accent)" : "var(--tn-text-faint)",
+              fontSize: "10px",
+              fontFamily: "var(--font-geist-mono), ui-monospace, monospace",
+              letterSpacing: "0.05em",
+              textTransform: "uppercase",
+            }}
           >
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" className="w-6 h-6">
-              <path
-                fillRule="evenodd"
-                d="M11.078 2.25c-.917 0-1.699.663-1.85 1.567L9.05 4.889c-.02.12-.115.26-.297.348a7.493 7.493 0 00-.986.57c-.166.115-.334.126-.45.083L6.3 5.508a1.875 1.875 0 00-2.282.819l-.922 1.597a1.875 1.875 0 00.432 2.385l.84.692c.095.078.17.229.154.43a7.598 7.598 0 000 1.139c.015.2-.059.352-.153.43l-.841.692a1.875 1.875 0 00-.432 2.385l.922 1.597a1.875 1.875 0 002.282.818l1.019-.382c.115-.043.283-.031.45.082.312.214.641.405.985.57.182.088.277.228.297.35l.178 1.071c.151.904.933 1.567 1.85 1.567h1.844c.916 0 1.699-.663 1.85-1.567l.178-1.072c.02-.12.114-.26.297-.349.344-.165.673-.356.985-.57.167-.114.335-.125.45-.082l1.02.382a1.875 1.875 0 002.28-.819l.923-1.597a1.875 1.875 0 00-.432-2.385l-.84-.692c-.095-.078-.17-.229-.154-.43a7.614 7.614 0 000-1.139c-.016-.2.059-.352.153-.43l.84-.692c.708-.582.891-1.59.433-2.385l-.922-1.597a1.875 1.875 0 00-2.282-.818l-1.02.382c-.114.043-.282.031-.449-.083a7.49 7.49 0 00-.985-.57c-.183-.087-.277-.227-.297-.348l-.179-1.072a1.875 1.875 0 00-1.85-1.567h-1.843zM12 15.75a3.75 3.75 0 100-7.5 3.75 3.75 0 000 7.5z"
-                clipRule="evenodd"
-              />
+            <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
+              <circle cx="12" cy="12" r="3" />
+              <path d="M19.07 4.93a10 10 0 0 1 0 14.14M4.93 4.93a10 10 0 0 0 0 14.14" />
             </svg>
             Admin
           </Link>

--- a/components/BulkResultsButton.tsx
+++ b/components/BulkResultsButton.tsx
@@ -34,86 +34,57 @@ export function BulkResultsButton({ pendingGames }: Props) {
 
   async function handleFetchAll() {
     if (pendingGames.length === 0 || fetching) return;
-
     setFetching(true);
-    // Initialise all rounds as "pending" so the user sees the list immediately
     setStatuses(
-      pendingGames.map((g) => ({
-        game_id: g.game_id,
-        date: g.date,
-        game_type: g.game_type,
-        track: g.track,
-        status: "pending",
-      }))
+      pendingGames.map((g) => ({ game_id: g.game_id, date: g.date, game_type: g.game_type, track: g.track, status: "pending" }))
     );
 
     for (let i = 0; i < pendingGames.length; i++) {
       const game = pendingGames[i];
-
-      // 500 ms delay between requests (skip before the very first one)
       if (i > 0) await delay(500);
-
       try {
-        const res = await fetch(
-          `/api/games/${encodeURIComponent(game.game_id)}/results`,
-          { method: "POST" }
-        );
+        const res = await fetch(`/api/games/${encodeURIComponent(game.game_id)}/results`, { method: "POST" });
         const data = await res.json().catch(() => ({}));
-
         let nextStatus: FetchStatus;
         let message: string | undefined;
-
-        if (res.status === 422) {
-          nextStatus = "not_ready";
-          message = "Inte redo";
-        } else if (res.ok) {
-          nextStatus = "success";
-          message = `${data.updated ?? "?"} hästar i ${data.races ?? "?"} avd`;
-        } else {
-          nextStatus = "error";
-          message = data.error ?? `HTTP ${res.status}`;
-        }
-
-        setStatuses((prev) =>
-          prev.map((s) =>
-            s.game_id === game.game_id
-              ? { ...s, status: nextStatus, message }
-              : s
-          )
-        );
+        if (res.status === 422) { nextStatus = "not_ready"; message = "Inte redo"; }
+        else if (res.ok) { nextStatus = "success"; message = `${data.updated ?? "?"} hästar i ${data.races ?? "?"} avd`; }
+        else { nextStatus = "error"; message = data.error ?? `HTTP ${res.status}`; }
+        setStatuses((prev) => prev.map((s) => s.game_id === game.game_id ? { ...s, status: nextStatus, message } : s));
       } catch (err) {
-        setStatuses((prev) =>
-          prev.map((s) =>
-            s.game_id === game.game_id
-              ? {
-                  ...s,
-                  status: "error",
-                  message: err instanceof Error ? err.message : "Nätverksfel",
-                }
-              : s
-          )
-        );
+        setStatuses((prev) => prev.map((s) =>
+          s.game_id === game.game_id ? { ...s, status: "error", message: err instanceof Error ? err.message : "Nätverksfel" } : s
+        ));
       }
     }
-
     setFetching(false);
     router.refresh();
   }
 
   const pendingCount = pendingGames.length;
 
+  const statusStyle = (status: FetchStatus): React.CSSProperties => {
+    if (status === "success") return { background: "rgba(52,211,153,0.15)", color: "var(--tn-value-high)" };
+    if (status === "not_ready") return { background: "rgba(251,191,36,0.15)", color: "var(--tn-warn)" };
+    if (status === "error") return { background: "rgba(248,113,113,0.15)", color: "var(--tn-value-low)" };
+    return { background: "var(--tn-bg-chip)", color: "var(--tn-text-faint)" };
+  };
+
   return (
     <div className="flex flex-col gap-3">
       <button
         onClick={handleFetchAll}
         disabled={pendingCount === 0 || fetching}
-        className="self-start px-4 py-2 rounded-lg border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 text-sm font-semibold hover:border-indigo-500 dark:hover:border-indigo-400 hover:text-indigo-600 dark:hover:text-indigo-400 disabled:opacity-40 transition"
+        className="self-start text-sm font-medium rounded-lg transition disabled:opacity-40"
+        style={{
+          padding: "8px 16px",
+          background: "var(--tn-bg-chip)",
+          border: "1px solid var(--tn-border)",
+          color: "var(--tn-text-dim)",
+          cursor: "pointer",
+        }}
       >
-        {fetching
-          ? "Hämtar..."
-          : pendingCount === 0
-          ? "Alla resultat hämtade"
-          : `Hämta alla resultat (${pendingCount})`}
+        {fetching ? "Hämtar..." : pendingCount === 0 ? "Alla resultat hämtade" : `Hämta alla resultat (${pendingCount})`}
       </button>
 
       {statuses.length > 0 && (
@@ -121,21 +92,13 @@ export function BulkResultsButton({ pendingGames }: Props) {
           {statuses.map((s) => (
             <div
               key={s.game_id}
-              className="flex items-center justify-between px-4 py-2 rounded-lg bg-gray-100 dark:bg-gray-800 text-sm"
+              className="flex items-center justify-between px-4 py-2 rounded-lg text-sm"
+              style={{ background: "var(--tn-bg-card)" }}
             >
-              <span className="text-gray-700 dark:text-gray-300">
-                {s.date} · {s.game_type} · {s.track}
-              </span>
+              <span style={{ color: "var(--tn-text)" }}>{s.date} · {s.game_type} · {s.track}</span>
               <span
-                className={`flex items-center gap-1.5 text-xs font-semibold px-2 py-0.5 rounded-full ${
-                  s.status === "success"
-                    ? "bg-green-100 dark:bg-green-900/40 text-green-700 dark:text-green-400"
-                    : s.status === "not_ready"
-                    ? "bg-yellow-100 dark:bg-yellow-900/40 text-yellow-700 dark:text-yellow-400"
-                    : s.status === "error"
-                    ? "bg-red-100 dark:bg-red-900/40 text-red-700 dark:text-red-400"
-                    : "bg-gray-200 dark:bg-gray-700 text-gray-500 dark:text-gray-400"
-                }`}
+                className="tn-mono flex items-center gap-1.5 text-xs font-semibold px-2 py-0.5 rounded-full"
+                style={statusStyle(s.status)}
               >
                 {s.status === "pending" && "Väntar..."}
                 {s.status === "success" && `Klar — ${s.message}`}

--- a/components/CollapsibleControls.tsx
+++ b/components/CollapsibleControls.tsx
@@ -7,34 +7,30 @@ export function CollapsibleControls({ children }: { children: React.ReactNode })
 
   return (
     <div className="mt-2">
-      {/* Toggle-knapp – bara synlig på mobil */}
       <button
         onClick={() => setOpen(!open)}
-        className="md:hidden w-full flex items-center justify-between py-1 text-xs text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition-colors"
+        className="md:hidden w-full flex items-center justify-between py-1 text-xs transition-colors"
+        style={{ color: "var(--tn-text-faint)", background: "none", border: "none", cursor: "pointer" }}
         aria-expanded={open}
         aria-label={open ? "Dölj spelkontroller" : "Visa spelkontroller"}
       >
-        <span className="font-medium">{open ? "Dölj kontroller" : "Spelkontroller"}</span>
+        <span className="tn-mono" style={{ letterSpacing: "0.08em", textTransform: "uppercase", fontSize: 10 }}>
+          {open ? "Dölj kontroller" : "Spelkontroller"}
+        </span>
         <svg
-          xmlns="http://www.w3.org/2000/svg"
           viewBox="0 0 24 24"
-          fill="currentColor"
-          className={`w-4 h-4 transition-transform duration-200 ${open ? "rotate-180" : ""}`}
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          className={`w-3.5 h-3.5 transition-transform duration-200 ${open ? "rotate-180" : ""}`}
         >
-          <path
-            fillRule="evenodd"
-            d="M12.53 16.28a.75.75 0 01-1.06 0l-7.5-7.5a.75.75 0 011.06-1.06L12 14.69l6.97-6.97a.75.75 0 111.06 1.06l-7.5 7.5z"
-            clipRule="evenodd"
-          />
+          <path d="M6 9l6 6 6-6" />
         </svg>
       </button>
 
-      {/* Kontroller – alltid synliga på desktop, expanderbara på mobil */}
-      <div
-        className={`${
-          open ? "flex" : "hidden"
-        } md:flex items-center gap-2 flex-wrap pt-1`}
-      >
+      <div className={`${open ? "flex" : "hidden"} md:flex items-center gap-2 flex-wrap pt-1`}>
         {children}
       </div>
     </div>

--- a/components/EvaluationPanel.tsx
+++ b/components/EvaluationPanel.tsx
@@ -42,15 +42,18 @@ export interface GameSummary {
 interface Props {
   overall: Overall;
   games: GameEval[];
-  allGames: GameSummary[]; // alla laddade omgångar, inkl. de utan resultat
+  allGames: GameSummary[];
 }
 
 function StatCard({ label, value, sub }: { label: string; value: string; sub?: string }) {
   return (
-    <div className="bg-gray-100 dark:bg-gray-800 rounded-xl p-5 text-center">
-      <p className="text-gray-500 dark:text-gray-400 text-sm mb-1">{label}</p>
-      <p className="text-3xl font-bold text-gray-900 dark:text-white">{value}</p>
-      {sub && <p className="text-xs text-gray-400 dark:text-gray-500 mt-1">{sub}</p>}
+    <div
+      className="rounded-xl p-5 text-center"
+      style={{ background: "var(--tn-bg-card)", border: "1px solid var(--tn-border)" }}
+    >
+      <p className="tn-eyebrow mb-1">{label}</p>
+      <p className="text-3xl font-bold" style={{ color: "var(--tn-text)" }}>{value}</p>
+      {sub && <p className="text-xs mt-1" style={{ color: "var(--tn-text-faint)" }}>{sub}</p>}
     </div>
   );
 }
@@ -75,32 +78,34 @@ export function EvaluationPanel({ overall, games, allGames }: Props) {
 
   if (allGames.length === 0) {
     return (
-      <div className="text-center py-20 text-gray-400 dark:text-gray-500">
+      <div className="text-center py-20" style={{ color: "var(--tn-text-faint)" }}>
         <p className="text-lg mb-2">Inga laddade omgångar ännu.</p>
-        <p className="text-sm">
-          Hämta en omgång via startsidan för att börja analysera.
-        </p>
+        <p className="text-sm">Hämta en omgång via startsidan för att börja analysera.</p>
       </div>
     );
   }
 
   return (
     <div className="flex flex-col gap-8">
-      {/* Bulk fetch knapp */}
       <BulkResultsButton pendingGames={pendingGames} />
 
-      {/* Alla omgångar — kollapsibel status per omgång */}
       <div className="flex flex-col gap-2">
         <button
           onClick={() => setShowAllGames((v) => !v)}
-          className="flex items-center gap-2 text-left group"
+          className="flex items-center gap-2 text-left"
+          style={{ background: "none", border: "none", cursor: "pointer" }}
         >
-          <h2 className="text-sm font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide group-hover:text-gray-700 dark:group-hover:text-gray-200 transition">
+          <h2 className="tn-eyebrow">
             Laddade omgångar ({localGames.length})
           </h2>
-          <span className="text-gray-400 dark:text-gray-500 text-xs">
-            {showAllGames ? "▼" : "▶"}
-          </span>
+          <svg
+            width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+            strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"
+            className={`transition-transform duration-200 ${showAllGames ? "rotate-180" : ""}`}
+            style={{ color: "var(--tn-text-faint)" }}
+          >
+            <path d="M6 9l6 6 6-6" />
+          </svg>
         </button>
 
         {showAllGames && (
@@ -108,25 +113,33 @@ export function EvaluationPanel({ overall, games, allGames }: Props) {
             {localGames.map((g) => (
               <div
                 key={g.game_id}
-                className="flex items-center justify-between px-4 py-2 rounded-lg bg-gray-100 dark:bg-gray-800"
+                className="flex items-center justify-between px-4 py-2 rounded-lg"
+                style={{ background: "var(--tn-bg-card)" }}
               >
-                <span className="text-sm text-gray-800 dark:text-gray-200">
+                <span className="text-sm" style={{ color: "var(--tn-text)" }}>
                   {g.date} · {g.game_type} · {g.track}
                 </span>
                 <div className="flex items-center gap-2">
                   {g.has_results ? (
-                    <span className="text-xs font-semibold px-2 py-0.5 rounded-full bg-green-100 dark:bg-green-900/40 text-green-700 dark:text-green-400">
+                    <span
+                      className="tn-mono text-xs font-bold px-2 py-0.5 rounded-full"
+                      style={{ background: "rgba(52,211,153,0.15)", color: "var(--tn-value-high)" }}
+                    >
                       Klar
                     </span>
                   ) : (
                     <>
-                      <span className="text-xs font-semibold px-2 py-0.5 rounded-full bg-yellow-100 dark:bg-yellow-900/40 text-yellow-700 dark:text-yellow-400">
+                      <span
+                        className="tn-mono text-xs font-bold px-2 py-0.5 rounded-full"
+                        style={{ background: "rgba(251,191,36,0.15)", color: "var(--tn-warn)" }}
+                      >
                         Saknar resultat
                       </span>
                       <button
                         onClick={() => handleDeleteGame(g.game_id)}
                         title="Ta bort omgång"
-                        className="text-gray-400 hover:text-red-500 dark:hover:text-red-400 transition text-sm leading-none px-1"
+                        className="text-sm leading-none px-1 transition"
+                        style={{ color: "var(--tn-text-faint)", background: "none", border: "none", cursor: "pointer" }}
                       >
                         ×
                       </button>
@@ -141,13 +154,11 @@ export function EvaluationPanel({ overall, games, allGames }: Props) {
 
       {overall.races_evaluated > 0 && (
         <>
-          {/* Förklaring */}
-          <p className="text-sm text-gray-500 dark:text-gray-400">
+          <p className="text-sm" style={{ color: "var(--tn-text-faint)" }}>
             Utvärderar hur ofta hästarna med högst Composite Score (CS) vinner loppet.
             Topp-3 = de tre hästar med högst CS i varje avdelning.
           </p>
 
-          {/* Totalstatistik */}
           <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
             <StatCard
               label="Topprankad (CS) vinner"
@@ -166,94 +177,97 @@ export function EvaluationPanel({ overall, games, allGames }: Props) {
             />
           </div>
 
-          {/* Per spel */}
           <div className="flex flex-col gap-3">
             {games.map((game) => {
               const isOpen = openGame === game.game_id;
+              const winRate = game.top_pick_win_rate;
+              const rateColor = winRate >= 40
+                ? "var(--tn-value-high)"
+                : winRate >= 20
+                ? "var(--tn-warn)"
+                : "var(--tn-value-low)";
+              const rateBg = winRate >= 40
+                ? "rgba(52,211,153,0.15)"
+                : winRate >= 20
+                ? "rgba(251,191,36,0.15)"
+                : "rgba(248,113,113,0.15)";
+
               return (
                 <div
                   key={game.game_id}
-                  className="bg-gray-100 dark:bg-gray-800 rounded-xl overflow-hidden"
+                  className="rounded-xl overflow-hidden"
+                  style={{ background: "var(--tn-bg-card)", border: "1px solid var(--tn-border)" }}
                 >
                   <button
                     onClick={() => setOpenGame(isOpen ? null : game.game_id)}
-                    className="w-full flex items-center justify-between px-5 py-4 text-left hover:bg-gray-200 dark:hover:bg-gray-700 transition"
+                    className="w-full flex items-center justify-between px-5 py-4 text-left transition"
+                    style={{ background: "none", border: "none", cursor: "pointer" }}
+                    onMouseEnter={(e) => { e.currentTarget.style.background = "var(--tn-bg-card-hover)"; }}
+                    onMouseLeave={(e) => { e.currentTarget.style.background = "none"; }}
                   >
                     <div className="flex items-center gap-3">
-                      <span className="text-gray-900 dark:text-white font-semibold">
+                      <span className="font-semibold" style={{ color: "var(--tn-text)" }}>
                         {game.date} · {game.game_type} · {game.track}
                       </span>
-                      <span className="text-xs text-gray-500 dark:text-gray-400">
+                      <span className="text-xs" style={{ color: "var(--tn-text-faint)" }}>
                         {game.races_evaluated} avd
                       </span>
                     </div>
                     <div className="flex items-center gap-3 shrink-0">
                       <span
-                        className={`text-xs font-bold px-2 py-1 rounded-full ${
-                          game.top_pick_win_rate >= 40
-                            ? "bg-green-100 dark:bg-green-900/40 text-green-700 dark:text-green-400"
-                            : game.top_pick_win_rate >= 20
-                            ? "bg-yellow-100 dark:bg-yellow-900/40 text-yellow-700 dark:text-yellow-400"
-                            : "bg-red-100 dark:bg-red-900/40 text-red-700 dark:text-red-400"
-                        }`}
+                        className="tn-mono text-xs font-bold px-2 py-1 rounded-full"
+                        style={{ background: rateBg, color: rateColor }}
                       >
-                        Topp {game.top_pick_win_rate.toFixed(0)}%
+                        Topp {winRate.toFixed(0)}%
                       </span>
-                      <span className="text-gray-400 dark:text-gray-500 text-sm">
-                        {isOpen ? "▲" : "▼"}
-                      </span>
+                      <svg
+                        width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                        strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"
+                        className={`transition-transform duration-200 ${isOpen ? "rotate-180" : ""}`}
+                        style={{ color: "var(--tn-text-faint)" }}
+                      >
+                        <path d="M6 9l6 6 6-6" />
+                      </svg>
                     </div>
                   </button>
 
                   {isOpen && (
-                    <div className="border-t border-gray-200 dark:border-gray-700 overflow-x-auto">
+                    <div className="overflow-x-auto" style={{ borderTop: "1px solid var(--tn-border)" }}>
                       <table className="w-full text-sm">
                         <thead>
-                          <tr className="text-gray-400 dark:text-gray-500 text-xs">
-                            <th className="text-left px-5 py-2 font-normal">Avd</th>
-                            <th className="text-left px-3 py-2 font-normal">Vinnare</th>
-                            <th className="text-left px-3 py-2 font-normal">Toppval (CS)</th>
-                            <th className="text-center px-3 py-2 font-normal">Toppval vann?</th>
-                            <th className="text-center px-3 py-2 font-normal">Vinnare i topp 3?</th>
+                          <tr>
+                            <th className="text-left px-5 py-2 font-normal tn-eyebrow">Avd</th>
+                            <th className="text-left px-3 py-2 font-normal tn-eyebrow">Vinnare</th>
+                            <th className="text-left px-3 py-2 font-normal tn-eyebrow">Toppval (CS)</th>
+                            <th className="text-center px-3 py-2 font-normal tn-eyebrow">Toppval vann?</th>
+                            <th className="text-center px-3 py-2 font-normal tn-eyebrow">Vinnare i topp 3?</th>
                           </tr>
                         </thead>
                         <tbody>
-                          {game.races.map((race) => (
-                            <tr
-                              key={race.race_number}
-                              className={`border-t border-gray-200 dark:border-gray-700 ${
-                                race.top_pick_won
-                                  ? "bg-green-50 dark:bg-green-900/20"
-                                  : race.top_3_covered_winner
-                                  ? "bg-yellow-50 dark:bg-yellow-900/20"
-                                  : "bg-red-50 dark:bg-red-900/10"
-                              }`}
-                            >
-                              <td className="px-5 py-2 text-gray-500 dark:text-gray-400">
-                                {race.race_number}
-                              </td>
-                              <td className="px-3 py-2 font-medium text-gray-900 dark:text-white">
-                                {race.winner_name || "–"}
-                              </td>
-                              <td className="px-3 py-2 text-gray-700 dark:text-gray-300">
-                                {race.top_pick_name || "–"}
-                              </td>
-                              <td className="px-3 py-2 text-center">
-                                {race.top_pick_won ? (
-                                  <span className="text-green-600 dark:text-green-400 font-bold">Ja</span>
-                                ) : (
-                                  <span className="text-red-500 dark:text-red-400">Nej</span>
-                                )}
-                              </td>
-                              <td className="px-3 py-2 text-center">
-                                {race.top_3_covered_winner ? (
-                                  <span className="text-green-600 dark:text-green-400 font-bold">Ja</span>
-                                ) : (
-                                  <span className="text-red-500 dark:text-red-400">Nej</span>
-                                )}
-                              </td>
-                            </tr>
-                          ))}
+                          {game.races.map((race) => {
+                            const rowBg = race.top_pick_won
+                              ? "rgba(52,211,153,0.08)"
+                              : race.top_3_covered_winner
+                              ? "rgba(251,191,36,0.08)"
+                              : "rgba(248,113,113,0.06)";
+                            return (
+                              <tr key={race.race_number} style={{ borderTop: "1px solid var(--tn-border)", background: rowBg }}>
+                                <td className="px-5 py-2" style={{ color: "var(--tn-text-faint)" }}>{race.race_number}</td>
+                                <td className="px-3 py-2 font-medium" style={{ color: "var(--tn-text)" }}>{race.winner_name || "–"}</td>
+                                <td className="px-3 py-2" style={{ color: "var(--tn-text-dim)" }}>{race.top_pick_name || "–"}</td>
+                                <td className="px-3 py-2 text-center">
+                                  {race.top_pick_won
+                                    ? <span className="font-bold" style={{ color: "var(--tn-value-high)" }}>Ja</span>
+                                    : <span style={{ color: "var(--tn-value-low)" }}>Nej</span>}
+                                </td>
+                                <td className="px-3 py-2 text-center">
+                                  {race.top_3_covered_winner
+                                    ? <span className="font-bold" style={{ color: "var(--tn-value-high)" }}>Ja</span>
+                                    : <span style={{ color: "var(--tn-value-low)" }}>Nej</span>}
+                                </td>
+                              </tr>
+                            );
+                          })}
                         </tbody>
                       </table>
                     </div>

--- a/components/FetchButton.tsx
+++ b/components/FetchButton.tsx
@@ -6,7 +6,7 @@ import type { AvailableGame } from "@/lib/atg";
 
 function todayLocal(): string {
   const d = new Date();
-  return d.toLocaleDateString("sv-SE"); // "YYYY-MM-DD"
+  return d.toLocaleDateString("sv-SE");
 }
 
 function minDate(): string {
@@ -70,26 +70,34 @@ export function FetchButton() {
 
   return (
     <div className="flex items-center gap-2 flex-wrap justify-end">
-      {message && <span className="text-sm text-gray-500 dark:text-gray-400">{message}</span>}
+      {message && (
+        <span className="text-sm" style={{ color: "var(--tn-text-faint)" }}>{message}</span>
+      )}
       <input
         type="date"
         value={date}
         min={minDate()}
         max={maxDate()}
         onChange={(e) => setDate(e.target.value)}
-        className="rounded-lg bg-gray-100 dark:bg-gray-800 border border-gray-300 dark:border-gray-700 text-gray-900 dark:text-white text-sm px-3 py-2 focus:outline-none focus:border-indigo-500"
+        className="rounded-lg text-sm px-3 py-2 focus:outline-none"
+        style={{
+          background: "var(--tn-bg-chip)",
+          border: "1px solid var(--tn-border)",
+          color: "var(--tn-text)",
+        }}
       />
       {loadingGames ? (
-        <span className="text-sm text-gray-400 dark:text-gray-500">Laddar...</span>
+        <span className="text-sm" style={{ color: "var(--tn-text-faint)" }}>Laddar...</span>
       ) : availableGames.length === 0 ? (
-        <span className="text-sm text-gray-400 dark:text-gray-500">Inga spel</span>
+        <span className="text-sm" style={{ color: "var(--tn-text-faint)" }}>Inga spel</span>
       ) : (
         availableGames.map((game) => (
           <button
             key={game.id}
             onClick={() => handleFetch(game)}
             disabled={loading !== null}
-            className="px-4 py-2 rounded-lg bg-indigo-600 hover:bg-indigo-500 text-white text-sm font-semibold disabled:opacity-50 transition"
+            className="px-4 py-2 rounded-lg text-sm font-semibold disabled:opacity-50 transition"
+            style={{ background: "var(--tn-accent)", color: "#fff", border: "none", cursor: "pointer" }}
           >
             {loading === game.id ? "Hämtar..." : `Hämta ${game.label}`}
           </button>

--- a/components/GamePickerBar.tsx
+++ b/components/GamePickerBar.tsx
@@ -12,33 +12,14 @@ interface SavedGame {
 }
 
 interface GamePickerBarProps {
-  /** Redan sparade omgångar i databasen */
   savedGames: SavedGame[];
-  /** Aktuellt valt spel-ID */
   selectedId: string | null;
 }
 
-function todayLocal(): string {
-  return new Date().toLocaleDateString("sv-SE");
-}
-
-function tomorrowLocal(): string {
-  const d = new Date();
-  d.setDate(d.getDate() + 1);
-  return d.toLocaleDateString("sv-SE");
-}
-
-function minDate(): string {
-  const d = new Date();
-  d.setDate(d.getDate() - 14);
-  return d.toLocaleDateString("sv-SE");
-}
-
-function maxDate(): string {
-  const d = new Date();
-  d.setDate(d.getDate() + 14);
-  return d.toLocaleDateString("sv-SE");
-}
+function todayLocal(): string { return new Date().toLocaleDateString("sv-SE"); }
+function tomorrowLocal(): string { const d = new Date(); d.setDate(d.getDate() + 1); return d.toLocaleDateString("sv-SE"); }
+function minDate(): string { const d = new Date(); d.setDate(d.getDate() - 14); return d.toLocaleDateString("sv-SE"); }
+function maxDate(): string { const d = new Date(); d.setDate(d.getDate() + 14); return d.toLocaleDateString("sv-SE"); }
 
 export function GamePickerBar({ savedGames, selectedId }: GamePickerBarProps) {
   const router = useRouter();
@@ -51,7 +32,6 @@ export function GamePickerBar({ savedGames, selectedId }: GamePickerBarProps) {
 
   const selectedGame = savedGames.find((g) => g.id === selectedId) ?? null;
 
-  // Hämta tillgängliga spel när datumet ändras eller panelen öppnas
   useEffect(() => {
     if (!open) return;
     let cancelled = false;
@@ -59,194 +39,147 @@ export function GamePickerBar({ savedGames, selectedId }: GamePickerBarProps) {
     setAvailableGames([]);
     fetch(`/api/games/available?date=${date}`)
       .then((r) => r.json())
-      .then((data) => {
-        if (!cancelled) setAvailableGames(data.games ?? []);
-      })
-      .catch(() => {
-        if (!cancelled) setAvailableGames([]);
-      })
-      .finally(() => {
-        if (!cancelled) setLoadingGames(false);
-      });
-    return () => {
-      cancelled = true;
-    };
+      .then((data) => { if (!cancelled) setAvailableGames(data.games ?? []); })
+      .catch(() => { if (!cancelled) setAvailableGames([]); })
+      .finally(() => { if (!cancelled) setLoadingGames(false); });
+    return () => { cancelled = true; };
   }, [date, open]);
 
-  const handleFetch = useCallback(
-    async (game: AvailableGame) => {
-      setFetchingId(game.id);
-      setMessage(null);
-      try {
-        const res = await fetch("/api/games/fetch", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ gameType: game.type, gameId: game.id }),
-        });
-        const data = await res.json();
-        if (!res.ok) throw new Error(data.error ?? "Fel");
-        setOpen(false);
-        router.push(`/?game=${encodeURIComponent(data.game_id)}`);
-        router.refresh();
-      } catch (err) {
-        setMessage(err instanceof Error ? err.message : "Okänt fel");
-      } finally {
-        setFetchingId(null);
-      }
-    },
-    [router]
-  );
+  const handleFetch = useCallback(async (game: AvailableGame) => {
+    setFetchingId(game.id);
+    setMessage(null);
+    try {
+      const res = await fetch("/api/games/fetch", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ gameType: game.type, gameId: game.id }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error ?? "Fel");
+      setOpen(false);
+      router.push(`/?game=${encodeURIComponent(data.game_id)}`);
+      router.refresh();
+    } catch (err) {
+      setMessage(err instanceof Error ? err.message : "Okänt fel");
+    } finally {
+      setFetchingId(null);
+    }
+  }, [router]);
 
-  // Navigera mellan sparade omgångar
   const currentIndex = savedGames.findIndex((g) => g.id === selectedId);
   const prevGame = currentIndex > 0 ? savedGames[currentIndex - 1] : null;
-  const nextGame =
-    currentIndex < savedGames.length - 1 ? savedGames[currentIndex + 1] : null;
+  const nextGame = currentIndex < savedGames.length - 1 ? savedGames[currentIndex + 1] : null;
+
+  const iconBtn: React.CSSProperties = {
+    padding: 6,
+    borderRadius: 8,
+    background: "none",
+    border: "none",
+    color: "var(--tn-text-faint)",
+    cursor: "pointer",
+    display: "flex",
+    alignItems: "center",
+  };
 
   return (
     <div className="relative">
-      {/* Kompakt spelväljare-rad */}
       <div className="flex items-center gap-1">
-        {/* Föregående spel */}
+        {/* Prev */}
         <button
           onClick={() => prevGame && router.push(`/?game=${prevGame.id}`)}
           disabled={!prevGame}
           aria-label="Föregående spel"
-          className="p-1.5 rounded-lg text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 disabled:opacity-30 transition"
+          style={{ ...iconBtn, opacity: prevGame ? 1 : 0.3 }}
         >
-          <svg
-            className="w-4 h-4"
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M15 19l-7-7 7-7"
-            />
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M15 19l-7-7 7-7" />
           </svg>
         </button>
 
-        {/* Aktuellt spel / öppna väljaren */}
+        {/* Current game / open picker */}
         <button
           onClick={() => setOpen((v) => !v)}
-          className="flex items-center gap-2 px-3 py-1.5 rounded-lg bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 dark:hover:bg-gray-700 transition text-sm font-medium text-gray-900 dark:text-white min-w-0"
+          className="flex items-center gap-2 rounded-lg text-sm transition-colors"
+          style={{
+            background: "var(--tn-bg-chip)",
+            border: "1px solid var(--tn-border)",
+            color: "var(--tn-text)",
+            padding: "5px 10px",
+            fontFamily: "var(--font-geist-sans)",
+            minWidth: 0,
+          }}
         >
           {selectedGame ? (
             <>
-              <span className="font-bold text-indigo-600 dark:text-indigo-400 shrink-0">
-                {selectedGame.game_type}
-              </span>
-              <span className="text-gray-400 dark:text-gray-500 shrink-0">·</span>
-              <span className="truncate max-w-[120px]">
-                {selectedGame.track ?? selectedGame.date}
-              </span>
-              <span className="text-gray-400 dark:text-gray-500 text-xs shrink-0">
-                {selectedGame.date}
-              </span>
+              <span className="tn-mono font-bold text-xs shrink-0" style={{ color: "var(--tn-accent)" }}>{selectedGame.game_type}</span>
+              <span style={{ color: "var(--tn-border-strong)" }}>·</span>
+              <span className="truncate max-w-[120px]" style={{ color: "var(--tn-text)" }}>{selectedGame.track ?? selectedGame.date}</span>
+              <span className="tn-mono text-xs shrink-0" style={{ color: "var(--tn-text-faint)" }}>{selectedGame.date}</span>
             </>
           ) : (
-            <span className="text-gray-500 dark:text-gray-400">Välj spel</span>
+            <span style={{ color: "var(--tn-text-faint)" }}>Välj spel</span>
           )}
           <svg
-            className={`w-3.5 h-3.5 text-gray-400 shrink-0 transition-transform ${open ? "rotate-180" : ""}`}
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
+            width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"
+            className={`shrink-0 transition-transform ${open ? "rotate-180" : ""}`}
+            style={{ color: "var(--tn-text-faint)" }}
           >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M19 9l-7 7-7-7"
-            />
+            <path d="M6 9l6 6 6-6" />
           </svg>
         </button>
 
-        {/* Nästa spel */}
+        {/* Next */}
         <button
           onClick={() => nextGame && router.push(`/?game=${nextGame.id}`)}
           disabled={!nextGame}
           aria-label="Nästa spel"
-          className="p-1.5 rounded-lg text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 disabled:opacity-30 transition"
+          style={{ ...iconBtn, opacity: nextGame ? 1 : 0.3 }}
         >
-          <svg
-            className="w-4 h-4"
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M9 5l7 7-7 7"
-            />
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M9 5l7 7-7 7" />
           </svg>
         </button>
       </div>
 
-      {/* Dropdown-panel */}
+      {/* Dropdown */}
       {open && (
         <>
-          {/* Bakgrundsoverlay */}
+          <div className="fixed inset-0 z-40" onClick={() => setOpen(false)} />
           <div
-            className="fixed inset-0 z-40"
-            onClick={() => setOpen(false)}
-          />
-          <div className="absolute top-full left-0 mt-1 z-50 w-80 rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 shadow-xl p-4">
-            {/* Rubrik */}
-            <div className="text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-3">
-              Hämta nytt spel
-            </div>
+            className="absolute top-full left-0 mt-1 z-50 w-80 rounded-xl p-4 shadow-2xl"
+            style={{ background: "var(--tn-bg-raised)", border: "1px solid var(--tn-border)" }}
+          >
+            <p className="tn-eyebrow mb-3">Hämta nytt spel</p>
 
-            {/* Datumväljare */}
+            {/* Date picker */}
             <div className="flex items-center gap-2 mb-3">
               <button
-                onClick={() => {
-                  const d = new Date(date);
-                  d.setDate(d.getDate() - 1);
-                  const s = d.toLocaleDateString("sv-SE");
-                  if (s >= minDate()) setDate(s);
-                }}
-                className="p-1 rounded text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-800 transition"
-                aria-label="Föregående dag"
+                onClick={() => { const d = new Date(date); d.setDate(d.getDate() - 1); const s = d.toLocaleDateString("sv-SE"); if (s >= minDate()) setDate(s); }}
+                style={iconBtn} aria-label="Föregående dag"
               >
-                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
-                </svg>
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M15 19l-7-7 7-7" /></svg>
               </button>
               <input
-                type="date"
-                value={date}
-                min={minDate()}
-                max={maxDate()}
+                type="date" value={date} min={minDate()} max={maxDate()}
                 onChange={(e) => setDate(e.target.value)}
-                className="flex-1 rounded-lg bg-gray-100 dark:bg-gray-800 border border-gray-300 dark:border-gray-700 text-gray-900 dark:text-white text-sm px-2 py-1.5 focus:outline-none focus:border-indigo-500"
+                className="flex-1 rounded-lg text-sm outline-none"
+                style={{ background: "var(--tn-bg-chip)", border: "1px solid var(--tn-border)", color: "var(--tn-text)", padding: "6px 10px" }}
               />
               <button
-                onClick={() => {
-                  const d = new Date(date);
-                  d.setDate(d.getDate() + 1);
-                  const s = d.toLocaleDateString("sv-SE");
-                  if (s <= maxDate()) setDate(s);
-                }}
-                className="p-1 rounded text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-800 transition"
-                aria-label="Nästa dag"
+                onClick={() => { const d = new Date(date); d.setDate(d.getDate() + 1); const s = d.toLocaleDateString("sv-SE"); if (s <= maxDate()) setDate(s); }}
+                style={iconBtn} aria-label="Nästa dag"
               >
-                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-                </svg>
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M9 5l7 7-7 7" /></svg>
               </button>
             </div>
 
-            {/* Tillgängliga spel — klick = auto-hämta */}
+            {/* Available games */}
             {loadingGames ? (
-              <div className="text-sm text-gray-400 text-center py-3">Letar spel...</div>
+              <div className="text-sm text-center py-3" style={{ color: "var(--tn-text-faint)" }}>Letar spel...</div>
             ) : availableGames.length === 0 ? (
-              <div className="text-sm text-gray-400 text-center py-3">Inga spel {date === todayLocal() ? "idag" : date === tomorrowLocal() ? "imorgon" : date}</div>
+              <div className="text-sm text-center py-3" style={{ color: "var(--tn-text-faint)" }}>
+                Inga spel {date === todayLocal() ? "idag" : date === tomorrowLocal() ? "imorgon" : date}
+              </div>
             ) : (
               <div className="flex flex-col gap-2">
                 {availableGames.map((game) => (
@@ -254,14 +187,15 @@ export function GamePickerBar({ savedGames, selectedId }: GamePickerBarProps) {
                     key={game.id}
                     onClick={() => handleFetch(game)}
                     disabled={fetchingId !== null}
-                    className="w-full flex items-center justify-between px-3 py-2.5 rounded-lg bg-indigo-50 dark:bg-indigo-950 hover:bg-indigo-100 dark:hover:bg-indigo-900 border border-indigo-200 dark:border-indigo-800 text-indigo-700 dark:text-indigo-300 font-semibold text-sm disabled:opacity-50 transition"
+                    className="w-full flex items-center justify-between rounded-lg text-sm font-semibold transition-colors disabled:opacity-50"
+                    style={{ padding: "10px 12px", background: "var(--tn-accent-faint)", border: "1px solid transparent", color: "var(--tn-accent)" }}
                   >
                     <span>{game.label}</span>
                     {fetchingId === game.id ? (
-                      <span className="text-xs text-indigo-400">Hämtar...</span>
+                      <span className="tn-mono text-xs" style={{ color: "var(--tn-accent)", opacity: 0.6 }}>Hämtar...</span>
                     ) : (
-                      <svg className="w-4 h-4 opacity-60" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+                      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{ opacity: 0.6 }}>
+                        <path d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
                       </svg>
                     )}
                   </button>
@@ -270,34 +204,32 @@ export function GamePickerBar({ savedGames, selectedId }: GamePickerBarProps) {
             )}
 
             {message && (
-              <p className="text-xs text-red-500 dark:text-red-400 mt-2">{message}</p>
+              <p className="text-xs mt-2" style={{ color: "var(--tn-value-low)" }}>{message}</p>
             )}
 
-            {/* Separerare + sparade omgångar */}
+            {/* Saved games */}
             {savedGames.length > 0 && (
               <>
-                <div className="border-t border-gray-100 dark:border-gray-800 my-3" />
-                <div className="text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-2">
-                  Sparade omgångar
-                </div>
+                <div className="my-3" style={{ borderTop: "1px solid var(--tn-border)" }} />
+                <p className="tn-eyebrow mb-2">Sparade omgångar</p>
                 <div className="flex flex-col gap-1 max-h-48 overflow-y-auto">
                   {savedGames.map((g) => (
                     <button
                       key={g.id}
-                      onClick={() => {
-                        setOpen(false);
-                        router.push(`/?game=${encodeURIComponent(g.id)}`);
+                      onClick={() => { setOpen(false); router.push(`/?game=${encodeURIComponent(g.id)}`); }}
+                      className="w-full text-left rounded-lg text-sm transition-colors"
+                      style={{
+                        padding: "8px 10px",
+                        background: g.id === selectedId ? "var(--tn-accent-faint)" : "transparent",
+                        color: g.id === selectedId ? "var(--tn-accent)" : "var(--tn-text-dim)",
+                        border: "none",
+                        cursor: "pointer",
                       }}
-                      className={`w-full text-left px-3 py-2 rounded-lg text-sm transition ${
-                        g.id === selectedId
-                          ? "bg-indigo-100 dark:bg-indigo-900 text-indigo-700 dark:text-indigo-300 font-semibold"
-                          : "text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800"
-                      }`}
                     >
-                      <span className="font-semibold">{g.game_type}</span>
-                      <span className="text-gray-500 dark:text-gray-400 mx-1.5">·</span>
+                      <span className="font-semibold tn-mono text-xs" style={{ color: g.id === selectedId ? "var(--tn-accent)" : "var(--tn-text)" }}>{g.game_type}</span>
+                      <span className="mx-1.5" style={{ color: "var(--tn-text-faint)" }}>·</span>
                       {g.track && <span>{g.track} · </span>}
-                      <span className="text-gray-500 dark:text-gray-400">{g.date}</span>
+                      <span style={{ color: "var(--tn-text-faint)" }}>{g.date}</span>
                     </button>
                   ))}
                 </div>

--- a/components/GameSelector.tsx
+++ b/components/GameSelector.tsx
@@ -23,7 +23,12 @@ export function GameSelector({ games, selectedId }: GameSelectorProps) {
     <select
       value={selectedId ?? ""}
       onChange={(e) => router.push(`/?game=${encodeURIComponent(e.target.value)}`)}
-      className="rounded-lg bg-gray-100 dark:bg-gray-800 border border-gray-300 dark:border-gray-700 text-gray-900 dark:text-white text-sm px-3 py-2 focus:outline-none focus:border-blue-500"
+      className="rounded-lg text-sm px-3 py-2 focus:outline-none"
+      style={{
+        background: "var(--tn-bg-chip)",
+        border: "1px solid var(--tn-border)",
+        color: "var(--tn-text)",
+      }}
     >
       {games.map((g) => (
         <option key={g.id} value={g.id}>

--- a/components/HorseCard.tsx
+++ b/components/HorseCard.tsx
@@ -31,31 +31,26 @@ interface Starter {
   odds: number | null;
   p_odds: number | null;
   bet_distribution: number | null;
-  // Skoinfo
   shoes_reported: boolean | null;
   shoes_front: boolean | null;
   shoes_back: boolean | null;
   shoes_front_changed: boolean | null;
   shoes_back_changed: boolean | null;
   sulky_type: string | null;
-  // Häst
   horse_age: number | null;
   horse_sex: string | null;
   horse_color: string | null;
   pedigree_father: string | null;
   home_track: string | null;
-  // Karriärstatistik
   starts_total: number | null;
   wins_total: number | null;
   places_2nd: number | null;
   places_3rd: number | null;
   earnings_total: number | null;
-  // Innevarande år
   starts_current_year: number | null;
   wins_current_year: number | null;
   places_2nd_current_year: number | null;
   places_3rd_current_year: number | null;
-  // Föregående år
   starts_prev_year: number | null;
   wins_prev_year: number | null;
   places_2nd_prev_year: number | null;
@@ -85,25 +80,42 @@ const DIST_LABEL: Record<string, string> = {
 const CS_EXPLANATION =
   "CS – Composite Score (0–100): viktat index baserat på form (30%), vinstprocent (20%), odds (15%), tid (15%), konsistens (10%), distans (5%) och spårfaktor (5%).";
 
-function ScoreBadge({ score }: { score: number | null }) {
+/* ── Form ring ───────────────────────────────────────────────── */
+function FormRing({ score }: { score: number | null }) {
   const [open, setOpen] = useState(false);
   if (score == null) return null;
-  const color =
-    score >= 70 ? "bg-green-600" : score >= 40 ? "bg-yellow-600" : "bg-gray-600";
+  const size = 38;
+  const r = size / 2 - 3;
+  const c = 2 * Math.PI * r;
+  const pct = Math.max(0, Math.min(100, score)) / 100;
+  const dash = c * pct;
+  const strokeColor =
+    score >= 70 ? "var(--tn-value-high)" : score >= 50 ? "var(--tn-accent)" : "var(--tn-text-faint)";
+
   return (
     <span className="relative inline-block">
       <button
         type="button"
-        onClick={(e) => {
-          e.stopPropagation();
-          setOpen((v) => !v);
-        }}
-        className={`${color} text-white text-[10px] font-bold font-mono px-1.5 py-0.5 rounded cursor-pointer select-none`}
+        onClick={(e) => { e.stopPropagation(); setOpen((v) => !v); }}
+        className="tn-form-ring"
+        style={{ width: size, height: size }}
+        title={CS_EXPLANATION}
       >
-        CS {score}
+        <svg viewBox={`0 0 ${size} ${size}`} width={size} height={size} style={{ transform: "rotate(-90deg)", position: "absolute", inset: 0 }}>
+          <circle cx={size / 2} cy={size / 2} r={r} className="ring-track" />
+          <circle
+            cx={size / 2} cy={size / 2} r={r}
+            className="ring-bar"
+            style={{ stroke: strokeColor, strokeDasharray: `${dash} ${c}` }}
+          />
+        </svg>
+        <span className="ring-val" style={{ position: "relative", zIndex: 1 }}>{score}</span>
       </button>
       {open && (
-        <span className="absolute right-0 top-full mt-1 z-20 w-64 bg-gray-900 text-gray-100 text-xs rounded shadow-lg p-2 leading-relaxed">
+        <span
+          className="absolute right-0 top-full mt-1 z-20 w-64 text-xs rounded-lg shadow-xl p-3 leading-relaxed"
+          style={{ background: "var(--tn-bg-card)", border: "1px solid var(--tn-border)", color: "var(--tn-text-dim)" }}
+        >
           {CS_EXPLANATION}
         </span>
       )}
@@ -111,159 +123,89 @@ function ScoreBadge({ score }: { score: number | null }) {
   );
 }
 
+/* ── Track adjustment badge ──────────────────────────────────── */
 function TrackAdjustmentBadge({
-  delta,
-  trackConfig,
-  postPosition,
-  raceDistance,
+  delta, trackConfig, postPosition, raceDistance,
 }: {
-  delta: number;
-  trackConfig: TrackConfig;
-  postPosition: number;
-  raceDistance?: number;
+  delta: number; trackConfig: TrackConfig; postPosition: number; raceDistance?: number;
 }) {
   const isPositive = delta > 0;
-  const color = isPositive
-    ? "bg-green-100 dark:bg-green-900/40 text-green-600 dark:text-green-400"
-    : "bg-red-100 dark:bg-red-900/30 text-red-500 dark:text-red-400";
-  const arrow = isPositive ? "↑" : "↓";
-
   const parts: string[] = [];
-  const openStretchApplied =
-    trackConfig.open_stretch && trackConfig.open_stretch_lanes.includes(postPosition);
+  const openStretchApplied = trackConfig.open_stretch && trackConfig.open_stretch_lanes.includes(postPosition);
   const shortRaceApplied =
     trackConfig.short_race_threshold > 0 &&
     raceDistance !== undefined &&
     raceDistance <= trackConfig.short_race_threshold &&
     postPosition >= 5;
-
-  if (openStretchApplied) {
-    parts.push(`Open stretch: +0.12 (spår ${postPosition}, ${trackConfig.track_name})`);
-  }
-  if (shortRaceApplied) {
-    parts.push(`Kort lopp: -0.08 (spår ${postPosition})`);
-  }
-  const tooltip = parts.join(" · ");
-
-  const absCs = Math.abs(delta);
-  const ariaLabel = isPositive
-    ? `Spårjustering: +${absCs} CS-poäng (open stretch)`
-    : `Spårjustering: -${absCs} CS-poäng (kort lopp)`;
+  if (openStretchApplied) parts.push(`Open stretch: +0.12 (spår ${postPosition}, ${trackConfig.track_name})`);
+  if (shortRaceApplied) parts.push(`Kort lopp: -0.08 (spår ${postPosition})`);
 
   return (
     <span
-      className={`inline-block text-[10px] font-bold px-1.5 py-0.5 rounded ${color}`}
-      title={tooltip}
-      aria-label={ariaLabel}
+      className="inline-block text-[10px] font-bold px-1.5 py-0.5 rounded"
+      title={parts.join(" · ")}
+      style={{
+        background: isPositive ? "var(--tn-value-high-bg)" : "var(--tn-value-low-bg)",
+        color: isPositive ? "var(--tn-value-high)" : "var(--tn-value-low)",
+      }}
     >
-      {arrow}
+      {isPositive ? "↑" : "↓"}
     </span>
   );
 }
 
-function HorseshoeIcon({ className = "", size = 18 }: { className?: string; size?: number }) {
+/* ── Horseshoe icon ──────────────────────────────────────────── */
+function HorseshoeIcon({ className = "", style, size = 18 }: { className?: string; style?: React.CSSProperties; size?: number }) {
   return (
-    <svg
-      width={size}
-      height={size}
-      viewBox="0 0 24 24"
-      fill="none"
-      xmlns="http://www.w3.org/2000/svg"
-      className={className}
-      aria-hidden="true"
-    >
-      <path
-        d="M8 20 L8 11 C8 7 10 5 12 5 C14 5 16 7 16 11 L16 20"
-        stroke="currentColor"
-        strokeWidth="3"
-        strokeLinecap="round"
-        fill="none"
-      />
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" className={className} style={style} aria-hidden="true">
+      <path d="M8 20 L8 11 C8 7 10 5 12 5 C14 5 16 7 16 11 L16 20" stroke="currentColor" strokeWidth="3" strokeLinecap="round" fill="none" />
       <line x1="5.5" y1="20" x2="10.5" y2="20" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" />
       <line x1="13.5" y1="20" x2="18.5" y2="20" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" />
     </svg>
   );
 }
 
-function ShoeBadge({
-  hasShoe,
-  changed,
-  label,
-}: {
-  hasShoe: boolean | null;
-  changed: boolean | null;
-  label: string;
-}) {
+/* ── Shoe badge ──────────────────────────────────────────────── */
+function ShoeBadge({ hasShoe, changed, label }: { hasShoe: boolean | null; changed: boolean | null; label: string }) {
   if (hasShoe == null) return null;
-
-  if (hasShoe) {
-    return (
-      <div className="flex flex-col items-center gap-0.5">
-        <HorseshoeIcon className={changed ? "text-amber-400" : "text-gray-400"} />
-        <span className={`text-[10px] leading-none ${changed ? "text-amber-400 font-semibold" : "text-gray-500"}`}>
-          {label}
-        </span>
-        {changed && (
-          <span className="text-[10px] leading-none text-amber-400 font-bold">Ändrad</span>
-        )}
-      </div>
-    );
-  } else {
-    return (
-      <div className="flex flex-col items-center gap-0.5 relative">
-        <div className="relative">
-          <HorseshoeIcon className={changed ? "text-amber-400" : "text-gray-600"} />
-          <svg
-            width="18"
-            height="18"
-            viewBox="0 0 24 24"
-            className={`absolute inset-0 ${changed ? "text-amber-400" : "text-gray-600"}`}
-          >
+  const color = changed ? "var(--tn-warn)" : "var(--tn-text-faint)";
+  return (
+    <div className="flex flex-col items-center gap-0.5">
+      <div className="relative">
+        <HorseshoeIcon style={{ color }} size={16} />
+        {!hasShoe && (
+          <svg width="16" height="16" viewBox="0 0 24 24" className="absolute inset-0" style={{ color }}>
             <line x1="4" y1="4" x2="20" y2="20" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
           </svg>
-        </div>
-        <span className={`text-[10px] leading-none ${changed ? "text-amber-400 font-semibold" : "text-gray-600"}`}>
-          {label}
-        </span>
-        {changed && (
-          <span className="text-[10px] leading-none text-amber-400 font-bold">Ändrad</span>
         )}
       </div>
-    );
-  }
-}
-
-function StatRow({ label, value }: { label: string; value: string | number | null | undefined }) {
-  if (value == null || value === "" || value === "–") return null;
-  return (
-    <div className="flex justify-between text-xs py-0.5">
-      <span className="text-gray-500 dark:text-gray-400">{label}</span>
-      <span className="text-gray-900 dark:text-white font-medium">{value}</span>
+      <span className="text-[9px] leading-none" style={{ color }}>{label}</span>
+      {changed && <span className="text-[9px] leading-none font-bold" style={{ color: "var(--tn-warn)" }}>Ny</span>}
     </div>
   );
 }
 
-function PlacementStr(
-  starts: number | null,
-  wins: number | null,
-  p2: number | null,
-  p3: number | null
-): string {
+/* ── Stat row ────────────────────────────────────────────────── */
+function StatRow({ label, value }: { label: string; value: string | number | null | undefined }) {
+  if (value == null || value === "" || value === "–") return null;
+  return (
+    <div className="flex justify-between text-xs py-1">
+      <span style={{ color: "var(--tn-text-faint)" }}>{label}</span>
+      <span className="tn-mono" style={{ color: "var(--tn-text)", fontWeight: 500 }}>{value}</span>
+    </div>
+  );
+}
+
+function PlacementStr(starts: number | null, wins: number | null, p2: number | null, p3: number | null): string {
   if (!starts) return "–";
   return `${starts} st  ${wins ?? 0}-${p2 ?? 0}-${p3 ?? 0}`;
 }
 
-function LifeRecordsTable({
-  records,
-  currentMethod,
-  currentDistance,
-}: {
-  records: LifeRecord[];
-  currentMethod: string;
-  currentDistance: string;
+/* ── Life records table ──────────────────────────────────────── */
+function LifeRecordsTable({ records, currentMethod, currentDistance }: {
+  records: LifeRecord[]; currentMethod: string; currentDistance: string;
 }) {
   if (!records.length) return null;
-
   const methods = Array.from(new Set(records.map((r) => r.start_method)));
   const distances = ["short", "medium", "long"];
 
@@ -272,15 +214,16 @@ function LifeRecordsTable({
       <table className="w-full text-xs border-collapse">
         <thead>
           <tr>
-            <th className="text-left text-gray-500 dark:text-gray-400 pb-1 pr-2 font-normal">Start</th>
+            <th className="text-left pb-1.5 pr-2 font-normal tn-eyebrow">Start</th>
             {distances.map((d) => (
               <th
                 key={d}
-                className={`text-center pb-1 px-2 font-normal ${
-                  d === currentDistance
-                    ? "text-indigo-600 dark:text-indigo-400 font-semibold"
-                    : "text-gray-500 dark:text-gray-400"
-                }`}
+                className="text-center pb-1.5 px-2 font-normal tn-mono"
+                style={{
+                  fontSize: 10, letterSpacing: "0.1em", textTransform: "uppercase",
+                  color: d === currentDistance ? "var(--tn-accent)" : "var(--tn-text-faint)",
+                  fontWeight: d === currentDistance ? 600 : 400,
+                }}
               >
                 {DIST_LABEL[d]}
               </th>
@@ -291,27 +234,26 @@ function LifeRecordsTable({
           {methods.map((method) => (
             <tr key={method}>
               <td
-                className={`pr-2 py-0.5 ${
-                  method === currentMethod
-                    ? "text-indigo-600 dark:text-indigo-400 font-semibold"
-                    : "text-gray-500 dark:text-gray-400"
-                }`}
+                className="pr-2 py-1 tn-mono text-xs"
+                style={{
+                  color: method === currentMethod ? "var(--tn-accent)" : "var(--tn-text-faint)",
+                  fontWeight: method === currentMethod ? 600 : 400,
+                }}
               >
                 {method === "auto" ? "Auto" : "Volt"}
               </td>
               {distances.map((dist) => {
-                const rec = records.find(
-                  (r) => r.start_method === method && r.distance === dist
-                );
+                const rec = records.find((r) => r.start_method === method && r.distance === dist);
                 const isCurrent = method === currentMethod && dist === currentDistance;
                 return (
                   <td
                     key={dist}
-                    className={`text-center px-2 py-0.5 ${
-                      isCurrent
-                        ? "bg-indigo-100 dark:bg-indigo-900/40 rounded font-semibold text-indigo-700 dark:text-indigo-300"
-                        : "text-gray-700 dark:text-gray-300"
-                    }`}
+                    className="text-center px-2 py-1 tn-mono text-xs rounded"
+                    style={{
+                      background: isCurrent ? "var(--tn-accent-faint)" : "transparent",
+                      color: isCurrent ? "var(--tn-accent)" : "var(--tn-text-dim)",
+                      fontWeight: isCurrent ? 600 : 400,
+                    }}
                   >
                     {rec ? rec.time : "–"}
                   </td>
@@ -325,6 +267,7 @@ function LifeRecordsTable({
   );
 }
 
+/* ── Fetched starts table ────────────────────────────────────── */
 interface FetchedStart {
   place: string;
   date: string;
@@ -338,6 +281,7 @@ interface FetchedStart {
   shoes_back: boolean | null;
 }
 
+/* ── Main HorseCard ──────────────────────────────────────────── */
 export function HorseCard({
   starter,
   notesSection,
@@ -387,15 +331,12 @@ export function HorseCard({
   const winRateYear = starter.starts_current_year
     ? Math.round(((starter.wins_current_year ?? 0) / starter.starts_current_year) * 100)
     : null;
-
   const platsRate = starter.starts_total
     ? Math.round(
         (((starter.wins_total ?? 0) + (starter.places_2nd ?? 0) + (starter.places_3rd ?? 0)) /
-          starter.starts_total) *
-          100
+          starter.starts_total) * 100
       )
     : null;
-
   const krPerStart =
     starter.earnings_total && starter.starts_total && starter.starts_total > 0
       ? Math.round(starter.earnings_total / starter.starts_total)
@@ -405,77 +346,69 @@ export function HorseCard({
   const shoesChanged = starter.shoes_front_changed || starter.shoes_back_changed;
 
   const currentDistanceCategory =
-    raceDistance == null
-      ? "short"
-      : raceDistance <= 1800
-      ? "short"
-      : raceDistance <= 2400
-      ? "medium"
-      : "long";
+    raceDistance == null ? "short"
+    : raceDistance <= 1800 ? "short"
+    : raceDistance <= 2400 ? "medium"
+    : "long";
   const currentMethod = raceStartMethod ?? "auto";
 
-  // Färg för startnummerboxen baserat på slutplacering
-  const finishBoxColor =
-    starter.finish_position === 1
-      ? "bg-yellow-400 text-black"
-      : starter.finish_position === 2
-      ? "bg-gray-300 text-black"
-      : starter.finish_position === 3
-      ? "bg-amber-600 text-white"
-      : starter.finish_position != null
-      ? "bg-gray-500 text-white"
-      : "bg-gray-100 dark:bg-gray-800 text-gray-900 dark:text-white";
+  // Start number box color based on finish position
+  const finishBoxStyle: React.CSSProperties = (() => {
+    if (starter.finish_position === 1) return { background: "var(--tn-p1)", color: "#0a0e14" };
+    if (starter.finish_position === 2) return { background: "var(--tn-p2)", color: "#0a0e14" };
+    if (starter.finish_position === 3) return { background: "var(--tn-p3)", color: "#fff" };
+    if (starter.finish_position != null) return { background: "var(--tn-bg-chip)", color: "var(--tn-text-dim)" };
+    return { background: "var(--tn-bg-chip)", color: "var(--tn-text)" };
+  })();
 
-  const cardBorder = isSelected
-    ? "border-gray-200 dark:border-gray-800 border-l-4 border-l-emerald-500"
-    : isValue
-    ? "border-green-400 dark:border-green-600"
-    : "border-gray-200 dark:border-gray-800";
+  // Card border style
+  const cardStyle: React.CSSProperties = {
+    background: "var(--tn-bg-card)",
+    border: isSelected
+      ? "1px solid var(--tn-value-high)"
+      : isValue
+      ? `1px solid color-mix(in oklab, var(--tn-value-high) 40%, var(--tn-border))`
+      : "1px solid var(--tn-border)",
+    borderRadius: 12,
+    overflow: "hidden",
+    transition: "border-color 0.15s",
+    ...(isSelected ? { boxShadow: "inset 3px 0 0 var(--tn-value-high)" } : {}),
+  };
 
-  // Beräkna spårjusteringsdelta för TrackAdjustmentBadge
+  // Track adjustment delta
   const trackDelta: number | null = (() => {
     if (!trackConfig || starter.post_position == null) return null;
     const history: never[] = [];
     const startMethod = raceStartMethod ?? "auto";
     const baseF = computeTrackFactor(starter.post_position, startMethod, history);
-    const adjustedF = computeTrackFactor(
-      starter.post_position,
-      startMethod,
-      history,
-      trackConfig,
-      raceDistance
-    );
+    const adjustedF = computeTrackFactor(starter.post_position, startMethod, history, trackConfig, raceDistance);
     const csDelta = Math.round((adjustedF - baseF) * 500);
     if (Math.abs(csDelta) < 1) return null;
     return csDelta;
   })();
 
   return (
-    <div
-      className={`rounded-lg border bg-white dark:bg-gray-900 ${cardBorder} cursor-pointer select-none`}
-      onClick={() => setExpanded((v) => !v)}
-    >
-      {/* ── Kompakt huvud ── */}
-      <div className="flex items-center gap-2.5 px-3 py-2.5">
-        {/* Startnummerbox / systemknapp */}
+    <div style={cardStyle} className="cursor-pointer select-none" onClick={() => setExpanded((v) => !v)}>
+      {/* ── Compact header ── */}
+      <div className="flex items-center gap-3 px-3.5 py-3">
+        {/* Start number / system button */}
         {onSelect != null ? (
           <button
-            onClick={(e) => {
-              e.stopPropagation();
-              onSelect();
-            }}
+            onClick={(e) => { e.stopPropagation(); onSelect(); }}
             title={isSelected ? "Ta bort från system" : "Lägg till i system"}
-            className={`w-8 h-8 rounded flex items-center justify-center text-sm font-bold transition-colors shrink-0 ${
+            className="w-8 h-8 rounded-lg flex items-center justify-center text-sm font-bold tn-mono transition-colors shrink-0"
+            style={
               isSelected
-                ? "bg-emerald-500 text-white ring-2 ring-emerald-300"
-                : "bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-200 hover:bg-emerald-200 dark:hover:bg-emerald-800"
-            }`}
+                ? { background: "var(--tn-value-high)", color: "#0a0e14" }
+                : { background: "var(--tn-bg-chip)", color: "var(--tn-text)" }
+            }
           >
             {starter.start_number}
           </button>
         ) : (
           <div
-            className={`w-8 h-8 rounded flex items-center justify-center text-sm font-bold shrink-0 ${finishBoxColor}`}
+            className="w-8 h-8 rounded-lg flex items-center justify-center text-sm font-bold tn-mono shrink-0"
+            style={finishBoxStyle}
             title={
               starter.finish_position != null
                 ? `Slutplacering: ${starter.finish_position}${starter.finish_time ? ` · ${starter.finish_time}` : ""}`
@@ -486,47 +419,47 @@ export function HorseCard({
           </div>
         )}
 
-        {/* Hästnamn + kusk */}
+        {/* Horse name + driver */}
         <div className="flex-1 min-w-0">
-          <div className="flex items-center gap-1 min-w-0">
+          <div className="flex items-center gap-1.5 min-w-0">
             {sortRank != null && (
-              <span className="text-[10px] font-bold text-indigo-400 dark:text-indigo-300 shrink-0">
+              <span className="tn-mono text-[10px] font-bold shrink-0" style={{ color: "var(--tn-accent)" }}>
                 #{sortRank}
               </span>
             )}
-            <span className="font-bold text-[13px] tracking-tight text-gray-900 dark:text-white truncate">
+            <span
+              className="font-semibold text-sm truncate"
+              style={{ color: "var(--tn-text)", letterSpacing: "-0.01em" }}
+            >
               {starter.horses?.name ?? "–"}
               {shoesChanged && (
-                <span className="ml-1 text-[10px] text-amber-400 font-semibold" title="Skoändring">
-                  ★
+                <span className="ml-1 text-[10px] font-semibold" style={{ color: "var(--tn-warn)" }} title="Skoändring">
+                  ●
                 </span>
               )}
             </span>
           </div>
-          <span className="text-[11px] text-gray-500 dark:text-gray-400 truncate block">
+          <span className="text-xs truncate block" style={{ color: "var(--tn-text-dim)" }}>
             {starter.driver}
           </span>
         </div>
 
-        {/* Höger: streck% · odds · badges */}
-        <div className="flex flex-col items-end gap-0.5 shrink-0">
-          <div className="flex items-center gap-1.5">
+        {/* Right: streck% · odds · badges */}
+        <div className="flex flex-col items-end gap-1 shrink-0">
+          <div className="flex items-center gap-2">
             {starter.bet_distribution != null && starter.bet_distribution > 0 && (
-              <span
-                className="text-indigo-600 dark:text-indigo-400 text-xs font-semibold"
-                title="Streckprocent"
-              >
+              <span className="tn-mono text-xs font-semibold" style={{ color: "var(--tn-accent)" }} title="Streckprocent">
                 {starter.bet_distribution.toFixed(1)}%
               </span>
             )}
             {starter.odds != null && (
-              <span className="text-gray-700 dark:text-gray-300 text-xs" title="Vinnarodds">
+              <span className="tn-mono text-xs" style={{ color: "var(--tn-text-dim)" }} title="Vinnarodds">
                 {starter.odds.toFixed(1)}x
               </span>
             )}
           </div>
           <div className="flex items-center gap-1">
-            <ScoreBadge score={starter.formscore} />
+            <FormRing score={starter.formscore} />
             {trackDelta !== null && trackConfig && starter.post_position != null && (
               <TrackAdjustmentBadge
                 delta={trackDelta}
@@ -539,24 +472,13 @@ export function HorseCard({
         </div>
       </div>
 
-      {/* Senaste 5 resultat — alltid synliga */}
+      {/* Last-5 results */}
       {starter.last_5_results.length > 0 && (
-        <div className="flex gap-1 px-3 pb-2">
+        <div className="tn-last5 px-3.5 pb-2.5">
           {starter.last_5_results.map((r, i) => {
-            const color =
-              r.place === "1"
-                ? "bg-yellow-500 text-black"
-                : r.place === "2"
-                ? "bg-gray-300 text-black"
-                : r.place === "3"
-                ? "bg-orange-600 text-white"
-                : "bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300";
+            const cls = r.place === "1" ? "r1" : r.place === "2" ? "r2" : r.place === "3" ? "r3" : "rdq";
             return (
-              <span
-                key={i}
-                className={`${color} text-[10px] font-bold w-5 h-5 flex items-center justify-center rounded`}
-                title={`${r.date} · ${r.track} · ${r.time}`}
-              >
+              <span key={i} className={cls} title={`${r.date} · ${r.track} · ${r.time}`}>
                 {r.place || "–"}
               </span>
             );
@@ -564,189 +486,128 @@ export function HorseCard({
         </div>
       )}
 
-      {/* Expand-indikator */}
-      <div className="px-3 pb-1.5 flex items-center justify-between">
-        <span className="text-[10px] text-gray-300 dark:text-gray-700">
-          {expanded ? "▲ Dölj" : "▼ Detaljer"}
+      {/* Expand indicator */}
+      <div className="px-3.5 pb-2 flex items-center">
+        <span className="tn-mono text-[9px]" style={{ color: "var(--tn-text-faint)", letterSpacing: "0.1em" }}>
+          {expanded ? "▲ DÖLJ" : "▼ DETALJER"}
         </span>
       </div>
 
-      {/* ── Expanderat innehåll ── */}
+      {/* ── Expanded content ── */}
       {expanded && (
         <div
-          className="border-t border-gray-200 dark:border-gray-700 px-3 pt-3 pb-3 flex flex-col gap-3"
+          className="flex flex-col gap-4 px-3.5 pt-3.5 pb-4"
+          style={{ borderTop: "1px solid var(--tn-border)" }}
           onClick={(e) => e.stopPropagation()}
         >
-          {/* Slutplacering (om resultat finns) */}
+          {/* Finish result badge */}
           {starter.finish_position != null && (
             <div className="flex items-center gap-2">
               <span
-                className={`text-sm font-bold px-2.5 py-1 rounded-full ${
-                  starter.finish_position === 1
-                    ? "bg-yellow-400 text-black"
-                    : starter.finish_position === 2
-                    ? "bg-gray-300 text-black"
-                    : starter.finish_position === 3
-                    ? "bg-amber-600 text-white"
-                    : "bg-gray-500 text-white"
-                }`}
+                className="tn-mono text-sm font-bold px-3 py-1.5 rounded-full"
+                style={finishBoxStyle}
               >
                 {starter.finish_position}:a
-                {starter.finish_time ? ` ${starter.finish_time}` : ""}
+                {starter.finish_time ? ` · ${starter.finish_time}` : ""}
               </span>
             </div>
           )}
 
-          {/* Häst-info */}
-          <div className="text-xs text-gray-500 dark:text-gray-400 space-y-0.5">
+          {/* Horse info */}
+          <div className="text-xs space-y-1" style={{ color: "var(--tn-text-dim)" }}>
             {(starter.horse_age || sex || starter.horse_color) && (
-              <p>
-                {[
-                  starter.horse_age ? `${starter.horse_age} år` : null,
-                  sex || null,
-                  starter.horse_color || null,
-                ]
-                  .filter(Boolean)
-                  .join(" · ")}
-              </p>
+              <p>{[starter.horse_age ? `${starter.horse_age} år` : null, sex || null, starter.horse_color || null].filter(Boolean).join(" · ")}</p>
             )}
             {starter.pedigree_father && (
-              <p>
-                Far:{" "}
-                <span className="text-gray-700 dark:text-gray-300">
-                  {starter.pedigree_father}
-                </span>
-              </p>
+              <p>Far: <span style={{ color: "var(--tn-text)" }}>{starter.pedigree_father}</span></p>
             )}
             {starter.home_track && (
-              <p>
-                Hemmaplan:{" "}
-                <span className="text-gray-700 dark:text-gray-300">{starter.home_track}</span>
-              </p>
+              <p>Hemmaplan: <span style={{ color: "var(--tn-text)" }}>{starter.home_track}</span></p>
             )}
           </div>
 
-          {/* Skoinfo + sulky */}
+          {/* Shoe info */}
           {starter.shoes_reported && (
             <div
-              className={`rounded p-2 text-xs border ${
-                shoesChanged
-                  ? "border-amber-300 dark:border-amber-700/60 bg-amber-50/50 dark:bg-amber-900/20"
-                  : "border-gray-200 dark:border-gray-700/50"
-              }`}
+              className="rounded-xl p-3 text-xs"
+              style={{
+                border: `1px solid ${shoesChanged ? "var(--tn-warn)" : "var(--tn-border)"}`,
+                background: shoesChanged ? "var(--tn-warn-bg)" : "var(--tn-bg-chip)",
+              }}
             >
-              <div className="flex items-center justify-between gap-2">
-                <div className="flex items-center gap-4">
-                  <ShoeBadge
-                    hasShoe={starter.shoes_front}
-                    changed={starter.shoes_front_changed}
-                    label="Fram"
-                  />
-                  <ShoeBadge
-                    hasShoe={starter.shoes_back}
-                    changed={starter.shoes_back_changed}
-                    label="Bak"
-                  />
+              <div className="flex items-center justify-between gap-3">
+                <div className="flex items-center gap-5">
+                  <ShoeBadge hasShoe={starter.shoes_front} changed={starter.shoes_front_changed} label="Fram" />
+                  <ShoeBadge hasShoe={starter.shoes_back} changed={starter.shoes_back_changed} label="Bak" />
                 </div>
                 {starter.sulky_type && (
-                  <span className="text-gray-500 dark:text-gray-400 ml-auto">
-                    Vagn: {starter.sulky_type}
-                  </span>
+                  <span style={{ color: "var(--tn-text-faint)" }}>Vagn: {starter.sulky_type}</span>
                 )}
               </div>
             </div>
           )}
 
-          {/* Snabbstatistik: karriär */}
-          <div className="grid grid-cols-3 text-center text-xs border border-gray-200 dark:border-gray-700 rounded-lg divide-x divide-gray-200 dark:divide-gray-700">
-            <div className="p-2">
-              <p className="text-[10px] uppercase tracking-wide text-gray-400 dark:text-gray-500">Livs</p>
-              <p className="text-gray-900 dark:text-white font-semibold">
-                {starter.wins_total ?? "–"}-{starter.places_2nd ?? "–"}-{starter.places_3rd ?? "–"}
-              </p>
-              <p className="text-gray-400 dark:text-gray-500 text-[10px]">
-                {starter.starts_total ?? "–"} st
-              </p>
-            </div>
-            <div className="p-2">
-              <p className="text-[10px] uppercase tracking-wide text-gray-400 dark:text-gray-500">År</p>
-              <p className="text-gray-900 dark:text-white font-semibold">
-                {winRateYear != null ? `${winRateYear}%` : "–"}
-              </p>
-              <p className="text-gray-400 dark:text-gray-500 text-[10px]">
-                {starter.starts_current_year ?? "–"} st
-              </p>
-            </div>
-            <div className="p-2">
-              <p className="text-[10px] uppercase tracking-wide text-gray-400 dark:text-gray-500">Rekord</p>
-              <p className="text-gray-900 dark:text-white font-semibold">
-                {starter.best_time || "–"}
-              </p>
-              <p className="text-gray-400 dark:text-gray-500 text-[10px]">
-                {platsRate != null ? `Plats ${platsRate}%` : ""}
-              </p>
-            </div>
+          {/* Quick stats grid */}
+          <div
+            className="grid grid-cols-3 text-center text-xs rounded-xl overflow-hidden"
+            style={{ border: "1px solid var(--tn-border)" }}
+          >
+            {[
+              {
+                label: "LIVS",
+                val: `${starter.wins_total ?? "–"}-${starter.places_2nd ?? "–"}-${starter.places_3rd ?? "–"}`,
+                sub: `${starter.starts_total ?? "–"} st`,
+              },
+              {
+                label: "ÅR",
+                val: winRateYear != null ? `${winRateYear}%` : "–",
+                sub: `${starter.starts_current_year ?? "–"} st`,
+              },
+              {
+                label: "REKORD",
+                val: starter.best_time || "–",
+                sub: platsRate != null ? `Plats ${platsRate}%` : "",
+              },
+            ].map((s, i) => (
+              <div
+                key={s.label}
+                className="p-2.5"
+                style={{ borderLeft: i > 0 ? "1px solid var(--tn-border)" : "none" }}
+              >
+                <p className="tn-eyebrow mb-1">{s.label}</p>
+                <p className="tn-mono font-semibold" style={{ color: "var(--tn-text)" }}>{s.val}</p>
+                <p className="tn-mono text-[10px] mt-0.5" style={{ color: "var(--tn-text-faint)" }}>{s.sub}</p>
+              </div>
+            ))}
           </div>
 
-          {/* Bästa tider per distans & startmetod */}
+          {/* Life records */}
           {starter.life_records && starter.life_records.length > 0 && (
             <div>
-              <p className="text-xs font-semibold text-gray-700 dark:text-gray-300 mb-1">
-                Bästa tider
-              </p>
+              <p className="tn-eyebrow mb-2">BÄSTA TIDER</p>
               <LifeRecordsTable
                 records={starter.life_records}
                 currentMethod={currentMethod}
                 currentDistance={currentDistanceCategory}
               />
-              <p className="text-[10px] text-gray-400 dark:text-gray-500 mt-0.5">
-                Markerat = dagens lopp (
-                {currentMethod === "auto" ? "autostart" : "voltstart"},{" "}
+              <p className="tn-mono text-[10px] mt-1" style={{ color: "var(--tn-text-faint)" }}>
+                Markerat = dagens lopp ({currentMethod === "auto" ? "autostart" : "voltstart"},{" "}
                 {DIST_LABEL[currentDistanceCategory]?.toLowerCase()})
               </p>
             </div>
           )}
 
-          {/* Karriärstatistik detaljerad */}
+          {/* Detailed career stats */}
           <div>
-            <p className="text-xs font-semibold text-gray-700 dark:text-gray-300 mb-1">Statistik</p>
-            <div className="border border-gray-200 dark:border-gray-700 rounded p-2 space-y-0.5">
-              <StatRow
-                label="Starter livs"
-                value={PlacementStr(
-                  starter.starts_total,
-                  starter.wins_total,
-                  starter.places_2nd,
-                  starter.places_3rd
-                )}
-              />
-              <StatRow
-                label="Innevarande år"
-                value={PlacementStr(
-                  starter.starts_current_year,
-                  starter.wins_current_year,
-                  starter.places_2nd_current_year,
-                  starter.places_3rd_current_year
-                )}
-              />
-              <StatRow
-                label="Föregående år"
-                value={PlacementStr(
-                  starter.starts_prev_year,
-                  starter.wins_prev_year,
-                  starter.places_2nd_prev_year,
-                  starter.places_3rd_prev_year
-                )}
-              />
+            <p className="tn-eyebrow mb-2">STATISTIK</p>
+            <div className="rounded-xl overflow-hidden" style={{ border: "1px solid var(--tn-border)" }}>
+              <StatRow label="Starter livs" value={PlacementStr(starter.starts_total, starter.wins_total, starter.places_2nd, starter.places_3rd)} />
+              <StatRow label="Innevarande år" value={PlacementStr(starter.starts_current_year, starter.wins_current_year, starter.places_2nd_current_year, starter.places_3rd_current_year)} />
+              <StatRow label="Föregående år" value={PlacementStr(starter.starts_prev_year, starter.wins_prev_year, starter.places_2nd_prev_year, starter.places_3rd_prev_year)} />
               {platsRate != null && <StatRow label="Plats%" value={`${platsRate}%`} />}
-              {krPerStart != null && (
-                <StatRow label="Kr/start" value={krPerStart.toLocaleString("sv-SE")} />
-              )}
+              {krPerStart != null && <StatRow label="Kr/start" value={krPerStart.toLocaleString("sv-SE")} />}
               {starter.earnings_total != null && starter.earnings_total > 0 && (
-                <StatRow
-                  label="Total intjänat"
-                  value={starter.earnings_total.toLocaleString("sv-SE") + " kr"}
-                />
+                <StatRow label="Total intjänat" value={starter.earnings_total.toLocaleString("sv-SE") + " kr"} />
               )}
             </div>
           </div>
@@ -754,42 +615,32 @@ export function HorseCard({
           {/* Odds */}
           {(starter.odds != null || starter.p_odds != null) && (
             <div>
-              <p className="text-xs font-semibold text-gray-700 dark:text-gray-300 mb-1">Odds</p>
-              <div className="border border-gray-200 dark:border-gray-700 rounded p-2 space-y-0.5">
-                {starter.odds != null && (
-                  <StatRow label="Vinnarodds" value={`${starter.odds.toFixed(2)}x`} />
-                )}
-                {starter.p_odds != null && (
-                  <StatRow label="Platsodds" value={`${starter.p_odds.toFixed(2)}x`} />
-                )}
+              <p className="tn-eyebrow mb-2">ODDS</p>
+              <div className="rounded-xl overflow-hidden" style={{ border: "1px solid var(--tn-border)" }}>
+                {starter.odds != null && <StatRow label="Vinnarodds" value={`${starter.odds.toFixed(2)}x`} />}
+                {starter.p_odds != null && <StatRow label="Platsodds" value={`${starter.p_odds.toFixed(2)}x`} />}
               </div>
             </div>
           )}
 
-          {/* Kusk & Tränare */}
+          {/* Driver & Trainer */}
           {(starter.driver || starter.trainer) && (
             <div>
-              <p className="text-xs font-semibold text-gray-700 dark:text-gray-300 mb-1">
-                Kusk & Tränare
-              </p>
-              <div className="bg-gray-100 dark:bg-gray-800 rounded p-2 space-y-1">
+              <p className="tn-eyebrow mb-2">KUSK & TRÄNARE</p>
+              <div className="rounded-xl overflow-hidden" style={{ border: "1px solid var(--tn-border)", background: "var(--tn-bg-chip)" }}>
                 {starter.driver && (
-                  <div className="flex justify-between text-xs py-0.5">
-                    <span className="text-gray-500 dark:text-gray-400">{starter.driver}</span>
-                    <span className="text-gray-900 dark:text-white font-medium">
-                      {starter.driver_win_pct != null
-                        ? `${starter.driver_win_pct}% vinst (år)`
-                        : "–"}
+                  <div className="flex justify-between text-xs px-3 py-2" style={{ borderBottom: starter.trainer ? "1px solid var(--tn-border)" : "none" }}>
+                    <span style={{ color: "var(--tn-text-dim)" }}>{starter.driver}</span>
+                    <span className="tn-mono" style={{ color: "var(--tn-text)" }}>
+                      {starter.driver_win_pct != null ? `${starter.driver_win_pct}% vinst (år)` : "–"}
                     </span>
                   </div>
                 )}
                 {starter.trainer && (
-                  <div className="flex justify-between text-xs py-0.5">
-                    <span className="text-gray-500 dark:text-gray-400">{starter.trainer}</span>
-                    <span className="text-gray-900 dark:text-white font-medium">
-                      {starter.trainer_win_pct != null
-                        ? `${starter.trainer_win_pct}% vinst (år)`
-                        : "–"}
+                  <div className="flex justify-between text-xs px-3 py-2">
+                    <span style={{ color: "var(--tn-text-dim)" }}>{starter.trainer}</span>
+                    <span className="tn-mono" style={{ color: "var(--tn-text)" }}>
+                      {starter.trainer_win_pct != null ? `${starter.trainer_win_pct}% vinst (år)` : "–"}
                     </span>
                   </div>
                 )}
@@ -797,92 +648,87 @@ export function HorseCard({
             </div>
           )}
 
-          {/* Senaste starter */}
+          {/* Recent starts */}
           <div>
-            <div className="flex items-center justify-between mb-1">
-              <p className="text-xs font-semibold text-gray-700 dark:text-gray-300">
-                Senaste starter
-              </p>
+            <div className="flex items-center justify-between mb-2">
+              <p className="tn-eyebrow">SENASTE STARTER</p>
               {fetchedStarts === null && (
                 <button
                   onClick={handleFetchStarts}
                   disabled={fetchingStarts}
-                  className="text-xs text-indigo-600 dark:text-indigo-400 hover:text-indigo-800 dark:hover:text-indigo-200 disabled:opacity-50 transition"
+                  className="tn-mono text-xs transition-colors disabled:opacity-50"
+                  style={{ color: "var(--tn-accent)" }}
                 >
                   {fetchingStarts ? "Hämtar..." : "Hämta från ATG"}
                 </button>
               )}
             </div>
             {startsError && (
-              <p className="text-xs text-red-500 dark:text-red-400 bg-red-50 dark:bg-red-900/20 rounded p-2">
+              <p className="text-xs rounded-lg p-2" style={{ color: "var(--tn-value-low)", background: "var(--tn-value-low-bg)" }}>
                 {startsError}
               </p>
             )}
             {fetchedStarts !== null && fetchedStarts.length > 0 && (
               <>
-                {/* Desktop: strukturerad tabell */}
-                <div className="hidden md:block">
+                {/* Desktop table */}
+                <div className="hidden md:block overflow-x-auto">
                   <table className="w-full text-xs">
                     <thead>
-                      <tr className="border-b border-gray-200 dark:border-gray-700 text-gray-400 dark:text-gray-500">
-                        <th className="text-left pb-1.5 pr-3 font-normal">Datum</th>
-                        <th className="text-left pb-1.5 pr-3 font-normal">Bana</th>
-                        <th className="text-left pb-1.5 pr-3 font-normal">Kusk</th>
-                        <th className="text-center pb-1.5 pr-3 font-normal">Spår</th>
-                        <th className="text-right pb-1.5 pr-3 font-normal">Dist</th>
-                        <th className="text-center pb-1.5 pr-3 font-normal">Startmetod</th>
-                        <th className="text-center pb-1.5 pr-3 font-normal">Plac</th>
-                        <th className="text-right pb-1.5 pr-3 font-normal">Tid</th>
-                        <th className="text-center pb-1.5 font-normal">Skor</th>
+                      <tr style={{ borderBottom: "1px solid var(--tn-border)" }}>
+                        {["Datum", "Bana", "Kusk", "Spår", "Dist", "Start", "Plac", "Tid", "Skor"].map((h) => (
+                          <th key={h} className="text-left pb-2 pr-3 font-normal tn-eyebrow" style={{ paddingRight: 8 }}>{h}</th>
+                        ))}
                       </tr>
                     </thead>
                     <tbody>
                       {fetchedStarts.map((r, i) => (
-                        <tr key={i} className="border-t border-gray-200 dark:border-gray-700">
-                          <td className="py-1.5 pr-3 text-gray-500 dark:text-gray-400 whitespace-nowrap">{r.date}</td>
-                          <td className="py-1.5 pr-3 text-gray-700 dark:text-gray-300">{r.track}</td>
-                          <td className="py-1.5 pr-3 text-gray-700 dark:text-gray-300">{r.driver || "–"}</td>
-                          <td className="py-1.5 pr-3 text-center text-gray-500 dark:text-gray-400">{r.post_position ?? "–"}</td>
-                          <td className="py-1.5 pr-3 text-right text-gray-500 dark:text-gray-400 whitespace-nowrap">{r.distance != null ? `${r.distance} m` : "–"}</td>
-                          <td className="py-1.5 pr-3 text-center">
+                        <tr key={i} style={{ borderTop: "1px solid var(--tn-border)" }}>
+                          <td className="py-2 pr-3 tn-mono text-[11px] whitespace-nowrap" style={{ color: "var(--tn-text-faint)" }}>{r.date}</td>
+                          <td className="py-2 pr-3 text-xs" style={{ color: "var(--tn-text-dim)" }}>{r.track}</td>
+                          <td className="py-2 pr-3 text-xs" style={{ color: "var(--tn-text-dim)" }}>{r.driver || "–"}</td>
+                          <td className="py-2 pr-3 text-center tn-mono text-xs" style={{ color: "var(--tn-text-faint)" }}>{r.post_position ?? "–"}</td>
+                          <td className="py-2 pr-3 text-right tn-mono text-xs whitespace-nowrap" style={{ color: "var(--tn-text-faint)" }}>{r.distance != null ? `${r.distance} m` : "–"}</td>
+                          <td className="py-2 pr-3 text-center">
                             {r.start_method ? (
-                              <span className={`text-[10px] font-medium px-1.5 py-0.5 rounded ${
-                                r.start_method === "auto"
-                                  ? "bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400"
-                                  : "bg-purple-100 dark:bg-purple-900/30 text-purple-600 dark:text-purple-400"
-                              }`}>
+                              <span
+                                className="tn-mono text-[10px] font-medium px-1.5 py-0.5 rounded"
+                                style={{
+                                  background: "var(--tn-bg-chip)",
+                                  color: r.start_method === "auto" ? "var(--tn-text-faint)" : "var(--tn-accent)",
+                                }}
+                              >
                                 {r.start_method === "auto" ? "Auto" : "Volt"}
                               </span>
                             ) : "–"}
                           </td>
-                          <td className="py-1.5 pr-3 text-center font-bold text-gray-900 dark:text-white">{r.place || "–"}</td>
-                          <td className="py-1.5 pr-3 text-right text-gray-500 dark:text-gray-400 whitespace-nowrap">{r.time}</td>
-                          <td className="py-1.5">
+                          <td className="py-2 pr-3 text-center tn-mono font-bold" style={{ color: "var(--tn-text)" }}>{r.place || "–"}</td>
+                          <td className="py-2 pr-3 text-right tn-mono text-xs whitespace-nowrap" style={{ color: "var(--tn-text-dim)" }}>{r.time}</td>
+                          <td className="py-2">
                             <div className="flex items-center justify-center gap-2">
                               {r.shoes_front != null && (
                                 <span className="flex flex-col items-center gap-0.5">
                                   <span className="relative inline-flex">
-                                    <HorseshoeIcon size={14} className={r.shoes_front ? "text-gray-400" : "text-gray-600"} />
+                                    <HorseshoeIcon size={13} style={{ color: r.shoes_front ? "var(--tn-text-faint)" : "var(--tn-border-strong)" }} />
                                     {!r.shoes_front && (
-                                      <svg width="14" height="14" viewBox="0 0 24 24" className="absolute inset-0 text-gray-600">
+                                      <svg width="13" height="13" viewBox="0 0 24 24" className="absolute inset-0" style={{ color: "var(--tn-border-strong)" }}>
                                         <line x1="4" y1="4" x2="20" y2="20" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
                                       </svg>
                                     )}
                                   </span>
-                                  <span className="text-[8px] text-gray-400 dark:text-gray-500 leading-none">Fram</span>
+                                  <span className="tn-mono" style={{ fontSize: 8, color: "var(--tn-text-faint)" }}>F</span>
                                 </span>
                               )}
                               {r.shoes_back != null && (
                                 <span className="flex flex-col items-center gap-0.5">
                                   <span className="relative inline-flex">
-                                    <HorseshoeIcon size={14} className={r.shoes_back ? "text-gray-400" : "text-gray-600"} />
+                                    <HorseshoeIcon size={13} style={{ color: r.shoes_back ? "var(--tn-text-faint)" : "var(--tn-border-strong)" }} />
                                     {!r.shoes_back && (
-                                      <svg width="14" height="14" viewBox="0 0 24 24" className="absolute inset-0 text-gray-600">
+                                      <svg width="13" height="13" viewBox="0 0 24 24" className="absolute inset-0" style={{ color: "var(--tn-border-strong)" }}>
                                         <line x1="4" y1="4" x2="20" y2="20" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
                                       </svg>
                                     )}
                                   </span>
-                                  <span className="text-[8px] text-gray-400 dark:text-gray-500 leading-none">Bak</span>
+                                  <span className="tn-mono" style={{ fontSize: 8, color: "var(--tn-text-faint)" }}>B</span>
                                 </span>
                               )}
                             </div>
@@ -893,65 +739,32 @@ export function HorseCard({
                   </table>
                 </div>
 
-                {/* Mobil: tvåraders flex-layout */}
+                {/* Mobile layout */}
                 <div className="md:hidden">
                   {fetchedStarts.map((r, i) => (
-                    <div key={i} className="border-t border-gray-200 dark:border-gray-700 py-1.5 space-y-0.5">
+                    <div key={i} className="py-2 space-y-1" style={{ borderTop: "1px solid var(--tn-border)" }}>
                       <div className="flex items-center gap-1.5 text-xs flex-wrap">
-                        <span className="text-gray-400 dark:text-gray-500 shrink-0 w-[68px]">{r.date}</span>
-                        <span className="flex-1 text-gray-700 dark:text-gray-300 truncate min-w-0">{r.track}</span>
+                        <span className="tn-mono shrink-0" style={{ color: "var(--tn-text-faint)", width: 68 }}>{r.date}</span>
+                        <span className="flex-1 truncate min-w-0" style={{ color: "var(--tn-text-dim)" }}>{r.track}</span>
                         {r.post_position != null && (
-                          <span className="text-[10px] text-gray-400 dark:text-gray-500 shrink-0">Sp {r.post_position}</span>
+                          <span className="tn-mono text-[10px] shrink-0" style={{ color: "var(--tn-text-faint)" }}>Sp {r.post_position}</span>
                         )}
                         {r.distance != null && (
-                          <span className="text-[10px] text-gray-400 dark:text-gray-500 shrink-0">{r.distance} m</span>
+                          <span className="tn-mono text-[10px] shrink-0" style={{ color: "var(--tn-text-faint)" }}>{r.distance} m</span>
                         )}
                         {r.start_method && (
-                          <span className={`text-[9px] font-bold px-1 py-0.5 rounded shrink-0 ${
-                            r.start_method === "auto"
-                              ? "bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400"
-                              : "bg-purple-100 dark:bg-purple-900/30 text-purple-600 dark:text-purple-400"
-                          }`}>
+                          <span
+                            className="tn-mono text-[9px] font-bold px-1 py-0.5 rounded shrink-0"
+                            style={{ background: "var(--tn-bg-chip)", color: r.start_method === "auto" ? "var(--tn-text-faint)" : "var(--tn-accent)" }}
+                          >
                             {r.start_method === "auto" ? "A" : "V"}
                           </span>
                         )}
-                        <span className="font-bold text-gray-900 dark:text-white shrink-0 w-4 text-center">{r.place || "–"}</span>
-                        <span className="text-gray-500 dark:text-gray-400 shrink-0 w-12 text-right">{r.time}</span>
+                        <span className="tn-mono font-bold shrink-0" style={{ color: "var(--tn-text)", width: 16, textAlign: "center" }}>{r.place || "–"}</span>
+                        <span className="tn-mono text-xs shrink-0" style={{ color: "var(--tn-text-dim)", width: 48, textAlign: "right" }}>{r.time}</span>
                       </div>
-                      {(r.driver || r.shoes_front != null || r.shoes_back != null) && (
-                        <div className="flex items-center gap-2">
-                          <span className="flex-1 text-[11px] text-gray-500 dark:text-gray-400 truncate min-w-0">{r.driver ?? ""}</span>
-                          {(r.shoes_front != null || r.shoes_back != null) && (
-                            <div className="flex items-center gap-1.5 shrink-0">
-                              {r.shoes_front != null && (
-                                <span className="flex items-center gap-0.5">
-                                  <span className="text-[8px] text-gray-400 dark:text-gray-500">F</span>
-                                  <span className="relative inline-flex">
-                                    <HorseshoeIcon size={12} className={r.shoes_front ? "text-gray-400" : "text-gray-600"} />
-                                    {!r.shoes_front && (
-                                      <svg width="12" height="12" viewBox="0 0 24 24" className="absolute inset-0 text-gray-600">
-                                        <line x1="4" y1="4" x2="20" y2="20" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
-                                      </svg>
-                                    )}
-                                  </span>
-                                </span>
-                              )}
-                              {r.shoes_back != null && (
-                                <span className="flex items-center gap-0.5">
-                                  <span className="text-[8px] text-gray-400 dark:text-gray-500">B</span>
-                                  <span className="relative inline-flex">
-                                    <HorseshoeIcon size={12} className={r.shoes_back ? "text-gray-400" : "text-gray-600"} />
-                                    {!r.shoes_back && (
-                                      <svg width="12" height="12" viewBox="0 0 24 24" className="absolute inset-0 text-gray-600">
-                                        <line x1="4" y1="4" x2="20" y2="20" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
-                                      </svg>
-                                    )}
-                                  </span>
-                                </span>
-                              )}
-                            </div>
-                          )}
-                        </div>
+                      {r.driver && (
+                        <div className="text-[11px] truncate" style={{ color: "var(--tn-text-faint)" }}>{r.driver}</div>
                       )}
                     </div>
                   ))}
@@ -959,18 +772,16 @@ export function HorseCard({
               </>
             )}
             {fetchedStarts !== null && fetchedStarts.length === 0 && (
-              <p className="text-xs text-gray-400 dark:text-gray-500 italic">
-                Inga starter hittades.
-              </p>
+              <p className="text-xs italic" style={{ color: "var(--tn-text-faint)" }}>Inga starter hittades.</p>
             )}
             {fetchedStarts === null && !fetchingStarts && !startsError && (
-              <p className="text-xs text-gray-400 dark:text-gray-500 italic">
+              <p className="text-xs italic" style={{ color: "var(--tn-text-faint)" }}>
                 Klicka &quot;Hämta från ATG&quot; för att visa senaste starter.
               </p>
             )}
           </div>
 
-          {/* Anteckningar */}
+          {/* Notes */}
           {notesSection}
         </div>
       )}

--- a/components/InstallPrompt.tsx
+++ b/components/InstallPrompt.tsx
@@ -15,16 +15,11 @@ export function InstallPrompt() {
   const [visible, setVisible] = useState(false);
 
   useEffect(() => {
-    // Redan installerad som PWA
     if (window.matchMedia("(display-mode: standalone)").matches) return;
-    // Användaren har stängt prompten tidigare
     if (localStorage.getItem(DISMISSED_KEY)) return;
 
-    // iOS-detektion (Safari)
     const ua = navigator.userAgent;
-    const isIOSDevice =
-      /iPad|iPhone|iPod/.test(ua) &&
-      !(window as unknown as { MSStream?: unknown }).MSStream;
+    const isIOSDevice = /iPad|iPhone|iPod/.test(ua) && !(window as unknown as { MSStream?: unknown }).MSStream;
 
     if (isIOSDevice) {
       setIsIOS(true);
@@ -32,7 +27,6 @@ export function InstallPrompt() {
       return;
     }
 
-    // Android / Chrome – lyssna på beforeinstallprompt
     const handler = (e: Event) => {
       e.preventDefault();
       setDeferredPrompt(e as BeforeInstallPromptEvent);
@@ -47,9 +41,7 @@ export function InstallPrompt() {
     await deferredPrompt.prompt();
     const { outcome } = await deferredPrompt.userChoice;
     setDeferredPrompt(null);
-    if (outcome === "accepted") {
-      dismiss();
-    }
+    if (outcome === "accepted") dismiss();
   };
 
   const dismiss = () => {
@@ -61,41 +53,34 @@ export function InstallPrompt() {
 
   return (
     <div className="fixed bottom-16 left-0 right-0 z-40 px-3 pb-2 md:hidden">
-      <div className="bg-indigo-600 dark:bg-indigo-700 rounded-2xl p-3 flex items-center gap-3 shadow-xl">
-        {/* App-ikon */}
+      <div
+        className="rounded-2xl p-3 flex items-center gap-3 shadow-xl"
+        style={{ background: "var(--tn-accent)", border: "1px solid var(--tn-accent-soft)" }}
+      >
         {/* eslint-disable-next-line @next/next/no-img-element */}
-        <img
-          src="/apple-touch-icon.png"
-          alt=""
-          className="w-12 h-12 rounded-xl shrink-0 shadow"
-        />
+        <img src="/apple-touch-icon.png" alt="" className="w-12 h-12 rounded-xl shrink-0 shadow" />
 
-        {/* Text + knapp */}
         <div className="flex-1 min-w-0">
-          <p className="text-white text-sm font-semibold leading-tight">
-            Installera V85 Analys
+          <p className="text-sm font-semibold leading-tight" style={{ color: "#fff" }}>
+            Installera Travappen
           </p>
           {isIOS ? (
-            <p className="text-indigo-200 text-xs mt-0.5 leading-snug">
+            <p className="text-xs mt-0.5 leading-snug" style={{ color: "rgba(255,255,255,0.7)" }}>
               Tryck på{" "}
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 24 24"
-                fill="currentColor"
-                className="w-3 h-3 inline-block align-middle"
-              >
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" className="w-3 h-3 inline-block align-middle">
                 <path d="M11.47 1.72a.75.75 0 011.06 0l3 3a.75.75 0 01-1.06 1.06l-1.72-1.72V7.5h-1.5V4.06L9.53 5.78a.75.75 0 01-1.06-1.06l3-3zM11.25 7.5V15a.75.75 0 001.5 0V7.5h3.75a3 3 0 013 3v9a3 3 0 01-3 3h-9a3 3 0 01-3-3v-9a3 3 0 013-3h3.75z" />
               </svg>{" "}
               och välj &quot;Lägg till på hemskärmen&quot;
             </p>
           ) : (
             <>
-              <p className="text-indigo-200 text-xs mt-0.5">
+              <p className="text-xs mt-0.5" style={{ color: "rgba(255,255,255,0.7)" }}>
                 Snabbare åtkomst, fungerar offline
               </p>
               <button
                 onClick={handleInstall}
-                className="mt-1.5 px-3 py-1 bg-white text-indigo-600 text-xs font-bold rounded-lg shadow"
+                className="mt-1.5 px-3 py-1 text-xs font-bold rounded-lg shadow"
+                style={{ background: "#fff", color: "var(--tn-accent)", border: "none", cursor: "pointer" }}
               >
                 Installera
               </button>
@@ -103,23 +88,14 @@ export function InstallPrompt() {
           )}
         </div>
 
-        {/* Stäng */}
         <button
           onClick={dismiss}
-          className="self-start text-indigo-200 hover:text-white transition-colors shrink-0 p-1"
+          className="self-start transition-colors shrink-0 p-1"
+          style={{ color: "rgba(255,255,255,0.7)", background: "none", border: "none", cursor: "pointer" }}
           aria-label="Stäng"
         >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 24 24"
-            fill="currentColor"
-            className="w-5 h-5"
-          >
-            <path
-              fillRule="evenodd"
-              d="M5.47 5.47a.75.75 0 011.06 0L12 10.94l5.47-5.47a.75.75 0 111.06 1.06L13.06 12l5.47 5.47a.75.75 0 11-1.06 1.06L12 13.06l-5.47 5.47a.75.75 0 01-1.06-1.06L10.94 12 5.47 6.53a.75.75 0 010-1.06z"
-              clipRule="evenodd"
-            />
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" className="w-5 h-5">
+            <path fillRule="evenodd" d="M5.47 5.47a.75.75 0 011.06 0L12 10.94l5.47-5.47a.75.75 0 111.06 1.06L13.06 12l5.47 5.47a.75.75 0 11-1.06 1.06L12 13.06l-5.47 5.47a.75.75 0 01-1.06-1.06L10.94 12 5.47 6.53a.75.75 0 010-1.06z" clipRule="evenodd" />
           </svg>
         </button>
       </div>

--- a/components/MainPageClient.tsx
+++ b/components/MainPageClient.tsx
@@ -25,11 +25,8 @@ interface MainPageClientProps {
   initialGroupId?: string | null
   gameId: string | null
   gameType: string | null
-  /** Befintligt utkast-ID att fortsätta redigera */
   draftId?: string | null
-  /** Förvalda hästar från ett utkast */
   initialSelections?: SystemSelection[]
-  /** Banspecifik konfiguration för spårfaktorjustering */
   trackConfig?: TrackConfig | null
 }
 
@@ -55,21 +52,14 @@ export function MainPageClient({
   const [draftName, setDraftName] = useState('Utkast')
   const [savedDrafts, setSavedDrafts] = useState<GameSystem[]>([])
 
-  // Auto-spara utkast (debounce 3 s) när systemMode är aktivt och val ändras
   const draftTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const isFirstRender = useRef(true)
 
   useEffect(() => {
-    // Hoppa över triggern vid initial render
-    if (isFirstRender.current) {
-      isFirstRender.current = false
-      return
-    }
+    if (isFirstRender.current) { isFirstRender.current = false; return }
     if (!systemMode || !gameId) return
-
     if (draftTimerRef.current) clearTimeout(draftTimerRef.current)
     setDraftSaveStatus('idle')
-
     draftTimerRef.current = setTimeout(async () => {
       setDraftSaveStatus('saving')
       try {
@@ -77,7 +67,6 @@ export function MainPageClient({
         if (activeDraftId) {
           await updateDraft(activeDraftId, systemSelections, totalRows)
         } else {
-          // Spara utkastet med group_id om vi är i sällskapsläge
           const draft = await createSystem(initialGroupId, gameId, draftName, systemSelections, totalRows, true)
           setActiveDraftId(draft.id)
         }
@@ -86,25 +75,18 @@ export function MainPageClient({
         setDraftSaveStatus('idle')
       }
     }, 3000)
-
-    return () => {
-      if (draftTimerRef.current) clearTimeout(draftTimerRef.current)
-    }
+    return () => { if (draftTimerRef.current) clearTimeout(draftTimerRef.current) }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [systemSelections, systemMode])
 
   const handleToggleHorse = useCallback((raceNumber: number, horse: SystemHorse) => {
     setSystemSelections(prev => {
       const existing = prev.find(s => s.race_number === raceNumber)
-      if (!existing) {
-        return [...prev, { race_number: raceNumber, horses: [horse] }]
-      }
+      if (!existing) return [...prev, { race_number: raceNumber, horses: [horse] }]
       const alreadySelected = existing.horses.some(h => h.horse_id === horse.horse_id)
       if (alreadySelected) {
         const updatedHorses = existing.horses.filter(h => h.horse_id !== horse.horse_id)
-        if (updatedHorses.length === 0) {
-          return prev.filter(s => s.race_number !== raceNumber)
-        }
+        if (updatedHorses.length === 0) return prev.filter(s => s.race_number !== raceNumber)
         return prev.map(s => s.race_number === raceNumber ? { ...s, horses: updatedHorses } : s)
       } else {
         return prev.map(s => s.race_number === raceNumber ? { ...s, horses: [...s.horses, horse] } : s)
@@ -122,9 +104,7 @@ export function MainPageClient({
       try {
         const drafts = await getUserDraftsForGame(gameId)
         setSavedDrafts(drafts)
-      } catch {
-        // ignorera fel
-      }
+      } catch { /* ignorera */ }
     }
   }, [gameId])
 
@@ -139,9 +119,7 @@ export function MainPageClient({
   const handleHorseClick = useCallback((raceNumber: number, startNumber: number) => {
     setActiveRace(raceNumber)
     requestAnimationFrame(() => {
-      const el = document.querySelector(
-        `[data-race="${raceNumber}"][data-start="${startNumber}"]`
-      )
+      const el = document.querySelector(`[data-race="${raceNumber}"][data-start="${startNumber}"]`)
       el?.scrollIntoView({ behavior: 'smooth', block: 'start' })
     })
   }, [setActiveRace])
@@ -164,26 +142,29 @@ export function MainPageClient({
 
   return (
     <>
-      {/* "Bygg system"-knapp visas ovanför listan när systemläge är AV */}
       {!systemMode && races.length > 0 && (
         <div className="flex justify-end mb-4">
           <button
             onClick={handleActivateSystemMode}
-            className="flex items-center gap-2 px-4 py-2 bg-emerald-900 hover:bg-emerald-800 text-white text-sm font-semibold rounded-lg transition-colors"
+            className="flex items-center gap-2 text-sm font-semibold rounded-lg transition-colors"
+            style={{
+              padding: "8px 16px",
+              background: "var(--tn-accent-faint)",
+              border: "1px solid var(--tn-accent-soft)",
+              color: "var(--tn-accent)",
+              cursor: "pointer",
+            }}
           >
-            🎯 Bygg system
+            Bygg system
           </button>
         </div>
       )}
 
-      {/* Innehåll: får högerpadding på desktop när sidopanelen är öppen */}
       <div className={systemMode ? "md:pr-[320px]" : ""}>
         {races.length === 0 ? (
-          <div className="text-center py-20 text-gray-400 dark:text-gray-500">
+          <div className="text-center py-20" style={{ color: "var(--tn-text-faint)" }}>
             <p className="text-lg mb-2">Ingen data inladdad ännu.</p>
-            <p className="text-sm">
-              Välj ett datum och klicka på ett spel för att ladda en omgång från ATG.
-            </p>
+            <p className="text-sm">Välj ett datum och klicka på ett spel för att ladda en omgång från ATG.</p>
           </div>
         ) : (
           <RaceList
@@ -200,7 +181,6 @@ export function MainPageClient({
         )}
       </div>
 
-      {/* Desktop-sidopanel: fast till högerkanten (dold på mobil) */}
       {systemMode && (
         <SystemSidebar
           races={races}
@@ -218,34 +198,41 @@ export function MainPageClient({
         />
       )}
 
-      {/* Mobil: sticky banner längst ner (dold på desktop) */}
       {systemMode && (
-        <div className="fixed bottom-16 left-0 right-0 z-50 md:hidden border-t border-gray-800 bg-gray-900 text-white shadow-lg">
+        <div
+          className="fixed bottom-16 left-0 right-0 z-50 md:hidden shadow-lg"
+          style={{ background: "var(--tn-bg-raised)", borderTop: "1px solid var(--tn-border)" }}
+        >
           <button
             aria-label="Öppna kupong"
             className="flex-1 w-full text-left px-4 py-3"
+            style={{ background: "none", border: "none", cursor: "pointer" }}
             onClick={() => setShowDrawer(true)}
           >
             <div className="flex items-center justify-between">
               <div>
-                <div className="text-xs text-gray-400">{completedRaces} av {races.length} avd. klara</div>
-                <div className="text-sm font-bold">
-                  {totalRows} {totalRows === 1 ? 'rad' : 'rader'}{totalRows > 0 && <> · <span className="text-emerald-400">{formatRowCost(totalRows, gameType ?? '')}</span></>}
+                <div className="text-xs" style={{ color: "var(--tn-text-faint)" }}>
+                  {completedRaces} av {races.length} avd. klara
                 </div>
-                <div className="text-xs text-emerald-400 mt-0.5">↑ Visa kupong</div>
+                <div className="text-sm font-bold" style={{ color: "var(--tn-text)" }}>
+                  {totalRows} {totalRows === 1 ? 'rad' : 'rader'}
+                  {totalRows > 0 && (
+                    <> · <span style={{ color: "var(--tn-accent)" }}>{formatRowCost(totalRows, gameType ?? '')}</span></>
+                  )}
+                </div>
+                <div className="text-xs mt-0.5" style={{ color: "var(--tn-accent)" }}>↑ Visa kupong</div>
               </div>
               {draftSaveStatus === 'saving' && (
-                <span className="text-xs text-gray-500">Sparar utkast...</span>
+                <span className="text-xs" style={{ color: "var(--tn-text-faint)" }}>Sparar utkast...</span>
               )}
               {draftSaveStatus === 'saved' && (
-                <span className="text-xs text-gray-500">Utkast sparat</span>
+                <span className="text-xs" style={{ color: "var(--tn-text-faint)" }}>Utkast sparat</span>
               )}
             </div>
           </button>
         </div>
       )}
 
-      {/* Mobil: slide-up drawer */}
       {systemMode && (
         <SystemDrawer
           open={showDrawer}

--- a/components/NavActiveLink.tsx
+++ b/components/NavActiveLink.tsx
@@ -16,11 +16,13 @@ export function NavActiveLink({ href, label }: NavActiveLinkProps) {
   return (
     <Link
       href={href}
-      className={`py-4 text-xs uppercase tracking-wide font-semibold border-b-2 transition-colors ${
-        isActive
-          ? "border-indigo-600 text-indigo-600 dark:border-indigo-400 dark:text-indigo-400"
-          : "border-transparent text-gray-400 dark:text-gray-500 hover:text-gray-900 dark:hover:text-white"
-      }`}
+      className="tn-mono py-4 px-3 text-xs border-b-2 transition-colors"
+      style={{
+        letterSpacing: "0.1em",
+        textTransform: "uppercase",
+        borderBottomColor: isActive ? "var(--tn-accent)" : "transparent",
+        color: isActive ? "var(--tn-accent)" : "var(--tn-text-faint)",
+      }}
     >
       {label}
     </Link>

--- a/components/RaceList.tsx
+++ b/components/RaceList.tsx
@@ -98,7 +98,6 @@ export function RaceList({
   const [hideOutsiders, setHideOutsiders] = useState(false);
   const [search, setSearch] = useState("");
 
-  // Reset analysis panel when switching races
   useEffect(() => {
     setShowAnalysis(false);
   }, [activeRaceNumber]);
@@ -112,14 +111,10 @@ export function RaceList({
 
   const activeRace = races.find((r) => r.race_number === activeRaceNumber) ?? races[0];
 
-  function sortStarters(
-    starters: Starter[],
-    compositeMap: Record<number, number>
-  ): Starter[] {
+  function sortStarters(starters: Starter[], compositeMap: Record<number, number>): Starter[] {
     return [...starters].sort((a, b) => {
       switch (sortKey) {
-        case "number":
-          return a.start_number - b.start_number;
+        case "number": return a.start_number - b.start_number;
         case "odds":
           if (a.odds == null && b.odds == null) return 0;
           if (a.odds == null) return 1;
@@ -141,13 +136,7 @@ export function RaceList({
   if (!activeRace) return null;
 
   const hasActiveFilter = filterValue || hideOutsiders || search.trim().length > 0;
-
-  // Bygg compositeMap direkt från DB-lagrad formscore (CS)
-  const compositeMap = Object.fromEntries(
-    activeRace.starters.map((s) => [s.start_number, s.formscore ?? 0])
-  );
-
-  // Beräkna "isValue" per häst: CS > 55 och positiv CS-andel vs streckning
+  const compositeMap = Object.fromEntries(activeRace.starters.map((s) => [s.start_number, s.formscore ?? 0]));
   const totalCS = activeRace.starters.reduce((sum, s) => sum + (s.formscore ?? 0), 0);
   const valueMap = Object.fromEntries(
     activeRace.starters.map((s) => {
@@ -164,110 +153,115 @@ export function RaceList({
     .filter((s) => !hideOutsiders || s.odds == null || s.odds <= 50)
     .filter((s) => {
       if (!q) return true;
-      return (
-        (s.horses?.name ?? "").toLowerCase().includes(q) ||
-        s.driver.toLowerCase().includes(q) ||
-        s.trainer.toLowerCase().includes(q)
-      );
+      return (s.horses?.name ?? "").toLowerCase().includes(q) || s.driver.toLowerCase().includes(q) || s.trainer.toLowerCase().includes(q);
     });
 
   const sorted = sortStarters(filtered, compositeMap);
   const raceSelections = systemSelections?.find((s) => s.race_number === activeRace.race_number);
-
   const startTimeStr = activeRace.start_time
-    ? new Date(activeRace.start_time).toLocaleTimeString("sv-SE", {
-        hour: "2-digit",
-        minute: "2-digit",
-        timeZone: "Europe/Stockholm",
-      })
+    ? new Date(activeRace.start_time).toLocaleTimeString("sv-SE", { hour: "2-digit", minute: "2-digit", timeZone: "Europe/Stockholm" })
     : null;
+
+  const chipBase: React.CSSProperties = {
+    background: "var(--tn-bg-chip)",
+    border: "1px solid var(--tn-border)",
+    color: "var(--tn-text-dim)",
+    borderRadius: 8,
+    fontSize: 12,
+    padding: "5px 10px",
+    cursor: "pointer",
+    transition: "background 0.15s",
+    fontFamily: "var(--font-geist-sans)",
+  };
 
   return (
     <div className="space-y-3">
       <TopFiveRanking races={races} onHorseClick={onHorseClick} />
 
-      {/* Toolbar: sortering + filter på en rad */}
+      {/* Toolbar */}
       <div className="flex items-center gap-2 flex-wrap px-1">
-        {/* Sort dropdown */}
         <select
           value={sortKey}
           onChange={(e) => setSortKey(e.target.value as SortKey)}
-          className="text-xs px-2 py-1.5 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 focus:outline-none focus:border-indigo-400 cursor-pointer"
+          className="text-xs rounded-lg outline-none cursor-pointer"
+          style={{ ...chipBase, minWidth: 0 }}
         >
           {SORT_OPTIONS.map((opt) => (
-            <option key={opt.key} value={opt.key}>
-              {opt.label}
-            </option>
+            <option key={opt.key} value={opt.key}>{opt.label}</option>
           ))}
         </select>
 
-        {/* Filter chips */}
         <button
           onClick={() => setFilterValue((v) => !v)}
-          className={`text-xs px-3 py-1.5 rounded-lg border transition font-medium ${
-            filterValue
-              ? "bg-green-600 border-green-500 text-white"
-              : "bg-transparent border-gray-300 dark:border-gray-600 text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800"
-          }`}
+          className="text-xs font-medium transition-colors"
+          style={{
+            ...chipBase,
+            background: filterValue ? "var(--tn-value-high-bg)" : "var(--tn-bg-chip)",
+            color: filterValue ? "var(--tn-value-high)" : "var(--tn-text-dim)",
+            border: filterValue ? "1px solid transparent" : "1px solid var(--tn-border)",
+          }}
         >
           Värde
         </button>
+
         <button
           onClick={() => setHideOutsiders((v) => !v)}
-          className={`text-xs px-3 py-1.5 rounded-lg border transition font-medium ${
-            hideOutsiders
-              ? "bg-indigo-700 border-indigo-600 text-white"
-              : "bg-transparent border-gray-300 dark:border-gray-600 text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800"
-          }`}
+          className="text-xs font-medium transition-colors"
+          style={{
+            ...chipBase,
+            background: hideOutsiders ? "var(--tn-accent-faint)" : "var(--tn-bg-chip)",
+            color: hideOutsiders ? "var(--tn-accent)" : "var(--tn-text-dim)",
+            border: hideOutsiders ? "1px solid transparent" : "1px solid var(--tn-border)",
+          }}
         >
           Dölj &gt;50x
         </button>
+
         {hasActiveFilter && (
           <button
-            onClick={() => {
-              setFilterValue(false);
-              setHideOutsiders(false);
-              setSearch("");
-            }}
-            className="text-xs px-2 py-1.5 text-gray-400 dark:text-gray-500 hover:text-red-500 transition"
+            onClick={() => { setFilterValue(false); setHideOutsiders(false); setSearch(""); }}
+            className="text-xs transition-colors"
+            style={{ color: "var(--tn-text-faint)", background: "none", border: "none", cursor: "pointer" }}
           >
             Rensa ✕
           </button>
         )}
 
-        {/* Sök */}
         <input
           type="text"
           value={search}
           onChange={(e) => setSearch(e.target.value)}
           placeholder="Sök häst, kusk…"
-          className="text-xs px-3 py-1.5 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:border-indigo-400 w-full sm:w-44 ml-auto"
+          className="text-xs rounded-lg outline-none w-full sm:w-44 ml-auto"
+          style={{
+            ...chipBase,
+            color: "var(--tn-text)",
+          }}
         />
       </div>
 
-      {/* Loppinfo + analysknapp */}
-      <div className="flex items-center justify-between px-1 text-xs text-gray-500 dark:text-gray-400">
-        <span className="truncate">
+      {/* Race info + analysis toggle */}
+      <div className="flex items-center justify-between px-1">
+        <span className="text-xs truncate" style={{ color: "var(--tn-text-faint)" }}>
           {activeRace.race_name ?? `Avdelning ${activeRace.race_number}`}
           {startTimeStr && <span className="ml-2">{startTimeStr}</span>}
           <span className="ml-2">{activeRace.distance} m</span>
-          {activeRace.start_method && (
-            <span className="ml-2 capitalize">{activeRace.start_method}</span>
-          )}
+          {activeRace.start_method && <span className="ml-2 capitalize">{activeRace.start_method}</span>}
         </span>
         <button
           onClick={() => setShowAnalysis((v) => !v)}
-          className={`ml-3 shrink-0 text-xs px-3 py-1.5 rounded-lg border transition font-medium ${
-            showAnalysis
-              ? "bg-indigo-700 border-indigo-600 text-white"
-              : "bg-transparent border-indigo-700 text-indigo-600 dark:text-indigo-400 hover:bg-indigo-50 dark:hover:bg-indigo-900/30"
-          }`}
+          className="ml-3 shrink-0 text-xs font-medium transition-colors"
+          style={{
+            ...chipBase,
+            background: showAnalysis ? "var(--tn-accent-faint)" : "transparent",
+            color: showAnalysis ? "var(--tn-accent)" : "var(--tn-accent)",
+            border: "1px solid var(--tn-accent-soft)",
+          }}
         >
           {showAnalysis ? "Dölj analys" : "Visa analys"}
         </button>
       </div>
 
-      {/* Analysvy */}
       {showAnalysis && (
         <AnalysisPanel
           starters={sorted}
@@ -278,54 +272,34 @@ export function RaceList({
       )}
 
       {sorted.length === 0 && (
-        <p className="text-sm text-gray-400 dark:text-gray-500 text-center py-8">
+        <p className="text-sm text-center py-8" style={{ color: "var(--tn-text-faint)" }}>
           Inga hästar matchar filtret.
         </p>
       )}
 
-      {/* Hästlista: en per rad */}
       <div className="flex flex-col gap-2">
-        {sorted.map((s, idx) => {
-          return (
-            <div
-              key={s.id}
-              data-race={activeRace.race_number}
-              data-start={s.start_number}
-            >
-              <HorseCard
-                starter={s}
-                internalRaceId={activeRace.id}
-                raceDistance={activeRace.distance}
-                raceStartMethod={activeRace.start_method ?? "auto"}
-                isValue={valueMap[s.start_number] ?? false}
-                sortRank={sortKey !== "number" ? idx + 1 : undefined}
-                trackConfig={trackConfig ?? undefined}
-                isSelected={
-                  systemMode
-                    ? (raceSelections?.horses.some((h) => h.horse_id === s.horse_id) ?? false)
-                    : undefined
-                }
-                onSelect={
-                  systemMode && onToggleHorse
-                    ? () =>
-                        onToggleHorse(activeRace.race_number, {
-                          horse_id: s.horse_id,
-                          start_number: s.start_number,
-                          horse_name: s.horses?.name ?? "",
-                        })
-                    : undefined
-                }
-                notesSection={
-                  <HorseNotes
-                    horseId={s.horse_id}
-                    userGroups={userGroups}
-                    currentUserId={currentUserId}
-                  />
-                }
-              />
-            </div>
-          );
-        })}
+        {sorted.map((s, idx) => (
+          <div key={s.id} data-race={activeRace.race_number} data-start={s.start_number}>
+            <HorseCard
+              starter={s}
+              internalRaceId={activeRace.id}
+              raceDistance={activeRace.distance}
+              raceStartMethod={activeRace.start_method ?? "auto"}
+              isValue={valueMap[s.start_number] ?? false}
+              sortRank={sortKey !== "number" ? idx + 1 : undefined}
+              trackConfig={trackConfig ?? undefined}
+              isSelected={systemMode ? (raceSelections?.horses.some((h) => h.horse_id === s.horse_id) ?? false) : undefined}
+              onSelect={
+                systemMode && onToggleHorse
+                  ? () => onToggleHorse(activeRace.race_number, { horse_id: s.horse_id, start_number: s.start_number, horse_name: s.horses?.name ?? "" })
+                  : undefined
+              }
+              notesSection={
+                <HorseNotes horseId={s.horse_id} userGroups={userGroups} currentUserId={currentUserId} />
+              }
+            />
+          </div>
+        ))}
       </div>
     </div>
   );

--- a/components/RaceTabBar.tsx
+++ b/components/RaceTabBar.tsx
@@ -10,8 +10,11 @@ export function RaceTabBar({ races }: RaceTabBarProps) {
   const { activeRaceNumber, setActiveRaceNumber } = useRaceTab();
 
   return (
-    <div className="border-t border-gray-200 dark:border-gray-800 overflow-x-auto scrollbar-none">
-      <div className="flex px-3 gap-0.5 py-1.5 min-w-max">
+    <div
+      className="overflow-x-auto scrollbar-none"
+      style={{ borderTop: "1px solid var(--tn-border)" }}
+    >
+      <div className="flex px-3 gap-1 py-2 min-w-max">
         {races.map((race) => {
           const isActive = race.race_number === activeRaceNumber;
           const timeStr = race.start_time
@@ -25,15 +28,22 @@ export function RaceTabBar({ races }: RaceTabBarProps) {
             <button
               key={race.race_number}
               onClick={() => setActiveRaceNumber(race.race_number)}
-              className={`px-3 py-1.5 text-xs font-semibold rounded-md whitespace-nowrap transition-colors ${
-                isActive
-                  ? "bg-indigo-700 text-white"
-                  : "text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 hover:text-gray-900 dark:hover:text-white"
-              }`}
+              className="px-3 py-1.5 rounded-lg whitespace-nowrap transition-colors tn-mono text-xs"
+              style={{
+                background: isActive ? "var(--tn-accent-faint)" : "transparent",
+                color: isActive ? "var(--tn-accent)" : "var(--tn-text-faint)",
+                border: isActive ? "1px solid transparent" : "1px solid transparent",
+                fontWeight: isActive ? "600" : "400",
+              }}
             >
               AVD {race.race_number}
               {timeStr && (
-                <span className="ml-1 font-normal opacity-70">{timeStr}</span>
+                <span
+                  className="ml-1.5"
+                  style={{ opacity: 0.65, fontWeight: 400 }}
+                >
+                  {timeStr}
+                </span>
               )}
             </button>
           );

--- a/components/ResultsButton.tsx
+++ b/components/ResultsButton.tsx
@@ -17,14 +17,9 @@ export function ResultsButton({ gameId }: Props) {
     setLoading(true);
     setMessage(null);
     try {
-      const res = await fetch(`/api/games/${encodeURIComponent(gameId)}/results`, {
-        method: "POST",
-      });
+      const res = await fetch(`/api/games/${encodeURIComponent(gameId)}/results`, { method: "POST" });
       const data = await res.json();
-      if (res.status === 422) {
-        setMessage("Inga resultat tillgängliga ännu");
-        return;
-      }
+      if (res.status === 422) { setMessage("Inga resultat tillgängliga ännu"); return; }
       if (!res.ok) throw new Error(data.error ?? "Fel");
       setMessage(`Uppdaterade ${data.updated} hästar i ${data.races} avd`);
       router.refresh();
@@ -38,12 +33,19 @@ export function ResultsButton({ gameId }: Props) {
   return (
     <div className="flex items-center gap-2">
       {message && (
-        <span className="text-sm text-gray-500 dark:text-gray-400">{message}</span>
+        <span className="text-xs" style={{ color: "var(--tn-text-faint)" }}>{message}</span>
       )}
       <button
         onClick={handleFetch}
         disabled={!gameId || loading}
-        className="px-4 py-2 rounded-lg border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 text-sm font-semibold hover:border-indigo-500 dark:hover:border-indigo-400 hover:text-indigo-600 dark:hover:text-indigo-400 disabled:opacity-40 transition"
+        className="text-xs font-medium rounded-lg transition disabled:opacity-40"
+        style={{
+          padding: "5px 12px",
+          background: "var(--tn-bg-chip)",
+          border: "1px solid var(--tn-border)",
+          color: "var(--tn-text-dim)",
+          cursor: "pointer",
+        }}
       >
         {loading ? "Hämtar..." : "Hämta resultat"}
       </button>

--- a/components/SaveSystemDialog.tsx
+++ b/components/SaveSystemDialog.tsx
@@ -16,7 +16,6 @@ interface SaveSystemDialogProps {
   totalRows: number
   userGroups: Group[]
   defaultGroupId?: string | null
-  /** Om ett utkast redan finns — publicera det istället för att skapa nytt */
   existingDraftId?: string | null
 }
 
@@ -42,19 +41,12 @@ export function SaveSystemDialog({
   if (!open) return null
 
   function handleSave() {
-    if (!name.trim()) {
-      setError('Systemet måste ha ett namn.')
-      return
-    }
-    if (!gameId) {
-      setError('Inget spel valt.')
-      return
-    }
+    if (!name.trim()) { setError('Systemet måste ha ett namn.'); return }
+    if (!gameId) { setError('Inget spel valt.'); return }
     setError(null)
     startTransition(async () => {
       try {
         if (existingDraftId) {
-          // Publicera befintligt utkast
           await publishDraft(existingDraftId, name.trim(), groupId)
         } else {
           await createSystem(groupId, gameId, name.trim(), selections, totalRows)
@@ -72,28 +64,43 @@ export function SaveSystemDialog({
     router.push(`/system?game=${gameId}`)
   }
 
-  // Success-vy
+  const inputStyle: React.CSSProperties = {
+    background: "var(--tn-bg-chip)",
+    border: "1px solid var(--tn-border)",
+    color: "var(--tn-text)",
+    borderRadius: 8,
+    padding: "8px 12px",
+    fontSize: 14,
+    width: "100%",
+    outline: "none",
+  }
+
   if (savedName !== null) {
     return (
-      <div className="fixed inset-0 z-50 flex items-end sm:items-center justify-center bg-black/50">
-        <div className="bg-white dark:bg-gray-900 w-full sm:max-w-md rounded-t-2xl sm:rounded-2xl p-6 pb-[calc(1.5rem+4rem)] sm:pb-6 shadow-xl">
+      <div className="fixed inset-0 z-50 flex items-end sm:items-center justify-center" style={{ background: "rgba(0,0,0,0.6)" }}>
+        <div
+          className="w-full sm:max-w-md rounded-t-2xl sm:rounded-2xl p-6 pb-[calc(1.5rem+4rem)] sm:pb-6 shadow-xl"
+          style={{ background: "var(--tn-bg-raised)", border: "1px solid var(--tn-border)" }}
+        >
           <div className="text-center mb-5">
-            <div className="text-3xl mb-2">✅</div>
-            <h2 className="text-lg font-bold text-gray-900 dark:text-white">System sparat!</h2>
-            <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
+            <p className="tn-eyebrow mb-2">Klart</p>
+            <h2 className="text-lg font-bold mb-1" style={{ color: "var(--tn-text)" }}>System sparat!</h2>
+            <p className="text-sm" style={{ color: "var(--tn-text-faint)" }}>
               &ldquo;{savedName}&rdquo; &mdash; {totalRows} {totalRows === 1 ? 'rad' : 'rader'} &middot; {formatRowCost(totalRows, gameType ?? '')}
             </p>
           </div>
           <div className="flex gap-3">
             <button
               onClick={onSaved}
-              className="flex-1 px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 bg-gray-100 dark:bg-gray-800 rounded-lg hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors"
+              className="flex-1 px-4 py-2 text-sm font-medium rounded-lg transition-colors"
+              style={{ background: "var(--tn-bg-chip)", color: "var(--tn-text-dim)", border: "1px solid var(--tn-border)" }}
             >
               Stäng
             </button>
             <button
               onClick={handleGoToSystem}
-              className="flex-1 px-4 py-2 text-sm font-bold text-white bg-emerald-600 hover:bg-emerald-700 rounded-lg transition-colors"
+              className="flex-1 px-4 py-2 text-sm font-bold rounded-lg transition-colors"
+              style={{ background: "var(--tn-accent)", color: "#fff", border: "none", cursor: "pointer" }}
             >
               Se systemet →
             </button>
@@ -103,38 +110,36 @@ export function SaveSystemDialog({
     )
   }
 
-  // Sparavy
   return (
-    <div className="fixed inset-0 z-50 flex items-end sm:items-center justify-center bg-black/50">
-      <div className="bg-white dark:bg-gray-900 w-full sm:max-w-md rounded-t-2xl sm:rounded-2xl p-6 pb-[calc(1.5rem+4rem)] sm:pb-6 shadow-xl">
-        <h2 className="text-lg font-bold mb-4 text-gray-900 dark:text-white">Spara system</h2>
+    <div className="fixed inset-0 z-50 flex items-end sm:items-center justify-center" style={{ background: "rgba(0,0,0,0.6)" }}>
+      <div
+        className="w-full sm:max-w-md rounded-t-2xl sm:rounded-2xl p-6 pb-[calc(1.5rem+4rem)] sm:pb-6 shadow-xl"
+        style={{ background: "var(--tn-bg-raised)", border: "1px solid var(--tn-border)" }}
+      >
+        <h2 className="text-lg font-bold mb-4" style={{ color: "var(--tn-text)" }}>Spara system</h2>
 
         <div className="mb-4">
-          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-            Systemnamn
-          </label>
+          <label className="block text-sm font-medium mb-1" style={{ color: "var(--tn-text-dim)" }}>Systemnamn</label>
           <input
             type="text"
             value={name}
             onChange={e => setName(e.target.value)}
             maxLength={100}
-            className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-white text-sm focus:outline-none focus:ring-2 focus:ring-emerald-500"
+            style={inputStyle}
           />
         </div>
 
         <div className="mb-4">
-          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-            Sällskap
-          </label>
+          <label className="block text-sm font-medium mb-1" style={{ color: "var(--tn-text-dim)" }}>Sällskap</label>
           {userGroups.length === 0 ? (
-            <p className="text-sm text-gray-500 dark:text-gray-400">
+            <p className="text-sm" style={{ color: "var(--tn-text-faint)" }}>
               Privat system (du är inte med i något sällskap ännu)
             </p>
           ) : (
             <select
               value={groupId ?? ''}
               onChange={e => setGroupId(e.target.value || null)}
-              className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-white text-sm focus:outline-none focus:ring-2 focus:ring-emerald-500"
+              style={inputStyle}
             >
               <option value="">Privat — inget sällskap</option>
               {userGroups.map(g => (
@@ -144,30 +149,31 @@ export function SaveSystemDialog({
           )}
         </div>
 
-        <div className="mb-4 text-sm text-gray-500 dark:text-gray-400">
+        <div className="mb-4 text-sm" style={{ color: "var(--tn-text-faint)" }}>
           {totalRows} {totalRows === 1 ? 'rad' : 'rader'} &middot; {formatRowCost(totalRows, gameType ?? '')}
         </div>
 
         {!gameId && (
-          <p className="mb-3 text-sm text-amber-600 dark:text-amber-400">Inget spel valt.</p>
+          <p className="mb-3 text-sm" style={{ color: "var(--tn-warn)" }}>Inget spel valt.</p>
         )}
-
         {error && (
-          <p className="mb-3 text-sm text-red-600 dark:text-red-400">{error}</p>
+          <p className="mb-3 text-sm" style={{ color: "var(--tn-value-low)" }}>{error}</p>
         )}
 
         <div className="flex gap-3">
           <button
             onClick={onClose}
             disabled={isPending}
-            className="flex-1 px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 bg-gray-100 dark:bg-gray-800 rounded-lg hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors disabled:opacity-50"
+            className="flex-1 px-4 py-2 text-sm font-medium rounded-lg transition-colors disabled:opacity-50"
+            style={{ background: "var(--tn-bg-chip)", color: "var(--tn-text-dim)", border: "1px solid var(--tn-border)", cursor: "pointer" }}
           >
             Avbryt
           </button>
           <button
             onClick={handleSave}
             disabled={isPending || selections.length === 0 || !gameId}
-            className="flex-1 px-4 py-2 text-sm font-bold text-white bg-emerald-600 hover:bg-emerald-700 rounded-lg transition-colors disabled:opacity-50"
+            className="flex-1 px-4 py-2 text-sm font-bold rounded-lg transition-colors disabled:opacity-50"
+            style={{ background: "var(--tn-accent)", color: "#fff", border: "none", cursor: "pointer" }}
           >
             {isPending ? 'Sparar...' : 'Spara system'}
           </button>

--- a/components/StartCountdown.tsx
+++ b/components/StartCountdown.tsx
@@ -11,25 +11,14 @@ function getTimeLabel(startTime: string): { label: string; status: "upcoming" | 
   const now = new Date();
   const diffMs = start.getTime() - now.getTime();
 
-  if (diffMs <= 0) {
-    return { label: "Pågår", status: "started" };
-  }
+  if (diffMs <= 0) return { label: "Pågår", status: "started" };
 
   const diffMin = Math.floor(diffMs / 60000);
   const hours = Math.floor(diffMin / 60);
   const minutes = diffMin % 60;
 
-  if (hours > 0) {
-    return {
-      label: `Startar om ${hours} tim ${minutes} min`,
-      status: "upcoming",
-    };
-  }
-
-  return {
-    label: `Startar om ${minutes} min`,
-    status: minutes <= 15 ? "soon" : "upcoming",
-  };
+  if (hours > 0) return { label: `Startar om ${hours} tim ${minutes} min`, status: "upcoming" };
+  return { label: `Startar om ${minutes} min`, status: minutes <= 15 ? "soon" : "upcoming" };
 }
 
 export function StartCountdown({ startTime }: StartCountdownProps) {
@@ -38,25 +27,19 @@ export function StartCountdown({ startTime }: StartCountdownProps) {
 
   useEffect(() => {
     if (!startTime) return;
-
-    const interval = setInterval(() => {
-      setTimeInfo(getTimeLabel(startTime));
-    }, 60000);
-
+    const interval = setInterval(() => setTimeInfo(getTimeLabel(startTime)), 60000);
     return () => clearInterval(interval);
   }, [startTime]);
 
   if (!startTime || !timeInfo) return null;
 
-  const colorClass =
-    timeInfo.status === "started"
-      ? "text-green-600 dark:text-green-400"
-      : timeInfo.status === "soon"
-      ? "text-orange-500 dark:text-orange-400"
-      : "text-gray-500 dark:text-gray-400";
+  const color =
+    timeInfo.status === "started" ? "var(--tn-value-high)"
+    : timeInfo.status === "soon" ? "var(--tn-warn)"
+    : "var(--tn-text-faint)";
 
   return (
-    <span className={`text-xs font-medium ${colorClass}`}>
+    <span className="text-xs font-medium" style={{ color }}>
       {timeInfo.label}
     </span>
   );

--- a/components/SystemDrawer.tsx
+++ b/components/SystemDrawer.tsx
@@ -41,69 +41,62 @@ export function SystemDrawer({
   if (!open) return null;
 
   function isSelected(raceNumber: number, horseId: string): boolean {
-    return (
-      selections
-        .find((s) => s.race_number === raceNumber)
-        ?.horses.some((h) => h.horse_id === horseId) ?? false
-    );
+    return selections.find((s) => s.race_number === raceNumber)?.horses.some((h) => h.horse_id === horseId) ?? false;
   }
 
   const completedRaces = selections.length;
 
   return (
     <>
-      {/* Backdrop */}
+      <div className="fixed inset-0 z-40 md:hidden" style={{ background: "rgba(0,0,0,0.6)" }} onClick={onClose} />
       <div
-        className="fixed inset-0 bg-black/50 z-40 md:hidden"
-        onClick={onClose}
-      />
-      {/* Panel */}
-      <div role="dialog" aria-modal="true" className="fixed bottom-0 left-0 right-0 z-50 md:hidden bg-gray-900 rounded-t-2xl max-h-[70vh] flex flex-col">
-        {/* Drag handle */}
+        role="dialog"
+        aria-modal="true"
+        className="fixed bottom-0 left-0 right-0 z-50 md:hidden rounded-t-2xl max-h-[70vh] flex flex-col"
+        style={{ background: "var(--tn-bg-raised)", border: "1px solid var(--tn-border)" }}
+      >
         <div className="flex justify-center pt-3 pb-1 flex-shrink-0">
-          <div className="w-8 h-1 rounded-full bg-gray-700" />
+          <div className="w-8 h-1 rounded-full" style={{ background: "var(--tn-border-strong)" }} />
         </div>
-        {/* Header */}
-        <div className="flex items-center justify-between px-4 py-2 border-b border-gray-800 flex-shrink-0">
-          <span className="font-bold text-sm text-white">🎯 Din kupong</span>
+
+        <div
+          className="flex items-center justify-between px-4 py-2 flex-shrink-0"
+          style={{ borderBottom: "1px solid var(--tn-border)" }}
+        >
+          <span className="tn-eyebrow">Din kupong</span>
           <button
             onClick={onClose}
             aria-label="Stäng"
-            className="text-gray-400 hover:text-white text-lg leading-none transition"
+            className="text-lg leading-none transition"
+            style={{ color: "var(--tn-text-faint)", background: "none", border: "none", cursor: "pointer" }}
           >
             ✕
           </button>
         </div>
-        {/* Races */}
+
         <div className="flex-1 overflow-y-auto px-4 py-3 space-y-4">
           {races.map((race) => {
-            const sorted = [...race.starters].sort(
-              (a, b) => a.start_number - b.start_number
-            );
+            const sorted = [...race.starters].sort((a, b) => a.start_number - b.start_number);
             return (
               <div key={race.id}>
-                <div className="text-[10px] uppercase tracking-wide font-semibold text-gray-500 mb-1.5">
-                  Avd {race.race_number} · {race.distance}m
-                </div>
+                <div className="tn-eyebrow mb-1.5">Avd {race.race_number} · {race.distance}m</div>
                 <div className="flex flex-wrap gap-1.5">
                   {sorted.map((starter) => {
                     const selected = isSelected(race.race_number, starter.horse_id);
                     return (
                       <button
                         key={starter.horse_id}
-                        onClick={() =>
-                          onToggleHorse(race.race_number, {
-                            horse_id: starter.horse_id,
-                            start_number: starter.start_number,
-                            horse_name: starter.horses?.name ?? "",
-                          })
-                        }
+                        onClick={() => onToggleHorse(race.race_number, {
+                          horse_id: starter.horse_id,
+                          start_number: starter.start_number,
+                          horse_name: starter.horses?.name ?? "",
+                        })}
                         title={starter.horses?.name ?? `Nr ${starter.start_number}`}
-                        className={`w-[30px] h-[30px] rounded-full flex items-center justify-center text-sm font-bold transition-colors ${
-                          selected
-                            ? "bg-emerald-500 text-white ring-2 ring-emerald-300"
-                            : "bg-gray-700 text-gray-400 hover:bg-emerald-900 hover:text-emerald-400"
-                        }`}
+                        className="w-[30px] h-[30px] rounded-full flex items-center justify-center text-sm font-bold transition-colors"
+                        style={selected
+                          ? { background: "var(--tn-accent)", color: "#fff", outline: "2px solid var(--tn-accent-soft)", outlineOffset: 1 }
+                          : { background: "var(--tn-bg-chip)", color: "var(--tn-text-faint)" }
+                        }
                       >
                         {starter.start_number}
                       </button>
@@ -114,29 +107,34 @@ export function SystemDrawer({
             );
           })}
         </div>
-        {/* Footer */}
-        <div className="px-4 py-3 border-t-2 border-emerald-500 flex-shrink-0">
+
+        <div
+          className="px-4 py-3 flex-shrink-0"
+          style={{ borderTop: "2px solid var(--tn-accent)" }}
+        >
           <div className="flex items-baseline justify-between mb-1">
-            <span className="text-lg font-extrabold text-emerald-400">
+            <span className="text-lg font-extrabold" style={{ color: "var(--tn-accent)" }}>
               {totalRows} {totalRows === 1 ? "rad" : "rader"}
             </span>
-            <span className="text-xs text-gray-500">
+            <span className="text-xs" style={{ color: "var(--tn-text-faint)" }}>
               {totalRows > 0 ? formatRowCost(totalRows, gameType ?? "") : "–"}
             </span>
           </div>
-          <div className="text-xs text-gray-500 mb-2">
+          <div className="text-xs mb-2" style={{ color: "var(--tn-text-faint)" }}>
             {completedRaces} av {races.length} avd. klara
           </div>
           <button
             onClick={onSave}
             disabled={selections.length === 0}
-            className="w-full py-2 bg-emerald-500 hover:bg-emerald-400 text-white text-sm font-bold rounded-lg disabled:opacity-40 transition"
+            className="w-full py-2 text-sm font-bold rounded-lg disabled:opacity-40 transition"
+            style={{ background: "var(--tn-accent)", color: "#fff", border: "none", cursor: "pointer" }}
           >
             Spara system →
           </button>
           <button
             onClick={onCancel}
-            className="w-full mt-2 text-xs text-gray-500 hover:text-gray-300 underline transition"
+            className="w-full mt-2 text-xs underline transition"
+            style={{ color: "var(--tn-text-faint)", background: "none", border: "none", cursor: "pointer" }}
           >
             Avbryt systemläge
           </button>

--- a/components/SystemSidebar.tsx
+++ b/components/SystemSidebar.tsx
@@ -45,62 +45,59 @@ export function SystemSidebar({
   onLoadDraft,
 }: SystemSidebarProps) {
   function isSelected(raceNumber: number, horseId: string): boolean {
-    return (
-      selections
-        .find((s) => s.race_number === raceNumber)
-        ?.horses.some((h) => h.horse_id === horseId) ?? false
-    );
+    return selections.find((s) => s.race_number === raceNumber)?.horses.some((h) => h.horse_id === horseId) ?? false;
   }
 
   const completedRaces = selections.length;
 
   return (
-    <aside className="hidden md:flex flex-col fixed right-0 top-[170px] bottom-0 z-40 w-[320px] border-l border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900">
-      {/* Header */}
-      <div className="px-3 py-3 border-b border-gray-200 dark:border-gray-800 flex-shrink-0">
-        <div className="font-bold text-sm text-gray-900 dark:text-white">
-          🎯 Din kupong
-        </div>
+    <aside
+      className="hidden md:flex flex-col fixed right-0 top-[170px] bottom-0 z-40 w-[320px]"
+      style={{ background: "var(--tn-bg-raised)", borderLeft: "1px solid var(--tn-border)" }}
+    >
+      <div
+        className="px-3 py-3 flex-shrink-0"
+        style={{ borderBottom: "1px solid var(--tn-border)" }}
+      >
+        <div className="tn-eyebrow mb-1.5">Din kupong</div>
         <input
           type="text"
           value={draftName}
           onChange={(e) => onDraftNameChange(e.target.value)}
           placeholder="Namnge utkast..."
           maxLength={80}
-          className="mt-1.5 w-full px-2 py-1 text-xs bg-gray-100 dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded text-gray-700 dark:text-gray-300 focus:outline-none focus:border-indigo-400"
+          className="w-full px-2 py-1 text-xs rounded outline-none"
+          style={{
+            background: "var(--tn-bg-chip)",
+            border: "1px solid var(--tn-border)",
+            color: "var(--tn-text)",
+          }}
         />
       </div>
 
-      {/* Races */}
       <div className="flex-1 overflow-y-auto px-3 py-2 space-y-4">
         {races.map((race) => {
-          const sorted = [...race.starters].sort(
-            (a, b) => a.start_number - b.start_number
-          );
+          const sorted = [...race.starters].sort((a, b) => a.start_number - b.start_number);
           return (
             <div key={race.id}>
-              <div className="text-[10px] uppercase tracking-wide font-semibold text-gray-400 dark:text-gray-500 mb-1.5">
-                Avd {race.race_number} · {race.distance}m
-              </div>
+              <div className="tn-eyebrow mb-1.5">Avd {race.race_number} · {race.distance}m</div>
               <div className="flex flex-wrap gap-1">
                 {sorted.map((starter) => {
                   const selected = isSelected(race.race_number, starter.horse_id);
                   return (
                     <button
                       key={starter.horse_id}
-                      onClick={() =>
-                        onToggleHorse(race.race_number, {
-                          horse_id: starter.horse_id,
-                          start_number: starter.start_number,
-                          horse_name: starter.horses?.name ?? "",
-                        })
-                      }
+                      onClick={() => onToggleHorse(race.race_number, {
+                        horse_id: starter.horse_id,
+                        start_number: starter.start_number,
+                        horse_name: starter.horses?.name ?? "",
+                      })}
                       title={starter.horses?.name ?? `Nr ${starter.start_number}`}
-                      className={`w-[26px] h-[26px] rounded-full flex items-center justify-center text-xs font-bold transition-colors ${
-                        selected
-                          ? "bg-emerald-500 text-white ring-2 ring-emerald-300"
-                          : "bg-gray-200 dark:bg-gray-700 text-gray-600 dark:text-gray-400 hover:bg-emerald-100 dark:hover:bg-emerald-900 hover:text-emerald-700 dark:hover:text-emerald-400"
-                      }`}
+                      className="w-[26px] h-[26px] rounded-full flex items-center justify-center text-xs font-bold transition-colors"
+                      style={selected
+                        ? { background: "var(--tn-accent)", color: "#fff", outline: "2px solid var(--tn-accent-soft)", outlineOffset: 1 }
+                        : { background: "var(--tn-bg-chip)", color: "var(--tn-text-faint)" }
+                      }
                     >
                       {starter.start_number}
                     </button>
@@ -111,22 +108,21 @@ export function SystemSidebar({
           );
         })}
 
-        {/* Sparade utkast */}
         {savedDrafts.length > 0 && (
-          <div className="border-t border-gray-200 dark:border-gray-800 pt-3 mt-2">
-            <p className="text-[10px] uppercase tracking-wide font-semibold text-gray-400 dark:text-gray-500 mb-2">
-              Mina utkast
-            </p>
+          <div className="pt-3 mt-2" style={{ borderTop: "1px solid var(--tn-border)" }}>
+            <p className="tn-eyebrow mb-2">Mina utkast</p>
             {savedDrafts.map((draft) => (
               <button
                 key={draft.id}
                 onClick={() => onLoadDraft?.(draft)}
-                className="w-full text-left px-2 py-1.5 rounded text-xs text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800 transition mb-1"
+                className="w-full text-left px-2 py-1.5 rounded text-xs transition mb-1"
+                style={{ color: "var(--tn-text-dim)", background: "none", border: "none", cursor: "pointer" }}
+                onMouseEnter={(e) => { e.currentTarget.style.background = "var(--tn-bg-card)"; }}
+                onMouseLeave={(e) => { e.currentTarget.style.background = "none"; }}
               >
-                <span className="font-semibold">{draft.name}</span>
-                <span className="text-gray-400 dark:text-gray-500 ml-2">
-                  {draft.total_rows} rader ·{" "}
-                  {new Date(draft.created_at).toLocaleDateString("sv-SE")}
+                <span className="font-semibold" style={{ color: "var(--tn-text)" }}>{draft.name}</span>
+                <span className="ml-2" style={{ color: "var(--tn-text-faint)" }}>
+                  {draft.total_rows} rader · {new Date(draft.created_at).toLocaleDateString("sv-SE")}
                 </span>
               </button>
             ))}
@@ -134,37 +130,41 @@ export function SystemSidebar({
         )}
       </div>
 
-      {/* Footer */}
-      <div className="px-3 py-3 border-t-2 border-emerald-500 flex-shrink-0">
+      <div
+        className="px-3 py-3 flex-shrink-0"
+        style={{ borderTop: "2px solid var(--tn-accent)" }}
+      >
         <div className="flex items-baseline justify-between mb-1">
-          <span className="text-lg font-extrabold text-emerald-500">
+          <span className="text-lg font-extrabold" style={{ color: "var(--tn-accent)" }}>
             {totalRows} {totalRows === 1 ? "rad" : "rader"}
           </span>
-          <span className="text-xs text-gray-500 dark:text-gray-400">
+          <span className="text-xs" style={{ color: "var(--tn-text-faint)" }}>
             {totalRows > 0 ? formatRowCost(totalRows, gameType ?? "") : "–"}
           </span>
         </div>
         <div className="flex items-center justify-between mb-2">
-          <span className="text-xs text-gray-400 dark:text-gray-500">
+          <span className="text-xs" style={{ color: "var(--tn-text-faint)" }}>
             {completedRaces} av {races.length} avd. klara
           </span>
           {draftSaveStatus === "saving" && (
-            <span className="text-xs text-gray-500">Sparar utkast...</span>
+            <span className="text-xs" style={{ color: "var(--tn-text-faint)" }}>Sparar utkast...</span>
           )}
           {draftSaveStatus === "saved" && (
-            <span className="text-xs text-emerald-500">Utkast sparat ✓</span>
+            <span className="text-xs" style={{ color: "var(--tn-value-high)" }}>Utkast sparat ✓</span>
           )}
         </div>
         <button
           onClick={onSave}
           disabled={selections.length === 0}
-          className="w-full py-2 bg-emerald-500 hover:bg-emerald-400 text-white text-sm font-bold rounded-lg disabled:opacity-40 transition"
+          className="w-full py-2 text-sm font-bold rounded-lg disabled:opacity-40 transition"
+          style={{ background: "var(--tn-accent)", color: "#fff", border: "none", cursor: "pointer" }}
         >
           Spara system →
         </button>
         <button
           onClick={onCancel}
-          className="w-full mt-2 text-xs text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 underline transition"
+          className="w-full mt-2 text-xs underline transition"
+          style={{ color: "var(--tn-text-faint)", background: "none", border: "none", cursor: "pointer" }}
         >
           Avbryt systemläge
         </button>

--- a/components/SystemsPageClient.tsx
+++ b/components/SystemsPageClient.tsx
@@ -49,11 +49,9 @@ export function SystemsPageClient({
     setSystems(prev => prev.filter(s => s.id !== id))
   }
 
-  // Dela upp i utkast och sparade system
   const myDrafts = systems.filter(s => s.is_draft && s.user_id === currentUserId)
   const savedSystems = systems.filter(s => !s.is_draft)
 
-  // Sortering sparade: egna först, sedan per sällskapsnamn A-Ö, sedan created_at desc
   const sortedSaved = [...savedSystems].sort((a, b) => {
     if (a.user_id === currentUserId && b.user_id !== currentUserId) return -1
     if (a.user_id !== currentUserId && b.user_id === currentUserId) return 1
@@ -67,12 +65,17 @@ export function SystemsPageClient({
 
   return (
     <div className="px-4 py-4 max-w-2xl mx-auto">
-      {/* Omgångsväljare */}
       <div className="mb-6">
         <select
           value={selectedGameId ?? ''}
           onChange={e => handleGameChange(e.target.value)}
-          className="w-full text-sm px-3 py-2 border border-gray-200 dark:border-gray-700 rounded-lg bg-white dark:bg-gray-900 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-emerald-500"
+          className="w-full text-sm rounded-lg outline-none"
+          style={{
+            padding: "8px 12px",
+            background: "var(--tn-bg-chip)",
+            border: "1px solid var(--tn-border)",
+            color: "var(--tn-text)",
+          }}
         >
           {games.map(g => (
             <option key={g.id} value={g.id}>
@@ -83,14 +86,13 @@ export function SystemsPageClient({
       </div>
 
       {loading ? (
-        <div className="text-center py-10 text-gray-400 text-sm">Laddar system...</div>
+        <div className="text-center py-10 text-sm" style={{ color: "var(--tn-text-faint)" }}>Laddar system...</div>
       ) : (
         <>
-          {/* Mina utkast */}
           {myDrafts.length > 0 && (
             <section className="mb-8">
-              <h2 className="text-sm font-semibold text-amber-600 dark:text-amber-400 uppercase tracking-wide mb-3 flex items-center gap-2">
-                <span>✏️</span> Mina utkast
+              <h2 className="tn-eyebrow mb-3" style={{ color: "var(--tn-warn)" }}>
+                Mina utkast
               </h2>
               <div className="flex flex-col gap-4">
                 {myDrafts.map(system => (
@@ -108,13 +110,10 @@ export function SystemsPageClient({
             </section>
           )}
 
-          {/* Sparade system */}
           {sortedSaved.length > 0 && (
             <section>
               {myDrafts.length > 0 && (
-                <h2 className="text-sm font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-3">
-                  Sparade system
-                </h2>
+                <h2 className="tn-eyebrow mb-3">Sparade system</h2>
               )}
               <div className="flex flex-col gap-4">
                 {sortedSaved.map(system => (
@@ -132,9 +131,8 @@ export function SystemsPageClient({
             </section>
           )}
 
-          {/* Tomt tillstånd */}
           {myDrafts.length === 0 && sortedSaved.length === 0 && (
-            <div className="text-center py-16 text-gray-400 dark:text-gray-500">
+            <div className="text-center py-16" style={{ color: "var(--tn-text-faint)" }}>
               <p className="text-base mb-1">Inga system sparade för denna omgång.</p>
               <p className="text-sm">Gå till Analys-fliken och klicka &ldquo;Bygg system&rdquo;.</p>
             </div>

--- a/components/ThemeProvider.tsx
+++ b/components/ThemeProvider.tsx
@@ -19,14 +19,14 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
     const stored = localStorage.getItem("theme") as Theme | null;
     const initial = stored ?? "dark";
     setTheme(initial);
-    document.documentElement.classList.toggle("dark", initial === "dark");
+    applyTheme(initial);
   }, []);
 
   function toggle() {
     setTheme((t) => {
       const next = t === "dark" ? "light" : "dark";
       localStorage.setItem("theme", next);
-      document.documentElement.classList.toggle("dark", next === "dark");
+      applyTheme(next);
       return next;
     });
   }
@@ -36,4 +36,12 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
       {children}
     </ThemeContext.Provider>
   );
+}
+
+function applyTheme(theme: Theme) {
+  const root = document.documentElement;
+  root.setAttribute("data-theme", theme);
+  // Keep dark class in sync for Tailwind dark: variants
+  root.classList.toggle("dark", theme === "dark");
+  root.classList.toggle("light", theme === "light");
 }

--- a/components/ThemeToggle.tsx
+++ b/components/ThemeToggle.tsx
@@ -8,27 +8,21 @@ export function ThemeToggle() {
     <button
       onClick={toggle}
       title={theme === "dark" ? "Byt till ljust läge" : "Byt till mörkt läge"}
-      className="w-9 h-9 rounded-full flex items-center justify-center transition
-        bg-gray-200 hover:bg-gray-300 text-gray-700
-        dark:bg-gray-700 dark:hover:bg-gray-600 dark:text-gray-200"
+      className="w-9 h-9 rounded-full flex items-center justify-center transition-colors"
+      style={{
+        background: "var(--tn-bg-chip)",
+        border: "1px solid var(--tn-border)",
+        color: "var(--tn-text-dim)",
+      }}
     >
       {theme === "dark" ? (
-        /* Sun icon */
-        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-          <circle cx="12" cy="12" r="5" />
-          <line x1="12" y1="1" x2="12" y2="3" />
-          <line x1="12" y1="21" x2="12" y2="23" />
-          <line x1="4.22" y1="4.22" x2="5.64" y2="5.64" />
-          <line x1="18.36" y1="18.36" x2="19.78" y2="19.78" />
-          <line x1="1" y1="12" x2="3" y2="12" />
-          <line x1="21" y1="12" x2="23" y2="12" />
-          <line x1="4.22" y1="19.78" x2="5.64" y2="18.36" />
-          <line x1="18.36" y1="5.64" x2="19.78" y2="4.22" />
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
+          <circle cx="12" cy="12" r="4" />
+          <path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4" />
         </svg>
       ) : (
-        /* Moon icon */
-        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-          <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8z" />
         </svg>
       )}
     </button>

--- a/components/TopFiveRanking.tsx
+++ b/components/TopFiveRanking.tsx
@@ -36,30 +36,18 @@ interface TopFiveRankingProps {
   onHorseClick?: (raceNumber: number, startNumber: number) => void;
 }
 
-const MEDAL_COLORS = [
-  "bg-yellow-500 text-white",
-  "bg-gray-400 text-white",
-  "bg-amber-700 text-white",
-  "bg-indigo-600 text-white",
-  "bg-indigo-600 text-white",
-];
-
 export function TopFiveRanking({ races, onHorseClick }: TopFiveRankingProps) {
   const [collapsed, setCollapsed] = useState(false);
 
   const allHorses: RankedHorse[] = [];
-
   for (const race of races) {
     for (const s of race.starters) {
       const cs = s.formscore ?? 0;
       if (cs === 0) continue;
-
-      // Beräkna om hästen är ett värde: CS > 55 och positivt spelvärde
       const totalCS = race.starters.reduce((sum, st) => sum + (st.formscore ?? 0), 0);
       const calcPct = totalCS > 0 ? (cs / totalCS) * 100 : 0;
       const streckPct = s.bet_distribution ?? 0;
       const isValue = cs > 55 && streckPct > 0 && calcPct > streckPct;
-
       allHorses.push({
         horseName: s.horses?.name ?? `Nr ${s.start_number}`,
         startNumber: s.start_number,
@@ -78,86 +66,110 @@ export function TopFiveRanking({ races, onHorseClick }: TopFiveRankingProps) {
   allHorses.sort((a, b) => b.compositeScore - a.compositeScore);
   const top5 = allHorses.slice(0, 5);
 
+  const rankColors = [
+    { color: "var(--tn-p1)", bg: "rgba(251,191,36,0.15)", textColor: "#0a0e14" },
+    { color: "var(--tn-p2)", bg: "rgba(148,163,184,0.15)", textColor: "#0a0e14" },
+    { color: "var(--tn-p3)", bg: "rgba(180,83,9,0.15)", textColor: "#fff" },
+    { color: "var(--tn-accent)", bg: "var(--tn-accent-faint)", textColor: "var(--tn-accent)" },
+    { color: "var(--tn-accent)", bg: "var(--tn-accent-faint)", textColor: "var(--tn-accent)" },
+  ];
+
   return (
-    <div className="mb-6 bg-indigo-50 dark:bg-indigo-950/40 border border-indigo-200 dark:border-indigo-800/40 rounded-xl overflow-hidden md:max-w-[45%]">
-      <div className="px-5 py-3 border-b border-indigo-200 dark:border-indigo-800/30 flex items-center justify-between">
+    <div
+      className="mb-4 rounded-xl overflow-hidden md:max-w-[45%]"
+      style={{ background: "var(--tn-bg-card)", border: "1px solid var(--tn-border)" }}
+    >
+      <div
+        className="px-4 py-3 flex items-center justify-between"
+        style={{ borderBottom: collapsed ? "none" : "1px solid var(--tn-border)" }}
+      >
         <div>
-          <h2 className="text-sm font-semibold text-indigo-700 dark:text-indigo-300 uppercase tracking-wide">
-            Top 5 spelvärda hästar
-          </h2>
+          <p className="tn-eyebrow mb-0.5">Top 5 — Composite Score</p>
           {!collapsed && (
-            <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
-              Rankad efter Composite Score (CS) — form, tid, odds, konsistens, distans och spår
+            <p className="text-xs" style={{ color: "var(--tn-text-faint)" }}>
+              Rankad efter CS — form, tid, odds, konsistens, distans och spår
             </p>
           )}
         </div>
         <button
           onClick={() => setCollapsed((v) => !v)}
-          className="ml-3 shrink-0 text-xs text-indigo-500 dark:text-indigo-400 hover:text-indigo-700 dark:hover:text-indigo-300 transition"
-          aria-label={collapsed ? "Expandera Top 5" : "Minimera Top 5"}
+          className="tn-mono text-xs ml-3 shrink-0 transition-colors"
+          style={{ color: "var(--tn-text-faint)", background: "none", border: "none", cursor: "pointer" }}
         >
-          {collapsed ? "▼ Visa" : "▲ Dölj"}
+          {collapsed ? "▼ VISA" : "▲ DÖLJ"}
         </button>
       </div>
 
       {!collapsed && (
-        <div className="divide-y divide-indigo-200 dark:divide-indigo-900/30">
-          {top5.map((horse, i) => (
-            <div
-              key={`${horse.raceNumber}-${horse.startNumber}`}
-              onClick={() => onHorseClick?.(horse.raceNumber, horse.startNumber)}
-              className={`flex items-center gap-3 px-5 py-3 hover:bg-indigo-100 dark:hover:bg-indigo-950/30 transition ${onHorseClick ? "cursor-pointer" : ""}`}
-            >
-              <span
-                className={`w-6 h-6 rounded-full flex items-center justify-center text-xs font-bold shrink-0 ${MEDAL_COLORS[i]}`}
+        <div>
+          {top5.map((horse, i) => {
+            const rank = rankColors[i];
+            const finishStyle: React.CSSProperties =
+              horse.finish_position === 1 ? { background: "var(--tn-p1)", color: "#0a0e14" }
+              : horse.finish_position === 2 ? { background: "var(--tn-p2)", color: "#0a0e14" }
+              : horse.finish_position === 3 ? { background: "var(--tn-p3)", color: "#fff" }
+              : horse.finish_position != null ? { background: "var(--tn-bg-chip)", color: "var(--tn-text-dim)" }
+              : {};
+
+            return (
+              <div
+                key={`${horse.raceNumber}-${horse.startNumber}`}
+                onClick={() => onHorseClick?.(horse.raceNumber, horse.startNumber)}
+                className="flex items-center gap-3 px-4 py-3 transition-colors"
+                style={{
+                  borderBottom: i < top5.length - 1 ? "1px solid var(--tn-border)" : "none",
+                  cursor: onHorseClick ? "pointer" : "default",
+                  background: "transparent",
+                }}
+                onMouseEnter={(e) => { if (onHorseClick) e.currentTarget.style.background = "var(--tn-bg-card-hover)"; }}
+                onMouseLeave={(e) => { e.currentTarget.style.background = "transparent"; }}
               >
-                {i + 1}
-              </span>
-
-              <div className="flex-1 min-w-0">
-                <div className="flex items-center gap-2 flex-wrap">
-                  <span className="font-semibold text-gray-900 dark:text-white text-sm truncate">
-                    {horse.horseName}
-                  </span>
-                  {horse.isValue && (
-                    <span className="text-xs bg-green-100 dark:bg-green-900/60 text-green-700 dark:text-green-300 border border-green-300 dark:border-green-700/50 px-1.5 py-0.5 rounded font-medium shrink-0">
-                      Värde
-                    </span>
-                  )}
-                </div>
-                <span className="text-xs text-gray-500 dark:text-gray-400">
-                  Avd {horse.raceNumber} &middot; Nr {horse.startNumber}
-                  {horse.odds ? ` · Odds ${horse.odds}` : ""}
-                </span>
-              </div>
-
-              {horse.finish_position != null && (
+                {/* Rank badge */}
                 <span
-                  className={`text-xs font-bold px-2 py-1 rounded-full shrink-0 ${
-                    horse.finish_position === 1
-                      ? "bg-yellow-400 text-black"
-                      : horse.finish_position === 2
-                      ? "bg-gray-300 text-black"
-                      : horse.finish_position === 3
-                      ? "bg-amber-600 text-white"
-                      : "bg-gray-500 text-white"
-                  }`}
-                  title={`Slutplacering: ${horse.finish_position}`}
+                  className="tn-mono w-6 h-6 rounded-full flex items-center justify-center text-xs font-bold shrink-0"
+                  style={{ background: rank.bg, color: rank.textColor === "#0a0e14" ? rank.color : rank.textColor }}
                 >
-                  {horse.finish_position}:a{horse.finish_time ? ` ${horse.finish_time}` : ""}
+                  {i + 1}
                 </span>
-              )}
 
-              <div className="text-right shrink-0">
-                <div className="text-sm font-bold text-indigo-600 dark:text-indigo-400">
-                  {horse.compositeScore}
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2 flex-wrap">
+                    <span className="font-semibold text-sm truncate" style={{ color: "var(--tn-text)" }}>
+                      {horse.horseName}
+                    </span>
+                    {horse.isValue && (
+                      <span
+                        className="tn-mono text-[9px] font-bold px-1.5 py-0.5 rounded shrink-0"
+                        style={{ background: "var(--tn-value-high-bg)", color: "var(--tn-value-high)", letterSpacing: "0.08em" }}
+                      >
+                        VÄRDE
+                      </span>
+                    )}
+                  </div>
+                  <span className="tn-mono text-[11px]" style={{ color: "var(--tn-text-faint)" }}>
+                    Avd {horse.raceNumber} · Nr {horse.startNumber}
+                    {horse.odds ? ` · ${horse.odds}x` : ""}
+                  </span>
                 </div>
-                <div className="text-xs text-gray-500 dark:text-gray-400">
-                  CS
+
+                {horse.finish_position != null && (
+                  <span
+                    className="tn-mono text-xs font-bold px-2 py-0.5 rounded-full shrink-0"
+                    style={finishStyle}
+                  >
+                    {horse.finish_position}:a{horse.finish_time ? ` ${horse.finish_time}` : ""}
+                  </span>
+                )}
+
+                <div className="text-right shrink-0">
+                  <div className="tn-mono text-sm font-bold" style={{ color: "var(--tn-accent)" }}>
+                    {horse.compositeScore}
+                  </div>
+                  <div className="tn-eyebrow" style={{ fontSize: 9 }}>CS</div>
                 </div>
               </div>
-            </div>
-          ))}
+            );
+          })}
         </div>
       )}
     </div>

--- a/components/TopNav.tsx
+++ b/components/TopNav.tsx
@@ -5,7 +5,7 @@ import { getProfile, getMyGroups } from "@/lib/actions/groups";
 import { createClient } from "@/lib/supabase/server";
 
 const tabs = [
-  { label: "Analys", href: "/" },
+  { label: "Lopp", href: "/" },
   { label: "Utvärdering", href: "/evaluation" },
   { label: "System", href: "/system" },
   { label: "Manual", href: "/manual" },
@@ -28,11 +28,30 @@ export async function TopNav() {
   const isAdmin = user != null && adminIds.includes(user.id);
 
   return (
-    <nav className="hidden md:flex items-center sticky top-0 z-50 bg-white/90 dark:bg-gray-950/90 backdrop-blur-sm border-b border-gray-200 dark:border-gray-800 px-6 gap-6">
+    <nav
+      className="hidden md:flex items-center sticky top-0 z-50 px-6 gap-1"
+      style={{
+        background: "color-mix(in oklab, var(--tn-bg) 88%, transparent)",
+        backdropFilter: "blur(20px)",
+        WebkitBackdropFilter: "blur(20px)",
+        borderBottom: "1px solid var(--tn-border)",
+      }}
+    >
+      {/* Brand */}
+      <div className="flex items-baseline gap-2 mr-6 py-3">
+        <span className="tn-brand-mark text-xl">Travappen</span>
+        <span
+          className="inline-block w-1.5 h-1.5 rounded-full"
+          style={{ background: "var(--tn-accent)", transform: "translateY(-3px)" }}
+        />
+      </div>
+
+      {/* Nav tabs */}
       {tabs.map((tab) => (
         <NavActiveLink key={tab.href} href={tab.href} label={tab.label} />
       ))}
       {isAdmin && <NavActiveLink href="/admin" label="Admin" />}
+
       <div className="flex-1" />
       <div className="flex items-center gap-2 py-2">
         <ThemeToggle />

--- a/components/UsefulLinks.tsx
+++ b/components/UsefulLinks.tsx
@@ -17,56 +17,22 @@ interface LinkGroup {
 const LINK_GROUPS: LinkGroup[] = [
   {
     heading: "Populära sidor för gratis travtips",
-    intro:
-      "Dessa länkar går till samlingssidorna där de senaste tipsen alltid ligger överst.",
+    intro: "Dessa länkar går till samlingssidorna där de senaste tipsen alltid ligger överst.",
     links: [
-      {
-        href: "https://travstugan.se",
-        label: "Travstugan – V75/V85 Tips",
-        desc: "En av de mest heltäckande sidorna. Analyser från flera experter, ranking och färdiga systemförslag.",
-      },
-      {
-        href: "https://minandel.se",
-        label: "MinAndel – V85/V75 Tips",
-        desc: "Tips och ranking specifikt under V85/V75-kategorin. Brukar ha \"sista minuten\"-tips och genomgångar av spikar och skrällar.",
-      },
-      {
-        href: "https://travnet.se",
-        label: "Travnet – V75 Analyser",
-        desc: "Publicerar \"V75-panelen\" och \"Erlands Hörna\" varje vecka. Bra för djupgående statistik.",
-      },
-      {
-        href: "https://rekatochklart.se",
-        label: "Rekat och Klart – Trav",
-        desc: "Bettingsida där experter (t.ex. DrTrav) lägger upp gratis rekningar och system inför lördagarna.",
-      },
-      {
-        href: "https://trav.se",
-        label: "Trav.se – Systemförslag",
-        desc: "Erbjuder konkreta systemförslag och rankningar för varje avdelning.",
-      },
-      {
-        href: "https://travcash.se",
-        label: "Travcash – Tips & Analyser",
-        desc: "Tips, analyser och systemförslag inför V75, V86 och V85. Bra genomgångar med fokus på spelvärde.",
-      },
+      { href: "https://travstugan.se", label: "Travstugan – V75/V85 Tips", desc: "En av de mest heltäckande sidorna. Analyser från flera experter, ranking och färdiga systemförslag." },
+      { href: "https://minandel.se", label: "MinAndel – V85/V75 Tips", desc: "Tips och ranking specifikt under V85/V75-kategorin. Brukar ha \"sista minuten\"-tips och genomgångar av spikar och skrällar." },
+      { href: "https://travnet.se", label: "Travnet – V75 Analyser", desc: "Publicerar \"V75-panelen\" och \"Erlands Hörna\" varje vecka. Bra för djupgående statistik." },
+      { href: "https://rekatochklart.se", label: "Rekat och Klart – Trav", desc: "Bettingsida där experter (t.ex. DrTrav) lägger upp gratis rekningar och system inför lördagarna." },
+      { href: "https://trav.se", label: "Trav.se – Systemförslag", desc: "Erbjuder konkreta systemförslag och rankningar för varje avdelning." },
+      { href: "https://travcash.se", label: "Travcash – Tips & Analyser", desc: "Tips, analyser och systemförslag inför V75, V86 och V85. Bra genomgångar med fokus på spelvärde." },
     ],
   },
   {
     heading: "Tips från källan (ATG)",
-    intro:
-      "ATG själva har faktiskt några av de bästa gratistipsen om man vet var man ska leta:",
+    intro: "ATG själva har faktiskt några av de bästa gratistipsen om man vet var man ska leta:",
     links: [
-      {
-        href: "https://www.atg.se",
-        label: "Björnkollen (ATG Play)",
-        desc: "Stjärnkusken Björn Goops egna tankar. Sök på \"Björnkollen\" på ATG Play – publiceras oftast fredag kväll.",
-      },
-      {
-        href: "https://www.atg.se",
-        label: "Fem Tippar (ATG)",
-        desc: "Fyra experter och en gästtippare gör varsitt system. Klassisk läsning inför lördagen.",
-      },
+      { href: "https://www.atg.se", label: "Björnkollen (ATG Play)", desc: "Stjärnkusken Björn Goops egna tankar. Sök på \"Björnkollen\" på ATG Play – publiceras oftast fredag kväll." },
+      { href: "https://www.atg.se", label: "Fem Tippar (ATG)", desc: "Fyra experter och en gästtippare gör varsitt system. Klassisk läsning inför lördagen." },
     ],
   },
 ];
@@ -75,35 +41,38 @@ export function UsefulLinks() {
   const [open, setOpen] = useState(false);
 
   return (
-    <div className="border border-gray-200 dark:border-gray-800 rounded-xl overflow-hidden">
+    <div className="rounded-xl overflow-hidden" style={{ border: "1px solid var(--tn-border)" }}>
       <button
         onClick={() => setOpen(!open)}
-        className="w-full flex items-center justify-between px-5 py-3 bg-gray-50 dark:bg-gray-900 hover:bg-gray-100 dark:hover:bg-gray-800 transition text-left"
+        className="w-full flex items-center justify-between px-5 py-3 text-left transition"
+        style={{ background: "var(--tn-bg-card)", border: "none", cursor: "pointer" }}
+        onMouseEnter={(e) => { e.currentTarget.style.background = "var(--tn-bg-card-hover)"; }}
+        onMouseLeave={(e) => { e.currentTarget.style.background = "var(--tn-bg-card)"; }}
       >
         <div className="flex items-center gap-2">
-          <span className="text-base">&#128270;</span>
-          <span className="font-semibold text-gray-900 dark:text-white text-sm">
+          <span className="font-semibold text-sm" style={{ color: "var(--tn-text)" }}>
             Nyttiga länktips
           </span>
-          <span className="text-xs text-gray-500 dark:text-gray-400">
+          <span className="text-xs" style={{ color: "var(--tn-text-faint)" }}>
             Analyser, tips och systemförslag
           </span>
         </div>
-        <span className="text-gray-400 dark:text-gray-500 text-xs ml-2">
-          {open ? "▲" : "▼"}
-        </span>
+        <svg
+          width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+          strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"
+          className={`transition-transform duration-200 ml-2 ${open ? "rotate-180" : ""}`}
+          style={{ color: "var(--tn-text-faint)" }}
+        >
+          <path d="M6 9l6 6 6-6" />
+        </svg>
       </button>
 
       {open && (
-        <div className="px-5 py-4 space-y-6 bg-white dark:bg-gray-950">
+        <div className="px-5 py-4 space-y-6" style={{ background: "var(--tn-bg-raised)", borderTop: "1px solid var(--tn-border)" }}>
           {LINK_GROUPS.map((group) => (
             <div key={group.heading}>
-              <h3 className="font-semibold text-gray-900 dark:text-white text-sm mb-1">
-                {group.heading}
-              </h3>
-              <p className="text-xs text-gray-500 dark:text-gray-400 mb-3">
-                {group.intro}
-              </p>
+              <h3 className="font-semibold text-sm mb-1" style={{ color: "var(--tn-text)" }}>{group.heading}</h3>
+              <p className="text-xs mb-3" style={{ color: "var(--tn-text-faint)" }}>{group.intro}</p>
               <div className="space-y-2">
                 {group.links.map((link) => (
                   <a
@@ -111,22 +80,23 @@ export function UsefulLinks() {
                     href={link.href}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="flex items-start gap-3 p-3 rounded-lg border border-gray-200 dark:border-gray-800 hover:border-indigo-400 dark:hover:border-indigo-600 hover:bg-indigo-50 dark:hover:bg-indigo-900/20 transition group"
+                    className="flex items-start gap-3 p-3 rounded-lg transition group"
+                    style={{ border: "1px solid var(--tn-border)", display: "flex" }}
+                    onMouseEnter={(e) => {
+                      e.currentTarget.style.borderColor = "var(--tn-accent-soft)";
+                      e.currentTarget.style.background = "var(--tn-accent-faint)";
+                    }}
+                    onMouseLeave={(e) => {
+                      e.currentTarget.style.borderColor = "var(--tn-border)";
+                      e.currentTarget.style.background = "transparent";
+                    }}
                   >
-                    <span className="text-indigo-500 dark:text-indigo-400 mt-0.5 shrink-0">
-                      &#128279;
-                    </span>
+                    <span className="mt-0.5 shrink-0" style={{ color: "var(--tn-accent)" }}>&#128279;</span>
                     <div className="min-w-0">
-                      <p className="text-sm font-medium text-indigo-700 dark:text-indigo-300 group-hover:underline">
-                        {link.label}
-                      </p>
-                      <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5 leading-relaxed">
-                        {link.desc}
-                      </p>
+                      <p className="text-sm font-medium" style={{ color: "var(--tn-accent)" }}>{link.label}</p>
+                      <p className="text-xs mt-0.5 leading-relaxed" style={{ color: "var(--tn-text-faint)" }}>{link.desc}</p>
                     </div>
-                    <span className="text-gray-400 dark:text-gray-600 text-xs shrink-0 mt-0.5">
-                      ↗
-                    </span>
+                    <span className="text-xs shrink-0 mt-0.5" style={{ color: "var(--tn-text-faint)" }}>↗</span>
                   </a>
                 ))}
               </div>

--- a/components/admin/TrackConfigRow.tsx
+++ b/components/admin/TrackConfigRow.tsx
@@ -20,7 +20,6 @@ export function TrackConfigRow({ initialConfig }: { initialConfig: TrackConfig }
     setSaveError(null);
     setLanesError(null);
 
-    // Validate open_stretch_lanes when toggle is ON
     const parsedLanes: number[] = [];
     if (openStretch) {
       const tokens = lanesInput.split(",").map((s) => s.trim()).filter(Boolean);
@@ -55,14 +54,25 @@ export function TrackConfigRow({ initialConfig }: { initialConfig: TrackConfig }
   const isLoading = status === "loading";
   const isSuccess = status === "success";
 
+  const inputStyle = {
+    background: "var(--tn-bg-chip)",
+    border: "1px solid var(--tn-border)",
+    color: "var(--tn-text)",
+    borderRadius: "0.375rem",
+    padding: "0.5rem 0.75rem",
+    fontSize: "0.875rem",
+    outline: "none",
+  };
+
   return (
-    <section className="space-y-3 border-b border-gray-200 dark:border-gray-800 pb-6 last:border-0">
-      {/* Track name header */}
-      <h2 className="text-sm font-bold text-gray-500 dark:text-gray-400 uppercase tracking-wide">
+    <section
+      className="space-y-3 pb-6 last:border-0"
+      style={{ borderBottom: "1px solid var(--tn-border)" }}
+    >
+      <h2 className="tn-eyebrow" style={{ color: "var(--tn-text-dim)" }}>
         {initialConfig.track_name}
       </h2>
 
-      {/* Open stretch toggle */}
       <div className="space-y-1">
         <div className="flex items-center gap-3">
           <label className="flex items-center gap-2 cursor-pointer select-none">
@@ -71,32 +81,30 @@ export function TrackConfigRow({ initialConfig }: { initialConfig: TrackConfig }
               role="switch"
               aria-checked={openStretch}
               onClick={() => setOpenStretch((v) => !v)}
-              className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-1 ${
-                openStretch
-                  ? "bg-indigo-600"
-                  : "bg-gray-300 dark:bg-gray-600"
-              }`}
+              className="relative inline-flex h-5 w-9 items-center rounded-full transition-colors focus:outline-none"
+              style={{
+                background: openStretch ? "var(--tn-accent)" : "var(--tn-bg-chip)",
+                border: "1px solid var(--tn-border)",
+              }}
             >
               <span
-                className={`inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform ${
-                  openStretch ? "translate-x-4" : "translate-x-0.5"
-                }`}
+                className="inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform"
+                style={{ transform: openStretch ? "translateX(1rem)" : "translateX(0.125rem)" }}
               />
             </button>
-            <span className="text-sm text-gray-700 dark:text-gray-300">Open stretch</span>
+            <span className="text-sm" style={{ color: "var(--tn-text)" }}>Open stretch</span>
           </label>
         </div>
-        <p className="text-xs text-gray-500 dark:text-gray-400">
+        <p className="text-xs" style={{ color: "var(--tn-text-faint)" }}>
           Hästar på gynnade spår får +0.12 CS. Aktiverar spårinställningen nedan.
         </p>
       </div>
 
-      {/* Gynnade spår (open_stretch_lanes) — visible only when open_stretch is on */}
       <div className={`space-y-1 ${openStretch ? "" : "opacity-50 pointer-events-none"}`}>
-        <label className="block text-xs font-medium text-gray-600 dark:text-gray-400">
+        <label className="block text-xs font-medium" style={{ color: "var(--tn-text-dim)" }}>
           Gynnade spår
         </label>
-        <p className="text-xs text-gray-500 dark:text-gray-400">
+        <p className="text-xs" style={{ color: "var(--tn-text-faint)" }}>
           Ange spårnummer 1–20, kommaseparerade. Gäller bara när Open stretch är på.
         </p>
         <input
@@ -105,19 +113,19 @@ export function TrackConfigRow({ initialConfig }: { initialConfig: TrackConfig }
           onChange={(e) => setLanesInput(e.target.value)}
           disabled={!openStretch || isLoading}
           placeholder="t.ex. 7,8,9,10"
-          className="w-full text-sm px-3 py-2 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-white focus:outline-none focus:border-indigo-400 disabled:cursor-not-allowed"
+          className="w-full disabled:cursor-not-allowed"
+          style={inputStyle}
         />
         {lanesError && (
-          <p className="text-xs text-red-500 dark:text-red-400">{lanesError}</p>
+          <p className="text-xs" style={{ color: "var(--tn-value-low)" }}>{lanesError}</p>
         )}
       </div>
 
-      {/* Distansgräns (short_race_threshold) */}
       <div className="space-y-1">
-        <label className="block text-xs font-medium text-gray-600 dark:text-gray-400">
+        <label className="block text-xs font-medium" style={{ color: "var(--tn-text-dim)" }}>
           Distansgräns
         </label>
-        <p className="text-xs text-gray-500 dark:text-gray-400">
+        <p className="text-xs" style={{ color: "var(--tn-text-faint)" }}>
           Lopp kortare än detta värde sänker CS med 0.08. Sätt 0 för att inaktivera.
         </p>
         <div className="flex items-center gap-2">
@@ -129,23 +137,24 @@ export function TrackConfigRow({ initialConfig }: { initialConfig: TrackConfig }
             onChange={(e) => setThreshold(Number(e.target.value))}
             disabled={isLoading}
             placeholder="0 = inaktiv"
-            className="w-28 text-sm px-3 py-2 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-white focus:outline-none focus:border-indigo-400 disabled:cursor-not-allowed"
+            className="w-28 disabled:cursor-not-allowed"
+            style={inputStyle}
           />
-          <span className="text-sm text-gray-500 dark:text-gray-400">m</span>
+          <span className="text-sm" style={{ color: "var(--tn-text-faint)" }}>m</span>
         </div>
       </div>
 
-      {/* Save button + feedback */}
       <div className="flex items-center gap-3">
         <button
           type="button"
           onClick={handleSave}
           disabled={isLoading}
-          className={`text-sm font-medium px-3 py-1.5 rounded transition disabled:cursor-not-allowed ${
+          className="text-sm font-medium px-3 py-1.5 rounded transition disabled:cursor-not-allowed"
+          style={
             isSuccess
-              ? "bg-green-600 text-white"
-              : "bg-indigo-600 hover:bg-indigo-700 text-white"
-          }`}
+              ? { background: "var(--tn-value-high)", color: "#0a0e14" }
+              : { background: "var(--tn-accent)", color: "#fff" }
+          }
         >
           {isLoading ? (
             <span className="flex items-center gap-1.5">
@@ -169,7 +178,7 @@ export function TrackConfigRow({ initialConfig }: { initialConfig: TrackConfig }
         </button>
       </div>
       {saveError && (
-        <p className="text-xs text-red-500 dark:text-red-400">{saveError}</p>
+        <p className="text-xs" style={{ color: "var(--tn-value-low)" }}>{saveError}</p>
       )}
     </section>
   );

--- a/components/groups/CreateGroupForm.tsx
+++ b/components/groups/CreateGroupForm.tsx
@@ -15,12 +15,8 @@ export function CreateGroupForm({ onCreated }: { onCreated: (group: Group) => vo
     setError(null);
     const { data, error } = await createGroup(name);
     setLoading(false);
-    if (error) {
-      setError(error);
-    } else if (data) {
-      setName("");
-      onCreated(data);
-    }
+    if (error) { setError(error); }
+    else if (data) { setName(""); onCreated(data); }
   }
 
   return (
@@ -32,17 +28,19 @@ export function CreateGroupForm({ onCreated }: { onCreated: (group: Group) => vo
           onChange={(e) => setName(e.target.value)}
           placeholder="Namn på sällskapet"
           maxLength={50}
-          className="flex-1 bg-gray-200 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-sm text-gray-900 dark:text-white placeholder-gray-400 focus:outline-none focus:border-indigo-500"
+          className="flex-1 rounded-lg px-3 py-2 text-sm outline-none"
+          style={{ background: "var(--tn-bg-chip)", border: "1px solid var(--tn-border)", color: "var(--tn-text)" }}
         />
         <button
           type="submit"
           disabled={loading || !name.trim()}
-          className="bg-indigo-600 hover:bg-indigo-500 disabled:opacity-50 text-white text-sm px-4 py-2 rounded-lg transition"
+          className="text-sm px-4 py-2 rounded-lg transition disabled:opacity-50"
+          style={{ background: "var(--tn-accent)", color: "#fff", border: "none", cursor: "pointer" }}
         >
           {loading ? "Skapar…" : "Skapa"}
         </button>
       </div>
-      {error && <p className="text-red-400 text-xs">{error}</p>}
+      {error && <p className="text-xs" style={{ color: "var(--tn-value-low)" }}>{error}</p>}
     </form>
   );
 }

--- a/components/groups/GroupAdminModal.tsx
+++ b/components/groups/GroupAdminModal.tsx
@@ -17,74 +17,52 @@ interface GroupAdminModalProps {
 export function GroupAdminModal({ open, onClose, profile, initialGroups }: GroupAdminModalProps) {
   const [groups, setGroups] = useState<Group[]>(initialGroups);
 
-  function handleCreated(group: Group) {
-    setGroups((prev) => [...prev, group]);
-  }
-
-  function handleJoined(group: Group) {
-    setGroups((prev) => (prev.find((g) => g.id === group.id) ? prev : [...prev, group]));
-  }
-
-  function handleLeft(groupId: string) {
-    setGroups((prev) => prev.filter((g) => g.id !== groupId));
-  }
+  function handleCreated(group: Group) { setGroups((prev) => [...prev, group]); }
+  function handleJoined(group: Group) { setGroups((prev) => (prev.find((g) => g.id === group.id) ? prev : [...prev, group])); }
+  function handleLeft(groupId: string) { setGroups((prev) => prev.filter((g) => g.id !== groupId)); }
 
   if (!open) return null;
 
   return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center p-4"
-      onClick={onClose}
-    >
-      {/* Backdrop */}
-      <div className="absolute inset-0 bg-black/70" />
-
-      {/* Modal */}
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4" onClick={onClose}>
+      <div className="absolute inset-0" style={{ background: "rgba(0,0,0,0.7)" }} />
       <div
-        className="relative bg-gray-50 dark:bg-gray-900 border border-gray-300 dark:border-gray-700 rounded-2xl w-full max-w-md max-h-[90vh] overflow-y-auto shadow-2xl"
+        className="relative w-full max-w-md max-h-[90vh] overflow-y-auto rounded-2xl shadow-2xl"
+        style={{ background: "var(--tn-bg-raised)", border: "1px solid var(--tn-border)" }}
         onClick={(e) => e.stopPropagation()}
       >
-        {/* Header */}
-        <div className="flex items-center justify-between px-5 py-4 border-b border-gray-300 dark:border-gray-700">
-          <h2 className="text-gray-900 dark:text-white font-semibold text-lg">Mina sällskap</h2>
+        <div
+          className="flex items-center justify-between px-5 py-4"
+          style={{ borderBottom: "1px solid var(--tn-border)" }}
+        >
+          <h2 className="font-semibold text-lg" style={{ color: "var(--tn-text)" }}>Mina sällskap</h2>
           <button
             onClick={onClose}
-            className="text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white transition text-xl leading-none"
+            className="text-xl leading-none transition"
+            style={{ color: "var(--tn-text-faint)", background: "none", border: "none", cursor: "pointer" }}
           >
             ✕
           </button>
         </div>
 
         <div className="px-5 py-4 space-y-6">
-          {/* Visningsnamn */}
           <section>
-            <h3 className="text-gray-500 dark:text-gray-400 text-xs font-semibold uppercase tracking-wider mb-2">
-              Visningsnamn
-            </h3>
+            <h3 className="tn-eyebrow mb-2">Visningsnamn</h3>
             <ProfileForm initialName={profile?.display_name ?? ""} />
           </section>
 
-          {/* Mina sällskap */}
           <section>
-            <h3 className="text-gray-500 dark:text-gray-400 text-xs font-semibold uppercase tracking-wider mb-2">
-              Mina sällskap
-            </h3>
+            <h3 className="tn-eyebrow mb-2">Mina sällskap</h3>
             <GroupList groups={groups} onLeft={handleLeft} />
           </section>
 
-          {/* Skapa nytt sällskap */}
           <section>
-            <h3 className="text-gray-500 dark:text-gray-400 text-xs font-semibold uppercase tracking-wider mb-2">
-              Skapa nytt sällskap
-            </h3>
+            <h3 className="tn-eyebrow mb-2">Skapa nytt sällskap</h3>
             <CreateGroupForm onCreated={handleCreated} />
           </section>
 
-          {/* Gå med via inbjudningskod */}
           <section>
-            <h3 className="text-gray-500 dark:text-gray-400 text-xs font-semibold uppercase tracking-wider mb-2">
-              Gå med via inbjudningskod
-            </h3>
+            <h3 className="tn-eyebrow mb-2">Gå med via inbjudningskod</h3>
             <JoinGroupForm onJoined={handleJoined} />
           </section>
         </div>

--- a/components/groups/GroupList.tsx
+++ b/components/groups/GroupList.tsx
@@ -6,17 +6,16 @@ import type { Group } from "@/lib/types";
 
 function CopyButton({ text, label, mono }: { text: string; label: string; mono?: boolean }) {
   const [copied, setCopied] = useState(false);
-
   async function handleCopy() {
     await navigator.clipboard.writeText(text);
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
   }
-
   return (
     <button
       onClick={handleCopy}
-      className={`text-xs text-indigo-600 dark:text-indigo-400 hover:text-indigo-300 transition ${mono ? "font-mono tracking-widest" : ""}`}
+      className={`text-xs transition ${mono ? "tn-mono" : ""}`}
+      style={{ color: "var(--tn-accent)", background: "none", border: "none", cursor: "pointer" }}
       title={`Kopiera ${label}`}
     >
       {mono ? text : label} {copied ? "✓" : "⎘"}
@@ -26,18 +25,17 @@ function CopyButton({ text, label, mono }: { text: string; label: string; mono?:
 
 function CopyLinkButton({ inviteCode }: { inviteCode: string }) {
   const [copied, setCopied] = useState(false);
-
   async function handleCopy() {
     const url = `${window.location.origin}/join/${inviteCode}`;
     await navigator.clipboard.writeText(url);
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
   }
-
   return (
     <button
       onClick={handleCopy}
-      className="text-xs text-indigo-600 dark:text-indigo-400 hover:text-indigo-300 transition"
+      className="text-xs transition"
+      style={{ color: "var(--tn-accent)", background: "none", border: "none", cursor: "pointer" }}
       title="Kopiera inbjudningslänk"
     >
       Kopiera länk {copied ? "✓" : "🔗"}
@@ -45,13 +43,7 @@ function CopyLinkButton({ inviteCode }: { inviteCode: string }) {
   );
 }
 
-export function GroupList({
-  groups,
-  onLeft,
-}: {
-  groups: Group[];
-  onLeft: (groupId: string) => void;
-}) {
+export function GroupList({ groups, onLeft }: { groups: Group[]; onLeft: (groupId: string) => void }) {
   const [leaving, setLeaving] = useState<string | null>(null);
 
   async function handleLeave(groupId: string) {
@@ -63,7 +55,7 @@ export function GroupList({
 
   if (groups.length === 0) {
     return (
-      <p className="text-gray-500 text-sm">
+      <p className="text-sm" style={{ color: "var(--tn-text-faint)" }}>
         Du tillhör inga sällskap ännu. Skapa ett eller gå med via en inbjudningskod.
       </p>
     );
@@ -74,13 +66,14 @@ export function GroupList({
       {groups.map((g) => (
         <li
           key={g.id}
-          className="flex items-center justify-between gap-3 bg-gray-200 dark:bg-gray-700 rounded-lg px-3 py-2"
+          className="flex items-center justify-between gap-3 rounded-lg px-3 py-2"
+          style={{ background: "var(--tn-bg-chip)" }}
         >
           <div className="min-w-0">
-            <p className="text-gray-900 dark:text-white text-sm font-medium truncate">{g.name}</p>
+            <p className="text-sm font-medium truncate" style={{ color: "var(--tn-text)" }}>{g.name}</p>
             <div className="flex items-center gap-2 mt-0.5 flex-wrap">
               <div className="flex items-center gap-1">
-                <span className="text-gray-500 dark:text-gray-400 text-xs">Kod:</span>
+                <span className="text-xs" style={{ color: "var(--tn-text-faint)" }}>Kod:</span>
                 <CopyButton text={g.invite_code} label="inbjudningskod" mono />
               </div>
               <CopyLinkButton inviteCode={g.invite_code} />
@@ -89,7 +82,8 @@ export function GroupList({
           <button
             onClick={() => handleLeave(g.id)}
             disabled={leaving === g.id}
-            className="text-xs text-red-400 hover:text-red-300 disabled:opacity-50 transition shrink-0"
+            className="text-xs disabled:opacity-50 transition shrink-0"
+            style={{ color: "var(--tn-value-low)", background: "none", border: "none", cursor: "pointer" }}
           >
             {leaving === g.id ? "Lämnar…" : "Lämna"}
           </button>

--- a/components/groups/JoinGroupForm.tsx
+++ b/components/groups/JoinGroupForm.tsx
@@ -15,12 +15,8 @@ export function JoinGroupForm({ onJoined }: { onJoined: (group: Group) => void }
     setError(null);
     const { data, error } = await joinGroup(code);
     setLoading(false);
-    if (error) {
-      setError(error);
-    } else if (data) {
-      setCode("");
-      onJoined(data);
-    }
+    if (error) { setError(error); }
+    else if (data) { setCode(""); onJoined(data); }
   }
 
   return (
@@ -32,17 +28,19 @@ export function JoinGroupForm({ onJoined }: { onJoined: (group: Group) => void }
           onChange={(e) => setCode(e.target.value.toUpperCase())}
           placeholder="Inbjudningskod (t.ex. AB12CD)"
           maxLength={10}
-          className="flex-1 bg-gray-200 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-sm text-gray-900 dark:text-white placeholder-gray-400 focus:outline-none focus:border-indigo-500 font-mono tracking-widest"
+          className="flex-1 rounded-lg px-3 py-2 text-sm outline-none tn-mono"
+          style={{ background: "var(--tn-bg-chip)", border: "1px solid var(--tn-border)", color: "var(--tn-text)", letterSpacing: "0.1em" }}
         />
         <button
           type="submit"
           disabled={loading || !code.trim()}
-          className="bg-emerald-700 hover:bg-emerald-600 disabled:opacity-50 text-white text-sm px-4 py-2 rounded-lg transition"
+          className="text-sm px-4 py-2 rounded-lg transition disabled:opacity-50"
+          style={{ background: "var(--tn-accent-faint)", border: "1px solid var(--tn-accent-soft)", color: "var(--tn-accent)", cursor: "pointer" }}
         >
           {loading ? "Går med…" : "Gå med"}
         </button>
       </div>
-      {error && <p className="text-red-400 text-xs">{error}</p>}
+      {error && <p className="text-xs" style={{ color: "var(--tn-value-low)" }}>{error}</p>}
     </form>
   );
 }

--- a/components/groups/ProfileForm.tsx
+++ b/components/groups/ProfileForm.tsx
@@ -18,24 +18,26 @@ export function ProfileForm({ initialName }: { initialName: string }) {
   }
 
   return (
-    <form onSubmit={handleSubmit} className="flex gap-2">
+    <form onSubmit={handleSubmit} className="flex gap-2 flex-wrap">
       <input
         type="text"
         value={name}
         onChange={(e) => setName(e.target.value)}
         placeholder="Ditt visningsnamn"
         maxLength={40}
-        className="flex-1 bg-gray-200 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-sm text-gray-900 dark:text-white placeholder-gray-400 focus:outline-none focus:border-indigo-500"
+        className="flex-1 rounded-lg px-3 py-2 text-sm outline-none"
+        style={{ background: "var(--tn-bg-chip)", border: "1px solid var(--tn-border)", color: "var(--tn-text)" }}
       />
       <button
         type="submit"
         disabled={loading || !name.trim()}
-        className="bg-indigo-600 hover:bg-indigo-500 disabled:opacity-50 text-white text-sm px-4 py-2 rounded-lg transition"
+        className="text-sm px-4 py-2 rounded-lg transition disabled:opacity-50"
+        style={{ background: "var(--tn-accent)", color: "#fff", border: "none", cursor: "pointer" }}
       >
         {loading ? "Sparar…" : "Spara"}
       </button>
       {message && (
-        <span className="text-xs text-gray-500 dark:text-gray-400 self-center">{message}</span>
+        <span className="text-xs self-center w-full" style={{ color: "var(--tn-text-faint)" }}>{message}</span>
       )}
     </form>
   );

--- a/components/groups/UserMenu.tsx
+++ b/components/groups/UserMenu.tsx
@@ -22,12 +22,9 @@ export function UserMenu({ profile, groups, userEmail }: UserMenuProps) {
   const displayName = profile?.display_name || userEmail.split("@")[0];
   const initials = displayName.slice(0, 2).toUpperCase();
 
-  // Close dropdown when clicking outside
   useEffect(() => {
     function handleClick(e: MouseEvent) {
-      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
-        setOpen(false);
-      }
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) setOpen(false);
     }
     document.addEventListener("mousedown", handleClick);
     return () => document.removeEventListener("mousedown", handleClick);
@@ -42,61 +39,74 @@ export function UserMenu({ profile, groups, userEmail }: UserMenuProps) {
   return (
     <>
       <div className="relative" ref={menuRef}>
-        {/* Avatar button */}
         <button
           onClick={() => setOpen((v) => !v)}
-          className="w-9 h-9 rounded-full bg-indigo-700 hover:bg-indigo-600 transition flex items-center justify-center text-white text-sm font-bold shrink-0"
+          className="w-9 h-9 rounded-full flex items-center justify-center text-sm font-bold shrink-0 transition"
+          style={{ background: "var(--tn-accent)", color: "#fff" }}
           title={displayName}
         >
           {initials}
         </button>
 
-        {/* Dropdown */}
         {open && (
-          <div className="absolute right-0 top-11 w-56 bg-gray-50 dark:bg-gray-900 border border-gray-300 dark:border-gray-700 rounded-xl shadow-2xl z-40 overflow-hidden">
-            <div className="px-4 py-3 border-b border-gray-300 dark:border-gray-700">
-              <p className="text-gray-900 dark:text-white text-sm font-medium truncate">{displayName}</p>
-              <p className="text-gray-500 dark:text-gray-400 text-xs truncate">{userEmail}</p>
-            </div>
-
-            {groups.length > 0 && (
-              <div className="px-4 py-2 border-b border-gray-300 dark:border-gray-700">
-                <p className="text-gray-400 dark:text-gray-500 text-xs mb-1">Sällskap</p>
-                {groups.map((g) => (
-                  <Link
-                    key={g.id}
-                    href={`/sallskap/${g.id}`}
-                    onClick={() => setOpen(false)}
-                    className="block text-gray-700 dark:text-gray-300 hover:text-indigo-600 dark:hover:text-indigo-400 text-xs truncate py-0.5 transition"
-                  >
-                    {g.name}
-                  </Link>
-                ))}
+          <>
+            <div className="fixed inset-0 z-30" onClick={() => setOpen(false)} />
+            <div
+              className="absolute right-0 top-11 w-56 rounded-xl shadow-2xl z-40 overflow-hidden"
+              style={{ background: "var(--tn-bg-raised)", border: "1px solid var(--tn-border)" }}
+            >
+              <div className="px-4 py-3" style={{ borderBottom: "1px solid var(--tn-border)" }}>
+                <p className="text-sm font-medium truncate" style={{ color: "var(--tn-text)" }}>{displayName}</p>
+                <p className="text-xs truncate" style={{ color: "var(--tn-text-faint)" }}>{userEmail}</p>
               </div>
-            )}
 
-            <div className="px-2 py-2 space-y-1">
-              <button
-                onClick={() => { setOpen(false); setModalOpen(true); }}
-                className="w-full text-left px-3 py-2 text-sm text-gray-800 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-lg transition"
-              >
-                Hantera sällskap
-              </button>
-              <Link
-                href="/manual"
-                onClick={() => setOpen(false)}
-                className="block px-3 py-2 text-sm text-gray-800 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-lg transition"
-              >
-                Användarmanual
-              </Link>
-              <button
-                onClick={handleSignOut}
-                className="w-full text-left px-3 py-2 text-sm text-red-400 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-lg transition"
-              >
-                Logga ut
-              </button>
+              {groups.length > 0 && (
+                <div className="px-4 py-2" style={{ borderBottom: "1px solid var(--tn-border)" }}>
+                  <p className="text-xs mb-1" style={{ color: "var(--tn-text-faint)" }}>Sällskap</p>
+                  {groups.map((g) => (
+                    <Link
+                      key={g.id}
+                      href={`/sallskap/${g.id}`}
+                      onClick={() => setOpen(false)}
+                      className="block text-xs truncate py-0.5 transition"
+                      style={{ color: "var(--tn-text-dim)" }}
+                    >
+                      {g.name}
+                    </Link>
+                  ))}
+                </div>
+              )}
+
+              <div className="px-2 py-2 space-y-1">
+                <button
+                  onClick={() => { setOpen(false); setModalOpen(true); }}
+                  className="w-full text-left px-3 py-2 text-sm rounded-lg transition"
+                  style={{ color: "var(--tn-text)", background: "none", border: "none", cursor: "pointer" }}
+                  onMouseEnter={(e) => { e.currentTarget.style.background = "var(--tn-bg-card)"; }}
+                  onMouseLeave={(e) => { e.currentTarget.style.background = "none"; }}
+                >
+                  Hantera sällskap
+                </button>
+                <Link
+                  href="/manual"
+                  onClick={() => setOpen(false)}
+                  className="block px-3 py-2 text-sm rounded-lg transition"
+                  style={{ color: "var(--tn-text)" }}
+                >
+                  Användarmanual
+                </Link>
+                <button
+                  onClick={handleSignOut}
+                  className="w-full text-left px-3 py-2 text-sm rounded-lg transition"
+                  style={{ color: "var(--tn-value-low)", background: "none", border: "none", cursor: "pointer" }}
+                  onMouseEnter={(e) => { e.currentTarget.style.background = "var(--tn-bg-card)"; }}
+                  onMouseLeave={(e) => { e.currentTarget.style.background = "none"; }}
+                >
+                  Logga ut
+                </button>
+              </div>
             </div>
-          </div>
+          </>
         )}
       </div>
 

--- a/components/notes/HorseNotes.tsx
+++ b/components/notes/HorseNotes.tsx
@@ -17,17 +17,12 @@ export function HorseNotes({ horseId, userGroups, currentUserId }: HorseNotesPro
   const [notes, setNotes] = useState<HorseNote[]>([]);
   const [loaded, setLoaded] = useState(false);
 
-  // Hämta anteckningar automatiskt när komponenten mountas (avdelningen öppnas)
   useEffect(() => {
     getHorseNotes(horseId).then((data) => {
       setNotes(data);
       setLoaded(true);
     });
   }, [horseId]);
-
-  function handleExpand() {
-    setExpanded((v) => !v);
-  }
 
   const handleAdded = useCallback((note: HorseNote) => {
     setNotes((prev) => [...prev, { ...note, replies: [] }]);
@@ -37,36 +32,39 @@ export function HorseNotes({ horseId, userGroups, currentUserId }: HorseNotesPro
     setNotes((prev) =>
       prev
         .filter((n) => n.id !== noteId)
-        .map((n) => ({
-          ...n,
-          replies: n.replies.filter((r) => r.id !== noteId),
-        }))
+        .map((n) => ({ ...n, replies: n.replies.filter((r) => r.id !== noteId) }))
     );
   }, []);
 
   const handleReplied = useCallback((reply: HorseNote, parentId: string) => {
     setNotes((prev) =>
-      prev.map((n) =>
-        n.id === parentId
-          ? { ...n, replies: [...n.replies, reply] }
-          : n
-      )
+      prev.map((n) => n.id === parentId ? { ...n, replies: [...n.replies, reply] } : n)
     );
   }, []);
 
   const noteCount = notes.length + notes.reduce((sum, n) => sum + n.replies.length, 0);
 
   return (
-    <div className="border-t border-gray-300 dark:border-gray-700 mt-3 pt-3">
+    <div className="mt-3 pt-3" style={{ borderTop: "1px solid var(--tn-border)" }}>
       <button
-        onClick={handleExpand}
-        className="flex items-center gap-2 text-xs text-gray-500 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200 transition w-full text-left"
+        onClick={() => setExpanded((v) => !v)}
+        className="flex items-center gap-2 text-xs transition w-full text-left"
+        style={{ color: "var(--tn-text-faint)", background: "none", border: "none", cursor: "pointer" }}
       >
-        <span>{expanded ? "▲" : "▼"}</span>
+        <svg
+          width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"
+          strokeLinecap="round" strokeLinejoin="round"
+          className={`transition-transform duration-200 ${expanded ? "rotate-180" : ""}`}
+        >
+          <path d="M6 9l6 6 6-6" />
+        </svg>
         <span>
           Anteckningar
           {noteCount > 0 && (
-            <span className="ml-1.5 bg-indigo-700 text-white text-xs px-1.5 py-0.5 rounded-full">
+            <span
+              className="ml-1.5 text-xs px-1.5 py-0.5 rounded-full"
+              style={{ background: "var(--tn-accent-faint)", color: "var(--tn-accent)" }}
+            >
               {noteCount}
             </span>
           )}
@@ -76,7 +74,7 @@ export function HorseNotes({ horseId, userGroups, currentUserId }: HorseNotesPro
       {expanded && (
         <div className="mt-3 space-y-3">
           {loaded && notes.length === 0 && (
-            <p className="text-gray-500 text-xs italic">
+            <p className="text-xs italic" style={{ color: "var(--tn-text-faint)" }}>
               Inga anteckningar ännu.
             </p>
           )}
@@ -93,13 +91,8 @@ export function HorseNotes({ horseId, userGroups, currentUserId }: HorseNotesPro
             />
           ))}
 
-          {/* New note form */}
           <div className="pt-1">
-            <NoteForm
-              horseId={horseId}
-              userGroups={userGroups}
-              onAdded={handleAdded}
-            />
+            <NoteForm horseId={horseId} userGroups={userGroups} onAdded={handleAdded} />
           </div>
         </div>
       )}

--- a/components/notes/NoteForm.tsx
+++ b/components/notes/NoteForm.tsx
@@ -11,7 +11,7 @@ interface NoteFormProps {
   horseId: string;
   userGroups: Group[];
   parentId?: string;
-  parentGroupId?: string | null; // For replies, inherit group from parent
+  parentGroupId?: string | null;
   onAdded: (note: HorseNote) => void;
   onCancel?: () => void;
   compact?: boolean;
@@ -28,7 +28,6 @@ export function NoteForm({
 }: NoteFormProps) {
   const [content, setContent] = useState("");
   const [label, setLabel] = useState<NoteLabel | null>(null);
-  // Default: inherit parent's group, or first group, or personal
   const defaultGroupId = parentGroupId ?? userGroups[0]?.id ?? PERSONAL;
   const [groupId, setGroupId] = useState<string>(defaultGroupId);
   const [loading, setLoading] = useState(false);
@@ -41,13 +40,7 @@ export function NoteForm({
     setLoading(true);
     setError(null);
     const resolvedGroupId = groupId === PERSONAL ? null : groupId;
-    const { data, error } = await addNote(
-      horseId,
-      resolvedGroupId,
-      content,
-      label,
-      parentId
-    );
+    const { data, error } = await addNote(horseId, resolvedGroupId, content, label, parentId);
     setLoading(false);
     if (error) {
       setError(error);
@@ -65,32 +58,30 @@ export function NoteForm({
         onChange={(e) => setContent(e.target.value)}
         placeholder={isReply ? "Skriv ett svar…" : "Lägg till en anteckning…"}
         rows={compact ? 2 : 3}
-        className="w-full bg-gray-200 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-sm text-gray-900 dark:text-white placeholder-gray-400 focus:outline-none focus:border-indigo-500 resize-none"
+        className="w-full rounded-lg px-3 py-2 text-sm resize-none outline-none"
+        style={{ background: "var(--tn-bg-chip)", border: "1px solid var(--tn-border)", color: "var(--tn-text)" }}
       />
 
       <div className="flex flex-wrap items-center gap-3 justify-between">
         <div className="flex flex-wrap items-center gap-3">
           <NoteLabelPicker value={label} onChange={setLabel} />
 
-          {/* Group selector — only for top-level notes */}
           {!isReply && (
             <select
               value={groupId}
               onChange={(e) => setGroupId(e.target.value)}
-              className="bg-gray-200 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 text-gray-900 dark:text-white text-xs rounded-lg px-2 py-1 focus:outline-none focus:border-indigo-500"
+              className="text-xs rounded-lg px-2 py-1 outline-none"
+              style={{ background: "var(--tn-bg-chip)", border: "1px solid var(--tn-border)", color: "var(--tn-text)" }}
             >
               {userGroups.map((g) => (
-                <option key={g.id} value={g.id}>
-                  {g.name}
-                </option>
+                <option key={g.id} value={g.id}>{g.name}</option>
               ))}
               <option value={PERSONAL}>Personlig</option>
             </select>
           )}
 
-          {/* For replies: show inherited group name */}
           {isReply && (
-            <span className="text-xs text-gray-500">
+            <span className="text-xs" style={{ color: "var(--tn-text-faint)" }}>
               {parentGroupId
                 ? userGroups.find((g) => g.id === parentGroupId)?.name ?? ""
                 : "Personlig"}
@@ -103,7 +94,8 @@ export function NoteForm({
             <button
               type="button"
               onClick={onCancel}
-              className="text-xs text-gray-500 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200 px-3 py-1.5 rounded-lg transition"
+              className="text-xs px-3 py-1.5 rounded-lg transition"
+              style={{ color: "var(--tn-text-faint)", background: "none", border: "none", cursor: "pointer" }}
             >
               Avbryt
             </button>
@@ -111,14 +103,15 @@ export function NoteForm({
           <button
             type="submit"
             disabled={loading || !content.trim()}
-            className="bg-indigo-600 hover:bg-indigo-500 disabled:opacity-50 text-white text-xs px-3 py-1.5 rounded-lg transition"
+            className="text-xs px-3 py-1.5 rounded-lg transition disabled:opacity-50"
+            style={{ background: "var(--tn-accent)", color: "#fff", border: "none", cursor: "pointer" }}
           >
             {loading ? "Sparar…" : isReply ? "Svara" : "Lägg till"}
           </button>
         </div>
       </div>
 
-      {error && <p className="text-red-400 text-xs">{error}</p>}
+      {error && <p className="text-xs" style={{ color: "var(--tn-value-low)" }}>{error}</p>}
     </form>
   );
 }

--- a/components/notes/NoteItem.tsx
+++ b/components/notes/NoteItem.tsx
@@ -52,28 +52,41 @@ export function NoteItem({
   }
 
   return (
-    <div className={`${isReply ? "ml-4 pl-3 border-l-2 border-gray-300 dark:border-gray-700" : ""}`}>
-      <div className="bg-gray-100 dark:bg-[rgb(40,44,52)] rounded-lg p-3 space-y-1.5">
-        {/* Header */}
+    <div
+      className={isReply ? "ml-4 pl-3" : ""}
+      style={isReply ? { borderLeft: "2px solid var(--tn-border)" } : {}}
+    >
+      <div
+        className="rounded-lg p-3 space-y-1.5"
+        style={{ background: "var(--tn-bg-chip)" }}
+      >
         <div className="flex items-center gap-2 flex-wrap">
           <NoteLabelDot label={note.label} />
-          <span className="text-gray-900 dark:text-white text-xs font-medium">{note.author_display_name}</span>
-          <span className="text-gray-400 dark:text-gray-500 text-xs">·</span>
-          <span className="text-gray-600 bg-gray-200 dark:text-gray-400 dark:bg-gray-700 text-xs px-1.5 py-0.5 rounded">
+          <span className="text-xs font-medium" style={{ color: "var(--tn-text)" }}>
+            {note.author_display_name}
+          </span>
+          <span className="text-xs" style={{ color: "var(--tn-text-faint)" }}>·</span>
+          <span
+            className="text-xs px-1.5 py-0.5 rounded"
+            style={{ background: "var(--tn-bg-card)", color: "var(--tn-text-dim)" }}
+          >
             {note.group_name ?? "Personlig"}
           </span>
-          <span className="text-gray-400 dark:text-gray-500 text-xs ml-auto">{relativeTime(note.created_at)}</span>
+          <span className="text-xs ml-auto" style={{ color: "var(--tn-text-faint)" }}>
+            {relativeTime(note.created_at)}
+          </span>
         </div>
 
-        {/* Content */}
-        <p className="text-gray-800 dark:text-gray-200 text-sm leading-relaxed whitespace-pre-wrap">{note.content}</p>
+        <p className="text-sm leading-relaxed whitespace-pre-wrap" style={{ color: "var(--tn-text)" }}>
+          {note.content}
+        </p>
 
-        {/* Actions */}
         <div className="flex items-center gap-3 pt-0.5">
           {!isReply && (
             <button
               onClick={() => setShowReplyForm((v) => !v)}
-              className="text-xs text-indigo-600 dark:text-indigo-400 hover:text-indigo-300 transition"
+              className="text-xs transition"
+              style={{ color: "var(--tn-accent)", background: "none", border: "none", cursor: "pointer" }}
             >
               {showReplyForm ? "Avbryt" : "Svara"}
             </button>
@@ -82,7 +95,8 @@ export function NoteItem({
             <button
               onClick={handleDelete}
               disabled={deleting}
-              className="text-xs text-red-400 hover:text-red-300 disabled:opacity-50 transition"
+              className="text-xs transition disabled:opacity-50"
+              style={{ color: "var(--tn-value-low)", background: "none", border: "none", cursor: "pointer" }}
             >
               {deleting ? "Tar bort…" : "Ta bort"}
             </button>
@@ -90,7 +104,6 @@ export function NoteItem({
         </div>
       </div>
 
-      {/* Reply form */}
       {showReplyForm && !isReply && (
         <div className="mt-2 ml-4">
           <NoteForm
@@ -105,7 +118,6 @@ export function NoteItem({
         </div>
       )}
 
-      {/* Replies */}
       {note.replies && note.replies.length > 0 && (
         <div className="mt-2 space-y-2">
           {note.replies.map((reply) => (

--- a/components/notes/NoteLabel.tsx
+++ b/components/notes/NoteLabel.tsx
@@ -1,12 +1,12 @@
 import type { NoteLabel } from "@/lib/types";
 
-const LABEL_COLORS: Record<NoteLabel, string> = {
-  red: "bg-red-500",
-  orange: "bg-orange-500",
-  yellow: "bg-yellow-400",
-  green: "bg-green-500",
-  blue: "bg-blue-500",
-  purple: "bg-purple-500",
+const LABEL_HEX: Record<NoteLabel, string> = {
+  red: "#f87171",
+  orange: "#fb923c",
+  yellow: "#fbbf24",
+  green: "#34d399",
+  blue: "#3b82f6",
+  purple: "#a78bfa",
 };
 
 const LABEL_NAMES: Record<NoteLabel, string> = {
@@ -24,7 +24,8 @@ export function NoteLabelDot({ label }: { label: NoteLabel | null }) {
   if (!label) return null;
   return (
     <span
-      className={`inline-block w-2.5 h-2.5 rounded-full shrink-0 ${LABEL_COLORS[label]}`}
+      className="inline-block w-2.5 h-2.5 rounded-full shrink-0"
+      style={{ background: LABEL_HEX[label] }}
       title={LABEL_NAMES[label]}
     />
   );
@@ -39,15 +40,20 @@ export function NoteLabelPicker({
 }) {
   return (
     <div className="flex items-center gap-1.5">
-      <span className="text-xs text-gray-500 dark:text-gray-400">Etikett:</span>
+      <span className="text-xs" style={{ color: "var(--tn-text-faint)" }}>Etikett:</span>
       {NOTE_LABELS.map((label) => (
         <button
           key={label}
           type="button"
           onClick={() => onChange(value === label ? null : label)}
-          className={`w-5 h-5 rounded-full transition-transform ${LABEL_COLORS[label]} ${
-            value === label ? "ring-2 ring-white scale-125" : "opacity-60 hover:opacity-100"
-          }`}
+          className="w-5 h-5 rounded-full transition-transform"
+          style={{
+            background: LABEL_HEX[label],
+            opacity: value === label ? 1 : 0.5,
+            transform: value === label ? "scale(1.25)" : "scale(1)",
+            outline: value === label ? "2px solid var(--tn-text)" : "none",
+            outlineOffset: 1,
+          }}
           title={LABEL_NAMES[label]}
         />
       ))}
@@ -55,7 +61,8 @@ export function NoteLabelPicker({
         <button
           type="button"
           onClick={() => onChange(null)}
-          className="text-xs text-gray-400 dark:text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 ml-1"
+          className="text-xs ml-1"
+          style={{ color: "var(--tn-text-faint)", background: "none", border: "none", cursor: "pointer" }}
         >
           ✕
         </button>

--- a/components/sallskap/TabBar.tsx
+++ b/components/sallskap/TabBar.tsx
@@ -16,21 +16,29 @@ interface TabBarProps {
 
 export function TabBar({ activeTab, onChange }: TabBarProps) {
   return (
-    <div className="sticky top-0 z-20 bg-white dark:bg-gray-950 border-b border-gray-200 dark:border-gray-800">
+    <div
+      className="sticky top-0 z-20"
+      style={{ background: "var(--tn-bg)", borderBottom: "1px solid var(--tn-border)" }}
+    >
       <div className="flex">
-        {TABS.map((tab) => (
-          <button
-            key={tab.key}
-            onClick={() => onChange(tab.key)}
-            className={`flex-1 py-3 text-sm font-medium transition border-b-2 ${
-              activeTab === tab.key
-                ? "border-indigo-600 text-indigo-600 dark:text-indigo-400"
-                : "border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200"
-            }`}
-          >
-            {tab.label}
-          </button>
-        ))}
+        {TABS.map((tab) => {
+          const isActive = activeTab === tab.key;
+          return (
+            <button
+              key={tab.key}
+              onClick={() => onChange(tab.key)}
+              className="flex-1 py-3 text-sm font-medium transition"
+              style={{
+                borderBottom: isActive ? "2px solid var(--tn-accent)" : "2px solid transparent",
+                color: isActive ? "var(--tn-accent)" : "var(--tn-text-faint)",
+                background: "none",
+                cursor: "pointer",
+              }}
+            >
+              {tab.label}
+            </button>
+          );
+        })}
       </div>
     </div>
   );

--- a/components/sallskap/activity/ActivityFeed.tsx
+++ b/components/sallskap/activity/ActivityFeed.tsx
@@ -9,7 +9,6 @@ function relativeTime(dateStr: string): string {
   const now = Date.now();
   const then = new Date(dateStr).getTime();
   const diffSec = Math.floor((now - then) / 1000);
-
   if (diffSec < 60) return "just nu";
   const diffMin = Math.floor(diffSec / 60);
   if (diffMin < 60) return `${diffMin} min sedan`;
@@ -26,30 +25,31 @@ const VALID_LABELS = new Set(["red", "orange", "yellow", "green", "blue", "purpl
 export function ActivityFeed({ items }: { items: ActivityItem[] }) {
   if (items.length === 0) {
     return (
-      <p className="text-sm text-gray-500 dark:text-gray-400 italic text-center py-8">
+      <p className="text-sm italic text-center py-8" style={{ color: "var(--tn-text-faint)" }}>
         Ingen aktivitet ännu. Börja diskutera i Forum-fliken!
       </p>
     );
   }
 
   return (
-    <div className="divide-y divide-gray-200 dark:divide-gray-800">
+    <div style={{ borderTop: "1px solid var(--tn-border)" }}>
       {items.map((item) => (
-        <div key={item.id} className="px-4 py-3">
+        <div key={item.id} className="px-4 py-3" style={{ borderBottom: "1px solid var(--tn-border)" }}>
           {item.kind === "post" ? (
             <div>
               <div className="flex items-center gap-2 mb-1">
-                <span className="text-xs font-medium text-indigo-600 dark:text-indigo-400">Forum</span>
-                <span className="text-xs text-gray-400 dark:text-gray-500">&middot;</span>
-                <span className="text-xs text-gray-500 dark:text-gray-400">{relativeTime(item.created_at)}</span>
+                <span className="text-xs font-medium" style={{ color: "var(--tn-accent)" }}>Forum</span>
+                <span className="text-xs" style={{ color: "var(--tn-text-faint)" }}>&middot;</span>
+                <span className="text-xs" style={{ color: "var(--tn-text-faint)" }}>{relativeTime(item.created_at)}</span>
               </div>
-              <p className="text-sm text-gray-900 dark:text-white line-clamp-2">{item.content}</p>
+              <p className="text-sm line-clamp-2" style={{ color: "var(--tn-text)" }}>{item.content}</p>
               <div className="flex items-center gap-2 mt-1">
-                <span className="text-xs text-gray-500 dark:text-gray-400">{item.author}</span>
+                <span className="text-xs" style={{ color: "var(--tn-text-faint)" }}>{item.author}</span>
                 {item.game_date && (
                   <Link
                     href={`/?game=${encodeURIComponent(item.game_id)}`}
-                    className="text-xs text-indigo-500 dark:text-indigo-400 hover:underline"
+                    className="text-xs hover:underline"
+                    style={{ color: "var(--tn-accent)" }}
                   >
                     {item.game_type} {item.game_date}
                   </Link>
@@ -59,17 +59,15 @@ export function ActivityFeed({ items }: { items: ActivityItem[] }) {
           ) : (
             <div>
               <div className="flex items-center gap-2 mb-1">
-                {VALID_LABELS.has(item.label) && (
-                  <NoteLabelDot label={item.label as NoteLabel} />
-                )}
-                <span className="text-xs font-medium text-purple-600 dark:text-purple-400">Anteckning</span>
-                <span className="text-xs text-gray-400 dark:text-gray-500">&middot;</span>
-                <span className="text-xs text-gray-500 dark:text-gray-400">{relativeTime(item.created_at)}</span>
+                {VALID_LABELS.has(item.label) && <NoteLabelDot label={item.label as NoteLabel} />}
+                <span className="text-xs font-medium" style={{ color: "var(--tn-text-dim)" }}>Anteckning</span>
+                <span className="text-xs" style={{ color: "var(--tn-text-faint)" }}>&middot;</span>
+                <span className="text-xs" style={{ color: "var(--tn-text-faint)" }}>{relativeTime(item.created_at)}</span>
               </div>
-              <p className="text-sm text-gray-900 dark:text-white line-clamp-2">{item.content}</p>
+              <p className="text-sm line-clamp-2" style={{ color: "var(--tn-text)" }}>{item.content}</p>
               <div className="flex items-center gap-2 mt-1">
-                <span className="text-xs text-gray-500 dark:text-gray-400">{item.author}</span>
-                <span className="text-xs text-gray-600 dark:text-gray-400 font-medium">{item.horse_name}</span>
+                <span className="text-xs" style={{ color: "var(--tn-text-faint)" }}>{item.author}</span>
+                <span className="text-xs font-medium" style={{ color: "var(--tn-text-dim)" }}>{item.horse_name}</span>
               </div>
             </div>
           )}

--- a/components/sallskap/activity/ActivityTab.tsx
+++ b/components/sallskap/activity/ActivityTab.tsx
@@ -24,11 +24,12 @@ export function ActivityTab({ groupId, initialActivity }: ActivityTabProps) {
   return (
     <div className="max-w-2xl mx-auto py-4">
       <div className="flex items-center justify-between px-4 mb-3">
-        <h2 className="text-sm font-semibold text-gray-700 dark:text-gray-300">Senaste aktivitet</h2>
+        <h2 className="tn-eyebrow">Senaste aktivitet</h2>
         <button
           onClick={handleRefresh}
           disabled={isPending}
-          className="text-xs text-indigo-600 dark:text-indigo-400 hover:text-indigo-800 dark:hover:text-indigo-200 disabled:opacity-50 transition"
+          className="text-xs transition disabled:opacity-50"
+          style={{ color: "var(--tn-accent)", background: "none", border: "none", cursor: "pointer" }}
         >
           {isPending ? "Uppdaterar..." : "Uppdatera"}
         </button>

--- a/components/sallskap/admin/AdminTab.tsx
+++ b/components/sallskap/admin/AdminTab.tsx
@@ -31,58 +31,41 @@ export function AdminTab({ group, members, currentUserId }: AdminTabProps) {
 
   return (
     <div className="px-4 py-5 space-y-6 max-w-2xl mx-auto">
-      {/* Namn */}
       <section className="space-y-2">
-        <h2 className="text-sm font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">
-          Sällskapets namn
-        </h2>
+        <h2 className="tn-eyebrow">Sällskapets namn</h2>
         {isCreator ? (
           <GroupNameForm groupId={group.id} initialName={groupName} onUpdated={setGroupName} />
         ) : (
-          <p className="text-gray-900 dark:text-white font-medium">{groupName}</p>
+          <p className="font-medium" style={{ color: "var(--tn-text)" }}>{groupName}</p>
         )}
       </section>
 
-      {/* ATG-lag */}
       <section className="space-y-2">
-        <h2 className="text-sm font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">
-          ATG-lag
-        </h2>
-        <AtgTeamUrlForm
-          groupId={group.id}
-          initialUrl={atgUrl}
-          isCreator={isCreator}
-          onUpdated={setAtgUrl}
-        />
+        <h2 className="tn-eyebrow">ATG-lag</h2>
+        <AtgTeamUrlForm groupId={group.id} initialUrl={atgUrl} isCreator={isCreator} onUpdated={setAtgUrl} />
       </section>
 
-      {/* Inbjudningslänk */}
       <section className="space-y-2">
-        <h2 className="text-sm font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">
-          Inbjudning
-        </h2>
+        <h2 className="tn-eyebrow">Inbjudning</h2>
         <InviteLinkSection inviteCode={group.invite_code} />
       </section>
 
-      {/* Medlemmar */}
       <section className="space-y-2">
-        <h2 className="text-sm font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">
-          Medlemmar ({members.length})
-        </h2>
+        <h2 className="tn-eyebrow">Medlemmar ({members.length})</h2>
         <MemberList members={members} creatorId={group.created_by} />
       </section>
 
-      {/* Lämna sällskap */}
-      <section className="pt-2 border-t border-gray-200 dark:border-gray-800">
+      <section className="pt-2" style={{ borderTop: "1px solid var(--tn-border)" }}>
         <button
           onClick={handleLeave}
           disabled={leaving}
-          className="text-sm text-red-400 hover:text-red-300 disabled:opacity-50 transition"
+          className="text-sm transition disabled:opacity-50"
+          style={{ color: "var(--tn-value-low)", background: "none", border: "none", cursor: "pointer" }}
         >
           {leaving ? "Lämnar…" : "Lämna sällskap"}
         </button>
         {isCreator && (
-          <p className="text-xs text-gray-400 dark:text-gray-500 mt-1">
+          <p className="text-xs mt-1" style={{ color: "var(--tn-text-faint)" }}>
             Du är skaparen — sällskapet kvarstår för övriga medlemmar.
           </p>
         )}

--- a/components/sallskap/admin/AtgTeamUrlForm.tsx
+++ b/components/sallskap/admin/AtgTeamUrlForm.tsx
@@ -24,51 +24,33 @@ export function AtgTeamUrlForm({ groupId, initialUrl, isCreator, onUpdated }: At
     const trimmed = url.trim() || null;
     const { error } = await updateGroup(groupId, { atg_team_url: trimmed });
     setLoading(false);
-    if (error) {
-      setError(error);
-    } else {
-      setSavedUrl(trimmed);
-      onUpdated(trimmed);
-      setEditing(false);
-    }
+    if (error) { setError(error); }
+    else { setSavedUrl(trimmed); onUpdated(trimmed); setEditing(false); }
   }
 
-  // Icke-skapare: bara visa länk
   if (!isCreator) {
-    if (!savedUrl) {
-      return <p className="text-sm text-gray-500 dark:text-gray-400 italic">Ingen ATG-lagslänk inlagd ännu.</p>;
-    }
+    if (!savedUrl) return <p className="text-sm italic" style={{ color: "var(--tn-text-faint)" }}>Ingen ATG-lagslänk inlagd ännu.</p>;
     return (
-      <a
-        href={savedUrl}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="text-sm text-indigo-600 dark:text-indigo-400 hover:underline break-all"
-      >
+      <a href={savedUrl} target="_blank" rel="noopener noreferrer" className="text-sm hover:underline break-all" style={{ color: "var(--tn-accent)" }}>
         {savedUrl}
       </a>
     );
   }
 
-  // Skapare i visningsläge
   if (!editing) {
     return (
       <div className="flex items-start gap-3 flex-wrap">
         {savedUrl ? (
-          <a
-            href={savedUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-sm text-indigo-600 dark:text-indigo-400 hover:underline break-all flex-1"
-          >
+          <a href={savedUrl} target="_blank" rel="noopener noreferrer" className="text-sm hover:underline break-all flex-1" style={{ color: "var(--tn-accent)" }}>
             {savedUrl}
           </a>
         ) : (
-          <p className="text-sm text-gray-500 dark:text-gray-400 italic flex-1">Ingen länk inlagd ännu.</p>
+          <p className="text-sm italic flex-1" style={{ color: "var(--tn-text-faint)" }}>Ingen länk inlagd ännu.</p>
         )}
         <button
           onClick={() => { setUrl(savedUrl ?? ""); setEditing(true); setError(null); }}
-          className="text-xs text-indigo-600 dark:text-indigo-400 hover:text-indigo-300 transition shrink-0"
+          className="text-xs transition shrink-0"
+          style={{ color: "var(--tn-accent)", background: "none", border: "none", cursor: "pointer" }}
         >
           {savedUrl ? "Redigera" : "Lägg till"}
         </button>
@@ -76,7 +58,6 @@ export function AtgTeamUrlForm({ groupId, initialUrl, isCreator, onUpdated }: At
     );
   }
 
-  // Redigeringsläge
   return (
     <form onSubmit={handleSubmit} className="space-y-2">
       <div className="flex gap-2 items-center flex-wrap">
@@ -86,24 +67,27 @@ export function AtgTeamUrlForm({ groupId, initialUrl, isCreator, onUpdated }: At
           onChange={(e) => setUrl(e.target.value)}
           placeholder="https://www.atg.se/lag/..."
           autoFocus
-          className="flex-1 min-w-0 bg-gray-100 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-sm text-gray-900 dark:text-white placeholder-gray-400 focus:outline-none focus:border-indigo-500"
+          className="flex-1 min-w-0 rounded-lg px-3 py-2 text-sm outline-none"
+          style={{ background: "var(--tn-bg-chip)", border: "1px solid var(--tn-border)", color: "var(--tn-text)" }}
         />
         <button
           type="button"
           onClick={() => { setEditing(false); setError(null); }}
-          className="text-xs text-gray-500 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200 px-3 py-2 rounded-lg transition"
+          className="text-xs px-3 py-2 rounded-lg transition"
+          style={{ color: "var(--tn-text-faint)", background: "none", border: "none", cursor: "pointer" }}
         >
           Avbryt
         </button>
         <button
           type="submit"
           disabled={loading}
-          className="bg-indigo-600 hover:bg-indigo-500 disabled:opacity-50 text-white text-sm px-4 py-2 rounded-lg transition"
+          className="text-sm px-4 py-2 rounded-lg transition disabled:opacity-50"
+          style={{ background: "var(--tn-accent)", color: "#fff", border: "none", cursor: "pointer" }}
         >
           {loading ? "Sparar…" : "Spara"}
         </button>
       </div>
-      {error && <p className="text-red-400 text-xs">{error}</p>}
+      {error && <p className="text-xs" style={{ color: "var(--tn-value-low)" }}>{error}</p>}
     </form>
   );
 }

--- a/components/sallskap/admin/GroupNameForm.tsx
+++ b/components/sallskap/admin/GroupNameForm.tsx
@@ -20,12 +20,8 @@ export function GroupNameForm({ groupId, initialName, onUpdated }: GroupNameForm
     setMessage(null);
     const { error } = await updateGroup(groupId, { name: name.trim() });
     setLoading(false);
-    if (error) {
-      setMessage(error);
-    } else {
-      setMessage("Sparat!");
-      onUpdated(name.trim());
-    }
+    if (error) { setMessage(error); }
+    else { setMessage("Sparat!"); onUpdated(name.trim()); }
   }
 
   return (
@@ -36,18 +32,18 @@ export function GroupNameForm({ groupId, initialName, onUpdated }: GroupNameForm
         onChange={(e) => setName(e.target.value)}
         placeholder="Sällskapets namn"
         maxLength={60}
-        className="flex-1 min-w-0 bg-gray-100 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-sm text-gray-900 dark:text-white placeholder-gray-400 focus:outline-none focus:border-indigo-500"
+        className="flex-1 min-w-0 rounded-lg px-3 py-2 text-sm outline-none"
+        style={{ background: "var(--tn-bg-chip)", border: "1px solid var(--tn-border)", color: "var(--tn-text)" }}
       />
       <button
         type="submit"
         disabled={loading || !name.trim()}
-        className="bg-indigo-600 hover:bg-indigo-500 disabled:opacity-50 text-white text-sm px-4 py-2 rounded-lg transition"
+        className="text-sm px-4 py-2 rounded-lg transition disabled:opacity-50"
+        style={{ background: "var(--tn-accent)", color: "#fff", border: "none", cursor: "pointer" }}
       >
         {loading ? "Sparar…" : "Spara"}
       </button>
-      {message && (
-        <span className="text-xs text-gray-500 dark:text-gray-400">{message}</span>
-      )}
+      {message && <span className="text-xs" style={{ color: "var(--tn-text-faint)" }}>{message}</span>}
     </form>
   );
 }

--- a/components/sallskap/admin/InviteLinkSection.tsx
+++ b/components/sallskap/admin/InviteLinkSection.tsx
@@ -4,17 +4,16 @@ import { useState } from "react";
 
 function CopyButton({ text, label, mono }: { text: string; label: string; mono?: boolean }) {
   const [copied, setCopied] = useState(false);
-
   async function handleCopy() {
     await navigator.clipboard.writeText(text);
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
   }
-
   return (
     <button
       onClick={handleCopy}
-      className={`text-xs text-indigo-600 dark:text-indigo-400 hover:text-indigo-300 transition ${mono ? "font-mono tracking-widest" : ""}`}
+      className={`text-xs transition ${mono ? "tn-mono" : ""}`}
+      style={{ color: "var(--tn-accent)", background: "none", border: "none", cursor: "pointer" }}
       title={`Kopiera ${label}`}
     >
       {mono ? text : label} {copied ? "✓" : "⎘"}
@@ -24,18 +23,17 @@ function CopyButton({ text, label, mono }: { text: string; label: string; mono?:
 
 function CopyLinkButton({ inviteCode }: { inviteCode: string }) {
   const [copied, setCopied] = useState(false);
-
   async function handleCopy() {
     const url = `${window.location.origin}/join/${inviteCode}`;
     await navigator.clipboard.writeText(url);
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
   }
-
   return (
     <button
       onClick={handleCopy}
-      className="text-xs text-indigo-600 dark:text-indigo-400 hover:text-indigo-300 transition"
+      className="text-xs transition"
+      style={{ color: "var(--tn-accent)", background: "none", border: "none", cursor: "pointer" }}
       title="Kopiera inbjudningslänk"
     >
       Kopiera länk {copied ? "✓" : "🔗"}
@@ -45,13 +43,13 @@ function CopyLinkButton({ inviteCode }: { inviteCode: string }) {
 
 export function InviteLinkSection({ inviteCode }: { inviteCode: string }) {
   return (
-    <div className="bg-gray-100 dark:bg-gray-800 rounded-lg px-3 py-3 flex items-center gap-3 flex-wrap">
+    <div className="rounded-lg px-3 py-3 flex items-center gap-3 flex-wrap" style={{ background: "var(--tn-bg-chip)" }}>
       <div className="flex items-center gap-1.5">
-        <span className="text-xs text-gray-500 dark:text-gray-400">Kod:</span>
+        <span className="text-xs" style={{ color: "var(--tn-text-faint)" }}>Kod:</span>
         <CopyButton text={inviteCode} label="inbjudningskod" mono />
       </div>
       <CopyLinkButton inviteCode={inviteCode} />
-      <p className="text-xs text-gray-400 dark:text-gray-500 w-full">
+      <p className="text-xs w-full" style={{ color: "var(--tn-text-faint)" }}>
         Dela koden eller länken med dina vänner så kan de gå med i sällskapet.
       </p>
     </div>

--- a/components/sallskap/admin/MemberList.tsx
+++ b/components/sallskap/admin/MemberList.tsx
@@ -14,19 +14,29 @@ export function MemberList({ members, creatorId }: { members: GroupMember[]; cre
   return (
     <ul className="space-y-2">
       {members.map((m) => (
-        <li key={m.user_id} className="flex items-center justify-between gap-2 bg-gray-100 dark:bg-gray-800 rounded-lg px-3 py-2">
+        <li
+          key={m.user_id}
+          className="flex items-center justify-between gap-2 rounded-lg px-3 py-2"
+          style={{ background: "var(--tn-bg-chip)" }}
+        >
           <div className="flex items-center gap-2 min-w-0">
-            <span className="w-7 h-7 rounded-full bg-indigo-700 flex items-center justify-center text-white text-xs font-bold shrink-0">
+            <span
+              className="w-7 h-7 rounded-full flex items-center justify-center text-xs font-bold shrink-0"
+              style={{ background: "var(--tn-accent)", color: "#fff" }}
+            >
               {m.display_name.slice(0, 2).toUpperCase()}
             </span>
-            <span className="text-sm text-gray-900 dark:text-white truncate">{m.display_name}</span>
+            <span className="text-sm truncate" style={{ color: "var(--tn-text)" }}>{m.display_name}</span>
             {m.user_id === creatorId && (
-              <span className="text-xs bg-gray-200 dark:bg-gray-700 text-gray-500 dark:text-gray-400 px-1.5 py-0.5 rounded shrink-0">
+              <span
+                className="text-xs px-1.5 py-0.5 rounded shrink-0"
+                style={{ background: "var(--tn-bg-card)", color: "var(--tn-text-faint)" }}
+              >
                 skapare
               </span>
             )}
           </div>
-          <span className="text-xs text-gray-400 dark:text-gray-500 shrink-0">
+          <span className="text-xs shrink-0" style={{ color: "var(--tn-text-faint)" }}>
             {relativeDate(m.joined_at)}
           </span>
         </li>

--- a/components/sallskap/forum/ForumTab.tsx
+++ b/components/sallskap/forum/ForumTab.tsx
@@ -35,71 +35,42 @@ export function ForumTab({ groupId, games, initialPosts, initialGameId, currentU
 
   const handleDeleted = useCallback((postId: string) => {
     setPosts((prev) =>
-      prev
-        .filter((p) => p.id !== postId)
-        .map((p) => ({
-          ...p,
-          replies: p.replies.filter((r) => r.id !== postId),
-        }))
+      prev.filter((p) => p.id !== postId).map((p) => ({ ...p, replies: p.replies.filter((r) => r.id !== postId) }))
     );
   }, []);
 
   const handleReplied = useCallback((reply: GroupPost, parentId: string) => {
-    setPosts((prev) =>
-      prev.map((p) =>
-        p.id === parentId ? { ...p, replies: [...p.replies, reply] } : p
-      )
-    );
+    setPosts((prev) => prev.map((p) => p.id === parentId ? { ...p, replies: [...p.replies, reply] } : p));
   }, []);
 
   return (
     <div className="px-4 py-5 space-y-5 max-w-2xl mx-auto">
-      {/* Omgångsväljare */}
       {games.length > 0 && (
-        <div>
-          <select
-            value={selectedGameId ?? ""}
-            onChange={(e) => handleGameChange(e.target.value)}
-            className="w-full bg-gray-100 dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded-lg px-3 py-2 text-sm text-gray-900 dark:text-white focus:outline-none focus:border-indigo-500"
-          >
-            {games.map((g) => (
-              <option key={g.id} value={g.id}>
-                {g.date}{g.track ? ` – ${g.track}` : ""}
-              </option>
-            ))}
-          </select>
-        </div>
+        <select
+          value={selectedGameId ?? ""}
+          onChange={(e) => handleGameChange(e.target.value)}
+          className="w-full rounded-lg px-3 py-2 text-sm outline-none"
+          style={{ background: "var(--tn-bg-chip)", border: "1px solid var(--tn-border)", color: "var(--tn-text)" }}
+        >
+          {games.map((g) => (
+            <option key={g.id} value={g.id}>{g.date}{g.track ? ` – ${g.track}` : ""}</option>
+          ))}
+        </select>
       )}
 
       {games.length === 0 && (
-        <p className="text-sm text-gray-500 dark:text-gray-400 italic">
+        <p className="text-sm italic" style={{ color: "var(--tn-text-faint)" }}>
           Ingen omgång inladdad ännu. Hämta en V85-omgång på startsidan först.
         </p>
       )}
 
       {selectedGameId && (
         <>
-          {/* Nytt inlägg */}
-          <div>
-            <PostForm
-              groupId={groupId}
-              gameId={selectedGameId}
-              onAdded={handleAdded}
-            />
-          </div>
-
-          {/* Inläggslista */}
+          <PostForm groupId={groupId} gameId={selectedGameId} onAdded={handleAdded} />
           {loading ? (
-            <p className="text-sm text-gray-400 dark:text-gray-500 text-center py-4">Laddar…</p>
+            <p className="text-sm text-center py-4" style={{ color: "var(--tn-text-faint)" }}>Laddar…</p>
           ) : (
-            <PostList
-              posts={posts}
-              groupId={groupId}
-              gameId={selectedGameId}
-              currentUserId={currentUserId}
-              onDeleted={handleDeleted}
-              onReplied={handleReplied}
-            />
+            <PostList posts={posts} groupId={groupId} gameId={selectedGameId} currentUserId={currentUserId} onDeleted={handleDeleted} onReplied={handleReplied} />
           )}
         </>
       )}

--- a/components/sallskap/forum/PostForm.tsx
+++ b/components/sallskap/forum/PostForm.tsx
@@ -26,12 +26,8 @@ export function PostForm({ groupId, gameId, parentId, onAdded, onCancel, compact
     setError(null);
     const { data, error } = await addPost(groupId, gameId, content, parentId);
     setLoading(false);
-    if (error) {
-      setError(error);
-    } else if (data) {
-      setContent("");
-      onAdded(data);
-    }
+    if (error) { setError(error); }
+    else if (data) { setContent(""); onAdded(data); }
   }
 
   return (
@@ -41,14 +37,16 @@ export function PostForm({ groupId, gameId, parentId, onAdded, onCancel, compact
         onChange={(e) => setContent(e.target.value)}
         placeholder={isReply ? "Skriv ett svar…" : "Dela din analys om omgången…"}
         rows={compact ? 2 : 3}
-        className="w-full bg-gray-100 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-sm text-gray-900 dark:text-white placeholder-gray-400 focus:outline-none focus:border-indigo-500 resize-none"
+        className="w-full rounded-lg px-3 py-2 text-sm resize-none outline-none"
+        style={{ background: "var(--tn-bg-chip)", border: "1px solid var(--tn-border)", color: "var(--tn-text)" }}
       />
       <div className="flex gap-2 justify-end">
         {onCancel && (
           <button
             type="button"
             onClick={onCancel}
-            className="text-xs text-gray-500 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200 px-3 py-1.5 rounded-lg transition"
+            className="text-xs px-3 py-1.5 rounded-lg transition"
+            style={{ color: "var(--tn-text-faint)", background: "none", border: "none", cursor: "pointer" }}
           >
             Avbryt
           </button>
@@ -56,12 +54,13 @@ export function PostForm({ groupId, gameId, parentId, onAdded, onCancel, compact
         <button
           type="submit"
           disabled={loading || !content.trim()}
-          className="bg-indigo-600 hover:bg-indigo-500 disabled:opacity-50 text-white text-xs px-3 py-1.5 rounded-lg transition"
+          className="text-xs px-3 py-1.5 rounded-lg transition disabled:opacity-50"
+          style={{ background: "var(--tn-accent)", color: "#fff", border: "none", cursor: "pointer" }}
         >
           {loading ? "Skickar…" : isReply ? "Svara" : "Publicera"}
         </button>
       </div>
-      {error && <p className="text-red-400 text-xs">{error}</p>}
+      {error && <p className="text-xs" style={{ color: "var(--tn-value-low)" }}>{error}</p>}
     </form>
   );
 }

--- a/components/sallskap/forum/PostItem.tsx
+++ b/components/sallskap/forum/PostItem.tsx
@@ -27,15 +27,7 @@ interface PostItemProps {
   isReply?: boolean;
 }
 
-export function PostItem({
-  post,
-  groupId,
-  gameId,
-  currentUserId,
-  onDeleted,
-  onReplied,
-  isReply = false,
-}: PostItemProps) {
+export function PostItem({ post, groupId, gameId, currentUserId, onDeleted, onReplied, isReply = false }: PostItemProps) {
   const [showReplyForm, setShowReplyForm] = useState(false);
   const [deleting, setDeleting] = useState(false);
 
@@ -51,26 +43,30 @@ export function PostItem({
   }
 
   return (
-    <div className={`${isReply ? "ml-4 pl-3 border-l-2 border-gray-300 dark:border-gray-700" : ""}`}>
-      <div className="bg-gray-100 dark:bg-gray-800 rounded-lg p-3 space-y-1.5">
-        {/* Header */}
+    <div
+      className={isReply ? "ml-4 pl-3" : ""}
+      style={isReply ? { borderLeft: "2px solid var(--tn-border)" } : {}}
+    >
+      <div className="rounded-lg p-3 space-y-1.5" style={{ background: "var(--tn-bg-chip)" }}>
         <div className="flex items-center gap-2 flex-wrap">
-          <span className="w-6 h-6 rounded-full bg-indigo-700 flex items-center justify-center text-white text-xs font-bold shrink-0">
+          <span
+            className="w-6 h-6 rounded-full flex items-center justify-center text-xs font-bold shrink-0"
+            style={{ background: "var(--tn-accent)", color: "#fff" }}
+          >
             {post.author_display_name.slice(0, 2).toUpperCase()}
           </span>
-          <span className="text-gray-900 dark:text-white text-xs font-medium">{post.author_display_name}</span>
-          <span className="text-gray-400 dark:text-gray-500 text-xs ml-auto">{relativeTime(post.created_at)}</span>
+          <span className="text-xs font-medium" style={{ color: "var(--tn-text)" }}>{post.author_display_name}</span>
+          <span className="text-xs ml-auto" style={{ color: "var(--tn-text-faint)" }}>{relativeTime(post.created_at)}</span>
         </div>
 
-        {/* Content */}
-        <p className="text-gray-800 dark:text-gray-200 text-sm leading-relaxed whitespace-pre-wrap">{post.content}</p>
+        <p className="text-sm leading-relaxed whitespace-pre-wrap" style={{ color: "var(--tn-text)" }}>{post.content}</p>
 
-        {/* Actions */}
         <div className="flex items-center gap-3 pt-0.5">
           {!isReply && (
             <button
               onClick={() => setShowReplyForm((v) => !v)}
-              className="text-xs text-indigo-600 dark:text-indigo-400 hover:text-indigo-300 transition"
+              className="text-xs transition"
+              style={{ color: "var(--tn-accent)", background: "none", border: "none", cursor: "pointer" }}
             >
               {showReplyForm ? "Avbryt" : "Svara"}
             </button>
@@ -79,7 +75,8 @@ export function PostItem({
             <button
               onClick={handleDelete}
               disabled={deleting}
-              className="text-xs text-red-400 hover:text-red-300 disabled:opacity-50 transition"
+              className="text-xs transition disabled:opacity-50"
+              style={{ color: "var(--tn-value-low)", background: "none", border: "none", cursor: "pointer" }}
             >
               {deleting ? "Tar bort…" : "Ta bort"}
             </button>
@@ -87,34 +84,16 @@ export function PostItem({
         </div>
       </div>
 
-      {/* Reply form */}
       {showReplyForm && !isReply && (
         <div className="mt-2 ml-4">
-          <PostForm
-            groupId={groupId}
-            gameId={gameId}
-            parentId={post.id}
-            onAdded={handleReplied}
-            onCancel={() => setShowReplyForm(false)}
-            compact
-          />
+          <PostForm groupId={groupId} gameId={gameId} parentId={post.id} onAdded={handleReplied} onCancel={() => setShowReplyForm(false)} compact />
         </div>
       )}
 
-      {/* Replies */}
       {post.replies && post.replies.length > 0 && (
         <div className="mt-2 space-y-2">
           {post.replies.map((reply) => (
-            <PostItem
-              key={reply.id}
-              post={reply}
-              groupId={groupId}
-              gameId={gameId}
-              currentUserId={currentUserId}
-              onDeleted={onDeleted}
-              onReplied={onReplied}
-              isReply
-            />
+            <PostItem key={reply.id} post={reply} groupId={groupId} gameId={gameId} currentUserId={currentUserId} onDeleted={onDeleted} onReplied={onReplied} isReply />
           ))}
         </div>
       )}

--- a/components/sallskap/forum/PostList.tsx
+++ b/components/sallskap/forum/PostList.tsx
@@ -13,7 +13,7 @@ interface PostListProps {
 export function PostList({ posts, groupId, gameId, currentUserId, onDeleted, onReplied }: PostListProps) {
   if (posts.length === 0) {
     return (
-      <p className="text-gray-500 dark:text-gray-400 text-sm italic py-4 text-center">
+      <p className="text-sm italic py-4 text-center" style={{ color: "var(--tn-text-faint)" }}>
         Inga inlägg ännu. Dela din analys!
       </p>
     );

--- a/components/sallskap/notes/GroupNotesRaceSection.tsx
+++ b/components/sallskap/notes/GroupNotesRaceSection.tsx
@@ -26,45 +26,49 @@ interface GroupNotesRaceSectionProps {
 }
 
 function formatTime(isoStr: string): string {
-  try {
-    return new Date(isoStr).toLocaleTimeString("sv-SE", { hour: "2-digit", minute: "2-digit" });
-  } catch {
-    return "";
-  }
+  try { return new Date(isoStr).toLocaleTimeString("sv-SE", { hour: "2-digit", minute: "2-digit" }); }
+  catch { return ""; }
 }
 
 export function GroupNotesRaceSection({ race, userGroups, currentUserId }: GroupNotesRaceSectionProps) {
   const [expanded, setExpanded] = useState(false);
-
   const sortedStarters = [...race.starters].sort((a, b) => a.start_number - b.start_number);
   const timeStr = race.start_time ? formatTime(race.start_time) : null;
 
   return (
-    <div className="border border-gray-200 dark:border-gray-800 rounded-xl overflow-hidden">
+    <div className="rounded-xl overflow-hidden" style={{ border: "1px solid var(--tn-border)" }}>
       <button
         onClick={() => setExpanded((v) => !v)}
-        className="w-full flex items-center justify-between px-4 py-3 bg-gray-50 dark:bg-gray-900 hover:bg-gray-100 dark:hover:bg-gray-800 transition text-left"
+        className="w-full flex items-center justify-between px-4 py-3 text-left transition"
+        style={{ background: "var(--tn-bg-card)", border: "none", cursor: "pointer" }}
+        onMouseEnter={(e) => { e.currentTarget.style.background = "var(--tn-bg-card-hover)"; }}
+        onMouseLeave={(e) => { e.currentTarget.style.background = "var(--tn-bg-card)"; }}
       >
-        <span className="text-sm font-semibold text-gray-900 dark:text-white">
-          Avd {race.race_number}
-          {race.race_name ? ` – ${race.race_name}` : ""}
-          {timeStr ? ` · ${timeStr}` : ""}
+        <span className="text-sm font-semibold" style={{ color: "var(--tn-text)" }}>
+          Avd {race.race_number}{race.race_name ? ` – ${race.race_name}` : ""}{timeStr ? ` · ${timeStr}` : ""}
         </span>
-        <span className="text-gray-400 dark:text-gray-500 text-xs">{expanded ? "▲" : "▼"}</span>
+        <svg
+          width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+          strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"
+          className={`transition-transform duration-200 ${expanded ? "rotate-180" : ""}`}
+          style={{ color: "var(--tn-text-faint)" }}
+        >
+          <path d="M6 9l6 6 6-6" />
+        </svg>
       </button>
 
       {expanded && (
-        <div className="divide-y divide-gray-200 dark:divide-gray-800">
-          {sortedStarters.map((starter) => (
-            <div key={starter.id} className="px-4 py-3">
-              <p className="text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">
+        <div style={{ borderTop: "1px solid var(--tn-border)" }}>
+          {sortedStarters.map((starter, i) => (
+            <div
+              key={starter.id}
+              className="px-4 py-3"
+              style={{ borderTop: i > 0 ? "1px solid var(--tn-border)" : "none" }}
+            >
+              <p className="text-xs font-medium mb-1" style={{ color: "var(--tn-text-dim)" }}>
                 {starter.start_number}. {starter.horses?.name ?? starter.horse_id}
               </p>
-              <HorseNotes
-                horseId={starter.horse_id}
-                userGroups={userGroups}
-                currentUserId={currentUserId}
-              />
+              <HorseNotes horseId={starter.horse_id} userGroups={userGroups} currentUserId={currentUserId} />
             </div>
           ))}
         </div>

--- a/components/sallskap/notes/NotesTab.tsx
+++ b/components/sallskap/notes/NotesTab.tsx
@@ -14,11 +14,8 @@ interface NotesTabProps {
 }
 
 function formatTime(isoStr: string): string {
-  try {
-    return new Date(isoStr).toLocaleTimeString("sv-SE", { hour: "2-digit", minute: "2-digit" });
-  } catch {
-    return "";
-  }
+  try { return new Date(isoStr).toLocaleTimeString("sv-SE", { hour: "2-digit", minute: "2-digit" }); }
+  catch { return ""; }
 }
 
 function relativeTime(dateStr: string): string {
@@ -38,9 +35,7 @@ export function NotesTab({ groupId, games, initialGameId, initialNotes }: NotesT
   const [races, setRaces] = useState<RaceWithNotes[]>(initialNotes);
   const [loading, setLoading] = useState(false);
 
-  useEffect(() => {
-    setRaces(initialNotes);
-  }, [initialNotes]);
+  useEffect(() => { setRaces(initialNotes); }, [initialNotes]);
 
   async function handleGameChange(gameId: string) {
     setSelectedGameId(gameId);
@@ -54,80 +49,72 @@ export function NotesTab({ groupId, games, initialGameId, initialNotes }: NotesT
 
   return (
     <div className="px-4 py-5 space-y-4 max-w-2xl mx-auto">
-      {/* Omgångsväljare */}
       {games.length > 0 && (
         <select
           value={selectedGameId ?? ""}
           onChange={(e) => handleGameChange(e.target.value)}
-          className="w-full bg-gray-100 dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded-lg px-3 py-2 text-sm text-gray-900 dark:text-white focus:outline-none focus:border-indigo-500"
+          className="w-full rounded-lg px-3 py-2 text-sm outline-none"
+          style={{ background: "var(--tn-bg-chip)", border: "1px solid var(--tn-border)", color: "var(--tn-text)" }}
         >
           {games.map((g) => (
-            <option key={g.id} value={g.id}>
-              {g.date}{g.track ? ` – ${g.track}` : ""}
-            </option>
+            <option key={g.id} value={g.id}>{g.date}{g.track ? ` – ${g.track}` : ""}</option>
           ))}
         </select>
       )}
 
       {games.length === 0 && (
-        <p className="text-sm text-gray-500 dark:text-gray-400 italic">
+        <p className="text-sm italic" style={{ color: "var(--tn-text-faint)" }}>
           Ingen omgång inladdad ännu. Hämta en V85-omgång på startsidan först.
         </p>
       )}
 
-      {loading && (
-        <p className="text-sm text-gray-400 dark:text-gray-500 text-center py-4">Laddar…</p>
-      )}
+      {loading && <p className="text-sm text-center py-4" style={{ color: "var(--tn-text-faint)" }}>Laddar…</p>}
 
       {!loading && selectedGameId && races.length === 0 && (
-        <p className="text-sm text-gray-500 dark:text-gray-400 italic text-center py-6">
+        <p className="text-sm italic text-center py-6" style={{ color: "var(--tn-text-faint)" }}>
           Inga sällskapsanteckningar finns för denna omgång.
         </p>
       )}
 
       {!loading && races.length > 0 && (
         <>
-          <p className="text-xs text-gray-400 dark:text-gray-500">
+          <p className="text-xs" style={{ color: "var(--tn-text-faint)" }}>
             {totalNotes} anteckning{totalNotes !== 1 ? "ar" : ""} på {races.reduce((s, r) => s + r.horses.length, 0)} hästar
           </p>
           <div className="space-y-4">
             {races.map((race) => (
               <div key={race.race_number} className="space-y-2">
-                {/* Loppheader */}
                 <div className="flex items-center gap-2">
-                  <span className="text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">
-                    Avd {race.race_number}
-                    {race.race_name ? ` – ${race.race_name}` : ""}
-                    {race.start_time ? ` · ${formatTime(race.start_time)}` : ""}
+                  <span className="tn-eyebrow">
+                    Avd {race.race_number}{race.race_name ? ` – ${race.race_name}` : ""}{race.start_time ? ` · ${formatTime(race.start_time)}` : ""}
                   </span>
-                  <div className="flex-1 h-px bg-gray-200 dark:bg-gray-800" />
+                  <div className="flex-1 h-px" style={{ background: "var(--tn-border)" }} />
                 </div>
 
-                {/* Hästar med anteckningar */}
                 {race.horses.map((horse) => (
                   <div key={horse.horse_id} className="space-y-2">
-                    <p className="text-xs font-medium text-gray-700 dark:text-gray-300 pl-1">
+                    <p className="text-xs font-medium pl-1" style={{ color: "var(--tn-text-dim)" }}>
                       {horse.start_number}. {horse.horse_name}
                     </p>
                     <div className="space-y-2 pl-1">
                       {horse.notes.map((note) => (
-                        <div key={note.id} className="bg-gray-100 dark:bg-gray-800 rounded-lg p-3 space-y-1.5">
+                        <div key={note.id} className="rounded-lg p-3 space-y-1.5" style={{ background: "var(--tn-bg-chip)" }}>
                           <div className="flex items-center gap-2 flex-wrap">
                             <NoteLabelDot label={note.label} />
-                            <span className="text-xs font-medium text-gray-900 dark:text-white">{note.author_display_name}</span>
-                            <span className="text-xs text-gray-400 dark:text-gray-500 ml-auto">{relativeTime(note.created_at)}</span>
+                            <span className="text-xs font-medium" style={{ color: "var(--tn-text)" }}>{note.author_display_name}</span>
+                            <span className="text-xs ml-auto" style={{ color: "var(--tn-text-faint)" }}>{relativeTime(note.created_at)}</span>
                           </div>
-                          <p className="text-sm text-gray-800 dark:text-gray-200 leading-relaxed whitespace-pre-wrap">{note.content}</p>
+                          <p className="text-sm leading-relaxed whitespace-pre-wrap" style={{ color: "var(--tn-text)" }}>{note.content}</p>
                           {note.replies.length > 0 && (
                             <div className="mt-2 space-y-2">
                               {note.replies.map((reply) => (
-                                <div key={reply.id} className="ml-4 pl-3 border-l-2 border-gray-300 dark:border-gray-700">
-                                  <div className="bg-gray-50 dark:bg-[rgb(40,44,52)] rounded-lg p-2.5 space-y-1">
+                                <div key={reply.id} className="ml-4 pl-3" style={{ borderLeft: "2px solid var(--tn-border)" }}>
+                                  <div className="rounded-lg p-2.5 space-y-1" style={{ background: "var(--tn-bg-card)" }}>
                                     <div className="flex items-center gap-2">
-                                      <span className="text-xs font-medium text-gray-900 dark:text-white">{reply.author_display_name}</span>
-                                      <span className="text-xs text-gray-400 dark:text-gray-500 ml-auto">{relativeTime(reply.created_at)}</span>
+                                      <span className="text-xs font-medium" style={{ color: "var(--tn-text)" }}>{reply.author_display_name}</span>
+                                      <span className="text-xs ml-auto" style={{ color: "var(--tn-text-faint)" }}>{relativeTime(reply.created_at)}</span>
                                     </div>
-                                    <p className="text-sm text-gray-800 dark:text-gray-200 leading-relaxed whitespace-pre-wrap">{reply.content}</p>
+                                    <p className="text-sm leading-relaxed whitespace-pre-wrap" style={{ color: "var(--tn-text)" }}>{reply.content}</p>
                                   </div>
                                 </div>
                               ))}

--- a/components/sallskap/spel/SpelTab.tsx
+++ b/components/sallskap/spel/SpelTab.tsx
@@ -52,12 +52,10 @@ export function SpelTab({ groupId, games, initialGameId, initialSystems, current
   const selectedGame = games.find(g => g.id === selectedGameId)
   const gameType = selectedGame?.game_type ?? ''
 
-  // Dela upp: utkast (egna) och sparade system (hela gruppen)
   const myDrafts = systems.filter(s => s.is_draft && s.user_id === currentUserId)
   const groupDrafts = systems.filter(s => s.is_draft && s.user_id !== currentUserId)
   const savedSystems = systems.filter(s => !s.is_draft)
 
-  // Sortera sparade: egna system först, sedan andras
   const sortedSaved = [...savedSystems].sort((a, b) => {
     if (a.user_id === currentUserId && b.user_id !== currentUserId) return -1
     if (a.user_id !== currentUserId && b.user_id === currentUserId) return 1
@@ -69,12 +67,16 @@ export function SpelTab({ groupId, games, initialGameId, initialSystems, current
 
   return (
     <div className="px-4 py-4 max-w-2xl mx-auto">
-      {/* Omgångsväljare */}
       <div className="flex items-center gap-3 mb-4">
         <select
           value={selectedGameId ?? ''}
           onChange={e => handleGameChange(e.target.value)}
-          className="flex-1 text-sm px-3 py-2 border border-gray-200 dark:border-gray-700 rounded-lg bg-white dark:bg-gray-900 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-emerald-500"
+          className="flex-1 text-sm px-3 py-2 rounded-lg focus:outline-none"
+          style={{
+            background: "var(--tn-bg-chip)",
+            border: "1px solid var(--tn-border)",
+            color: "var(--tn-text)",
+          }}
         >
           {games.map(g => (
             <option key={g.id} value={g.id}>
@@ -85,23 +87,32 @@ export function SpelTab({ groupId, games, initialGameId, initialSystems, current
         {selectedGame && (
           <Link
             href={`/?systemMode=1&groupId=${groupId}&game=${selectedGameId}`}
-            className="shrink-0 px-3 py-2 text-sm font-semibold bg-emerald-900 hover:bg-emerald-800 text-white rounded-lg transition"
+            className="shrink-0 px-3 py-2 text-sm font-semibold rounded-lg transition"
+            style={{
+              background: "var(--tn-accent-faint)",
+              color: "var(--tn-accent)",
+              border: "1px solid var(--tn-accent-soft)",
+            }}
           >
             + Bygg system
           </Link>
         )}
       </div>
 
-      {/* Systemlista */}
       {loading ? (
-        <div className="text-center py-10 text-gray-400 text-sm">Laddar system...</div>
+        <div className="text-center py-10 text-sm" style={{ color: "var(--tn-text-faint)" }}>
+          Laddar system...
+        </div>
       ) : isEmpty ? (
-        <div className="text-center py-10 text-gray-400 dark:text-gray-500">
-          <p className="mb-2">Inga system sparade för denna omgång ännu.</p>
+        <div className="text-center py-10">
+          <p className="mb-2 text-sm" style={{ color: "var(--tn-text-faint)" }}>
+            Inga system sparade för denna omgång ännu.
+          </p>
           {selectedGame && (
             <Link
               href={`/?systemMode=1&groupId=${groupId}&game=${selectedGameId}`}
-              className="text-sm text-emerald-600 dark:text-emerald-400 underline"
+              className="text-sm hover:underline"
+              style={{ color: "var(--tn-accent)" }}
             >
               Bygg ett system
             </Link>
@@ -109,11 +120,13 @@ export function SpelTab({ groupId, games, initialGameId, initialSystems, current
         </div>
       ) : (
         <div className="flex flex-col gap-6">
-          {/* Utkast */}
           {allDrafts.length > 0 && (
             <section>
-              <h2 className="text-sm font-semibold text-amber-600 dark:text-amber-400 uppercase tracking-wide mb-3 flex items-center gap-2">
-                <span>✏️</span> Utkast
+              <h2
+                className="text-sm font-semibold uppercase tracking-wide mb-3 flex items-center gap-2 tn-eyebrow"
+                style={{ color: "var(--tn-warn)" }}
+              >
+                Utkast
               </h2>
               <div className="flex flex-col gap-4">
                 {allDrafts.map(system => (
@@ -131,11 +144,13 @@ export function SpelTab({ groupId, games, initialGameId, initialSystems, current
             </section>
           )}
 
-          {/* Sparade system */}
           {sortedSaved.length > 0 && (
             <section>
               {allDrafts.length > 0 && (
-                <h2 className="text-sm font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-3">
+                <h2
+                  className="text-sm font-semibold uppercase tracking-wide mb-3 tn-eyebrow"
+                  style={{ color: "var(--tn-text-dim)" }}
+                >
                   Sparade system
                 </h2>
               )}

--- a/components/sallskap/spel/SystemCard.tsx
+++ b/components/sallskap/spel/SystemCard.tsx
@@ -13,7 +13,6 @@ interface SystemCardProps {
   onDeleted?: (id: string) => void
   winnersByRace?: Record<number, string>
   gameType?: string
-  /** Spel-ID behövs för "Fortsätt"-länken på utkast */
   gameId?: string | null
 }
 
@@ -48,77 +47,80 @@ export function SystemCard({ system, currentUserId, onDeleted, winnersByRace, ga
     })
   }
 
-  const scoreColor = system.score == null
-    ? ''
-    : system.score >= 7
-    ? 'bg-emerald-500 text-white'
-    : system.score >= 5
-    ? 'bg-amber-400 text-black'
-    : 'bg-gray-300 text-gray-800 dark:bg-gray-600 dark:text-white'
+  const score = system.score
+  const scoreStyle: React.CSSProperties = score == null ? {}
+    : score >= 7 ? { background: "var(--tn-value-high)", color: "#0a0e14" }
+    : score >= 5 ? { background: "var(--tn-warn)", color: "#0a0e14" }
+    : { background: "var(--tn-bg-chip)", color: "var(--tn-text-dim)" }
 
-  // URL för att fortsätta ett utkast
-  const continueHref = gameId
-    ? `/?game=${encodeURIComponent(gameId)}&systemMode=1`
-    : null
+  const continueHref = gameId ? `/?game=${encodeURIComponent(gameId)}&systemMode=1` : null
+
+  const borderColor = system.is_draft ? "var(--tn-warn)" : "var(--tn-border)"
 
   return (
-    <div className={`border rounded-xl p-4 bg-white dark:bg-gray-900 ${
-      system.is_draft
-        ? 'border-amber-300 dark:border-amber-700'
-        : 'border-gray-200 dark:border-gray-700'
-    }`}>
-      {/* Systemhuvud */}
+    <div
+      className="rounded-xl p-4"
+      style={{ background: "var(--tn-bg-card)", border: `1px solid ${borderColor}` }}
+    >
       <div className="flex items-start justify-between mb-3">
         <div>
           <div className="flex items-center gap-2">
-            <span className="font-bold text-gray-900 dark:text-white">{system.name}</span>
+            <span className="font-bold" style={{ color: "var(--tn-text)" }}>{system.name}</span>
             {system.is_draft && (
-              <span className="text-xs px-2 py-0.5 rounded-full bg-amber-100 dark:bg-amber-900 text-amber-700 dark:text-amber-300 font-semibold">
-                ✏️ Utkast
+              <span
+                className="tn-mono text-xs px-2 py-0.5 rounded-full font-semibold"
+                style={{ background: "rgba(251,191,36,0.15)", color: "var(--tn-warn)" }}
+              >
+                Utkast
               </span>
             )}
           </div>
-          <div className="text-xs text-gray-500 dark:text-gray-400">
+          <div className="text-xs" style={{ color: "var(--tn-text-faint)" }}>
             {system.author_display_name} · {system.total_rows} {system.total_rows === 1 ? 'rad' : 'rader'} · {formatRowCost(system.total_rows, gameType)}
           </div>
         </div>
         <div className="flex items-center gap-2 flex-wrap justify-end">
-          {/* Privat/sällskap-bricka */}
           {!system.is_draft && (
             system.group_name != null ? (
-              <span className="text-xs px-2 py-1 rounded-full bg-blue-100 dark:bg-blue-900 text-blue-700 dark:text-blue-300 font-semibold whitespace-nowrap">
-                👥 {system.group_name}
+              <span
+                className="tn-mono text-xs px-2 py-1 rounded-full font-semibold whitespace-nowrap"
+                style={{ background: "var(--tn-accent-faint)", color: "var(--tn-accent)" }}
+              >
+                {system.group_name}
               </span>
             ) : (
-              <span className="text-xs px-2 py-1 rounded-full bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400 font-semibold">
-                🔒 Privat
+              <span
+                className="tn-mono text-xs px-2 py-1 rounded-full font-semibold"
+                style={{ background: "var(--tn-bg-chip)", color: "var(--tn-text-faint)" }}
+              >
+                Privat
               </span>
             )
           )}
-          {/* Poängbadge */}
-          {!system.is_draft && system.is_graded && system.score != null && (
-            <span className={`text-lg font-black px-3 py-1 rounded-lg ${scoreColor}`}>
-              {system.score}/8
+          {!system.is_draft && system.is_graded && score != null && (
+            <span className="tn-mono text-lg font-black px-3 py-1 rounded-lg" style={scoreStyle}>
+              {score}/8
             </span>
           )}
           {!system.is_draft && !system.is_graded && (
-            <span className="text-xs px-2 py-1 rounded-md bg-gray-100 dark:bg-gray-800 text-gray-500">Pågår</span>
+            <span className="tn-mono text-xs px-2 py-1 rounded-md" style={{ background: "var(--tn-bg-chip)", color: "var(--tn-text-faint)" }}>
+              Pågår
+            </span>
           )}
         </div>
       </div>
 
-      {/* ATG-kvittoformat tabell */}
       <table className="w-full border-collapse text-sm mb-3">
         <thead>
-          <tr className="border-b-2 border-gray-900 dark:border-gray-100">
-            <th className="text-left py-1 px-1 text-xs font-semibold text-gray-500 uppercase tracking-wide w-9">Avd</th>
-            <th className="text-left py-1 px-1 text-xs font-semibold text-gray-500 uppercase tracking-wide">Hästar</th>
+          <tr style={{ borderBottom: `2px solid var(--tn-text)` }}>
+            <th className="text-left py-1 px-1 tn-eyebrow w-9">Avd</th>
+            <th className="text-left py-1 px-1 tn-eyebrow">Hästar</th>
           </tr>
         </thead>
         <tbody>
           {[...system.selections].sort((a, b) => a.race_number - b.race_number).map(sel => (
-            <tr key={sel.race_number} className="border-b border-gray-100 dark:border-gray-800">
-              <td className="py-1.5 px-1 font-bold text-base text-gray-900 dark:text-white">{sel.race_number}</td>
+            <tr key={sel.race_number} style={{ borderBottom: "1px solid var(--tn-border)" }}>
+              <td className="py-1.5 px-1 font-bold text-base" style={{ color: "var(--tn-text)" }}>{sel.race_number}</td>
               <td className="py-1.5 px-1">
                 <div className="flex gap-1.5 flex-wrap">
                   {[...sel.horses].sort((a, b) => a.start_number - b.start_number).map(h => {
@@ -128,15 +130,13 @@ export function SystemCard({ system, currentUserId, onDeleted, winnersByRace, ga
                     return (
                       <span
                         key={h.horse_id}
-                        className={`inline-flex items-center justify-center w-7 h-7 rounded-full font-bold text-sm transition-colors ${
-                          won
-                            ? 'border-2 border-green-600 text-green-700 dark:text-green-400 bg-green-50 dark:bg-green-950'
-                            : lost
-                            ? 'text-gray-400 dark:text-gray-600'
-                            : system.is_draft
-                            ? 'text-amber-700 dark:text-amber-300 bg-amber-50 dark:bg-amber-950'
-                            : 'text-gray-900 dark:text-white'
-                        }`}
+                        className="inline-flex items-center justify-center w-7 h-7 rounded-full font-bold text-sm"
+                        style={
+                          won ? { border: "2px solid var(--tn-value-high)", color: "var(--tn-value-high)", background: "rgba(52,211,153,0.1)" }
+                          : lost ? { color: "var(--tn-text-faint)" }
+                          : system.is_draft ? { color: "var(--tn-warn)", background: "rgba(251,191,36,0.1)" }
+                          : { color: "var(--tn-text)" }
+                        }
                       >
                         {h.start_number}
                       </span>
@@ -148,7 +148,7 @@ export function SystemCard({ system, currentUserId, onDeleted, winnersByRace, ga
           ))}
           {system.selections.length === 0 && (
             <tr>
-              <td colSpan={2} className="py-2 px-1 text-xs text-gray-400 dark:text-gray-500 italic">
+              <td colSpan={2} className="py-2 px-1 text-xs italic" style={{ color: "var(--tn-text-faint)" }}>
                 Inga hästar valda ännu
               </td>
             </tr>
@@ -156,25 +156,23 @@ export function SystemCard({ system, currentUserId, onDeleted, winnersByRace, ga
         </tbody>
       </table>
 
-      {deleteError && (
-        <p className="text-xs text-red-500 mb-2">{deleteError}</p>
-      )}
+      {deleteError && <p className="text-xs mb-2" style={{ color: "var(--tn-value-low)" }}>{deleteError}</p>}
 
-      {/* Åtgärder */}
       <div className="flex gap-2 flex-wrap">
-        {/* Fortsätt-knapp för utkast */}
         {system.is_draft && isOwner && continueHref && (
           <Link
             href={continueHref}
-            className="text-xs px-3 py-1.5 rounded-lg bg-amber-500 hover:bg-amber-400 text-white font-semibold transition"
+            className="text-xs px-3 py-1.5 rounded-lg font-semibold transition"
+            style={{ background: "rgba(251,191,36,0.15)", color: "var(--tn-warn)", border: "1px solid rgba(251,191,36,0.3)" }}
           >
-            ✏️ Fortsätt utkast
+            Fortsätt utkast
           </Link>
         )}
         {!system.is_draft && (
           <button
             onClick={handleCopy}
-            className="text-xs px-3 py-1.5 rounded-lg border border-gray-200 dark:border-gray-700 text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 transition"
+            className="text-xs px-3 py-1.5 rounded-lg transition"
+            style={{ background: "var(--tn-bg-chip)", border: "1px solid var(--tn-border)", color: "var(--tn-text-dim)", cursor: "pointer" }}
           >
             Kopiera system
           </button>
@@ -183,7 +181,8 @@ export function SystemCard({ system, currentUserId, onDeleted, winnersByRace, ga
           <button
             onClick={handleDelete}
             disabled={isPending}
-            className="text-xs px-3 py-1.5 rounded-lg border border-red-200 dark:border-red-900 text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-950 transition disabled:opacity-50"
+            className="text-xs px-3 py-1.5 rounded-lg transition disabled:opacity-50"
+            style={{ border: "1px solid rgba(248,113,113,0.3)", color: "var(--tn-value-low)", background: "none", cursor: "pointer" }}
           >
             Ta bort
           </button>


### PR DESCRIPTION
Ersätter alla Tailwind-färgklasser (gray-*, indigo-*, dark:*) med CSS custom properties i 64 filer. Lägger till nytt tokensystem i globals.css med stöd för ljust/mörkt tema via data-theme-attribut. Enhetlig visuell identitet i hela appen.