### PR TITLE
Kalibrerad vinstsannolikhet, robustare backtest och omräkning av formscore

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,8 @@ npm run dev      # Starta dev-server
 npm run build    # Produktionsbygge
 npm run lint     # ESLint
 npx jest         # Kör tester (lib/__tests__/)
-npm run backtest # Kalibrera CS-vikter mot faktiska resultat (kräver Supabase-env)
+npm run backtest # Kalibrera CS-vikter mot faktiska resultat (train/test, log-loss; kräver Supabase-env)
+npm run recompute-formscore  # Räkna om lagrad CS för alla omgångar med aktuella vikter (kräver Supabase-env)
 ```
 
 ---
@@ -107,12 +108,14 @@ components/
     ProfileForm.tsx         # Byt visningsnamn
 
 scripts/
-  backtest-weights.ts       # Grid-söker CS-vikter mot lopp med facit (npm run backtest)
+  backtest-weights.ts       # Grid-söker CS-vikter mot lopp med facit, train/test + log-loss (npm run backtest)
+  recompute-formscore.ts    # Räknar om lagrad CS med aktuella vikter (npm run recompute-formscore)
 
 lib/
   analysis.ts               # Hjälpformler (distanssignal, spårfaktor, tidsparsning)
   formscore.ts              # Composite Score: computeComponents + CS_WEIGHTS
   skrall.ts                 # Skrällkandidat-signal (låg streck + odds/streck-diskrepans + klass)
+  probability.ts            # Kalibrerad vinstsannolikhet (50% streck + 50% odds, BLEND_ALPHA)
   atg.ts                    # Typer för ATG-data (AvailableGame m.m.)
   types.ts                  # Delade TS-typer (Group, GroupMember, HorseNote, m.m.)
   supabase/                 # Supabase-klienter (server/browser)
@@ -163,11 +166,20 @@ omgångshämtning och lagras i kolumnen `starters.formscore`. Vikterna kalibrera
 mot faktiska resultat med `npm run backtest` (scripts/backtest-weights.ts).
 Vinstprocent, tid, spårfaktor, kuskform och galopprisk har för närvarande vikt 0
 men beräknas och visas fortfarande i UI.
-Häst markeras som "Värde" om CS > 55 och värdeindex > 0.
+Häst markeras som "Värde" om CS > 55 och kalibrerad chans > streckning.
+CS rankar fältet; den kalibrerade sannolikheten (se nedan) är värdemåttet.
+
+### Kalibrerad vinstsannolikhet – `lib/probability.ts → computeWinProbabilities()`
+Blandning `p = α·streck_norm + (1−α)·odds_norm` med `BLEND_ALPHA = 0.5`,
+normaliserad så fältet summerar till 1. Backtest mot 221 lopp (2026-06-13) gav
+lägst log-loss vid α≈0.5 (1.58 mot 1.62 för rent streck/odds). Faller tillbaka
+på enbart streck (innan pool öppnat: enbart odds). Beräknas i RaceList och
+skickas som `probMap` till AnalysisPanel (kolumnen "Chans", Värde = chans−streck).
 
 ### Analysverktyget – `components/AnalysisPanel.tsx`
-Visar per häst: CS-andel av fältet, spelvärde (CS-andel − streckning%),
-distanssignal och spårfaktor (inkl. banspecifik justering från `track_configs`).
+Visar per häst: CS, kalibrerad chans, spelvärde (chans − streckning%),
+distanssignal och spårfaktor (inkl. banspecifik justering från `track_configs`)
+samt skrällmarkering. CS-rankad tabell.
 
 ### Skrällkandidat – `lib/skrall.ts → computeSkrallSignals()`
 Häst flaggas som skrällkandidat när alla tre villkor uppfylls (trösklar i

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -171,14 +171,25 @@ Klicka på knappen **Visa analys** inuti en avdelning för att öppna analyspane
 |--------|-----------|
 | **#** | Rank i loppet enligt CS |
 | **Häst** | Startnummer och namn, med **VÄRDE**- och/eller **SKRÄLL**-märke |
-| **CS** | Composite Score 0–100 (se 5.2) |
+| **CS** | Composite Score 0–100 (se 5.2) — tabellen rankas på denna |
 | **Odds** | Aktuellt vinnarodds |
-| **Ber.** | Beräknad vinstchans: hästens CS som andel av fältets totala CS |
+| **Chans** | Kalibrerad vinstsannolikhet (se nedan) |
 | **Strk.** | Hästens faktiska andel av spelpoolen (marknadens röst) |
 | **Distans** | Distanssignal baserat på hästens historik på aktuell distans och startmetod |
 | **Spår** | Spårfaktor med banspecifik justering — visas bara för banor med konfiguration (se 6.2) |
-| **Värde** | Spelvärde: beräknad chans minus streckning, i procentenheter |
+| **Värde** | Spelvärde: chans minus streckning, i procentenheter |
 | **Res.** | Slutplacering om loppet är avslutat |
+
+#### Kalibrerad vinstchans
+
+**Chans** är systemets bästa skattning av hur ofta hästen verkligen vinner. Den är en jämn blandning (50/50) av två oberoende marknadssignaler:
+
+- **Streckningen** – spelarnas kollektiva insatsfördelning i poolen.
+- **Oddsmarknaden** – vinnaroddsens implicita sannolikhet (1/odds, normaliserad över fältet).
+
+Analys av historiska lopp visar att blandningen är bättre kalibrerad än någon av signalerna ensam — sanningen ligger mitt emellan poolen och oddsmarknaden. Innan poolen öppnat (ingen streckning) används enbart oddsen; saknas odds används enbart streckningen.
+
+Eftersom **Värde = Chans − Streckning** lyfter tabellen fram hästar där den samlade marknaden (särskilt oddsen) tror mer på hästen än vad poolen streckar den för — alltså potentiellt undervärderade hästar.
 
 #### Distansfaktor-symboler
 
@@ -192,11 +203,11 @@ Klicka på knappen **Visa analys** inuti en avdelning för att öppna analyspane
 
 #### Tolka spelvärdet
 
-- **Positiv** (beräknad chans > streckning) → hästen kan vara ett värdebet (fetstil = ≥5 pp).
+- **Positiv** (chans > streckning) → hästen kan vara ett värdebet (fetstil = ≥5 pp).
 - **Negativ** → hästen är hårt streckad relativt systemets bedömning.
 - Rader med **VÄRDE**-märke (CS > 55 och positivt spelvärde) lyfts fram med grön markering.
 
-> **Obs!** Streckningsdata saknas innan poolen öppnat. Hämta om spelet senare för att se spelvärden.
+> **Obs!** Streckningsdata saknas innan poolen öppnat — då bygger chansen enbart på oddsen tills du hämtar om spelet.
 
 #### Skrällkandidater
 
@@ -358,7 +369,8 @@ Sidan visar:
 | **Odds** | ATG:s vinnarodds på hästen |
 | **Streckning / Streck%** | Hästens procentuella andel av V85-poolens insatser |
 | **Composite Score (CS)** | Systemets samlade bedömning (0–100): streckning 55 %, distansrekord 20 %, odds 10 %, konsistens 10 %, form 5 % — kalibrerad mot historiska resultat |
-| **Spelvärde** | Beräknad chans (CS-andel av fältet) minus streckprocent – positivt värde indikerar potentiellt värdebet |
+| **Kalibrerad chans** | Systemets skattning av verklig vinstsannolikhet — 50 % streckning + 50 % oddsmarknad |
+| **Spelvärde** | Kalibrerad chans minus streckprocent – positivt värde indikerar potentiellt värdebet |
 | **Värdebet** | En häst vars verkliga chanser bedöms vara högre än vad marknaden prissätter |
 | **Skrällkandidat** | Lågstreckad häst (<15 %) med hög klass (topp-3 på intjänat/start) som är understreckad mot vinnaroddsen |
 | **Klass** | Intjänade kronor per start – ett mått på vilken nivå hästen tävlat på |
@@ -373,4 +385,4 @@ Sidan visar:
 
 ---
 
-*Manual version 2.2 – V85 Analys*
+*Manual version 2.3 – V85 Analys*

--- a/components/AnalysisPanel.tsx
+++ b/components/AnalysisPanel.tsx
@@ -2,6 +2,7 @@
 
 import { computeDistanceSignal, computeTrackFactor, type LifeRecord, type DistanceSignal } from "@/lib/analysis";
 import type { SkrallSignal } from "@/lib/skrall";
+import type { WinProbability } from "@/lib/probability";
 import type { TrackConfig } from "@/lib/types";
 
 interface AnalysisStarter {
@@ -22,6 +23,8 @@ interface AnalysisPanelProps {
   trackConfig?: TrackConfig;
   /** Skrällsignaler beräknade på hela fältet, nycklade på startnummer */
   skrallMap?: Record<number, SkrallSignal>;
+  /** Kalibrerad vinstsannolikhet beräknad på hela fältet, nycklad på startnummer */
+  probMap?: Record<number, WinProbability>;
 }
 
 function DistBadge({ factor, label }: { factor: number; label: string }) {
@@ -74,8 +77,10 @@ interface RankedStarter {
   starter: AnalysisStarter;
   cs: number;
   distSignal: DistanceSignal;
-  calcPct: number;
+  /** Kalibrerad vinstchans i procent (blandning streck + odds) */
+  chansPct: number;
   streckPct: number;
+  hasChans: boolean;
   value: number;
   rank: number;
   isValue: boolean;
@@ -88,7 +93,8 @@ function rankStarters(
   starters: AnalysisStarter[],
   raceMeters: number,
   raceStartMethod: string,
-  trackConfig?: TrackConfig
+  trackConfig?: TrackConfig,
+  probMap?: Record<number, WinProbability>
 ): RankedStarter[] {
   const withDist = starters.map((s) => {
     const records: LifeRecord[] = Array.isArray(s.life_records) ? s.life_records : [];
@@ -96,9 +102,10 @@ function rankStarters(
     const cs = s.formscore ?? 0;
     const betDist = s.bet_distribution;
     const streckPct = betDist != null && isFinite(Number(betDist)) ? Number(betDist) : 0;
-    const totalCS = starters.reduce((sum, st) => sum + (st.formscore ?? 0), 0);
-    const calcPct = totalCS > 0 ? Math.round(((cs / totalCS) * 100) * 10) / 10 : 0;
-    const value = streckPct > 0 ? Math.round((calcPct - streckPct) * 10) / 10 : 0;
+    const prob = probMap?.[s.start_number];
+    const hasChans = prob != null && prob.source !== "uniform";
+    const chansPct = hasChans ? Math.round(prob!.p * 1000) / 10 : 0;
+    const value = hasChans && streckPct > 0 ? Math.round((chansPct - streckPct) * 10) / 10 : 0;
     const isValue = cs > 55 && value > 0;
     const postPos = (s as { post_position?: number | null }).post_position ?? 1;
     const horseHistory = (s as { horse_starts_history?: unknown[] }).horse_starts_history ?? [];
@@ -107,15 +114,15 @@ function rankStarters(
       ? computeTrackFactor(postPos, raceStartMethod, horseHistory as never[], trackConfig, raceMeters)
       : trackFactorBase;
     const trackFactorDelta = Math.round((trackFactorAdjusted - trackFactorBase) * 100) / 100;
-    return { starter: s, cs, distSignal, calcPct, streckPct, value, rank: 0, isValue, trackFactorBase, trackFactorAdjusted, trackFactorDelta };
+    return { starter: s, cs, distSignal, chansPct, streckPct, hasChans, value, rank: 0, isValue, trackFactorBase, trackFactorAdjusted, trackFactorDelta };
   });
   withDist.sort((a, b) => b.cs - a.cs);
   withDist.forEach((r, i) => (r.rank = i + 1));
   return withDist;
 }
 
-export function AnalysisPanel({ starters, raceMeters, raceStartMethod, trackConfig, skrallMap }: AnalysisPanelProps) {
-  const ranked = rankStarters(starters, raceMeters, raceStartMethod, trackConfig);
+export function AnalysisPanel({ starters, raceMeters, raceStartMethod, trackConfig, skrallMap, probMap }: AnalysisPanelProps) {
+  const ranked = rankStarters(starters, raceMeters, raceStartMethod, trackConfig, probMap);
   const hasStreckning = ranked.some((r) => r.streckPct > 0);
   const distLabel = raceMeters <= 1800 ? "kort" : raceMeters <= 2400 ? "medel" : "lång";
   const skrallCandidates = ranked.filter((r) => skrallMap?.[r.starter.start_number]?.isCandidate);
@@ -134,9 +141,10 @@ export function AnalysisPanel({ starters, raceMeters, raceStartMethod, trackConf
           Matematisk analys
         </h3>
         <p className="text-xs mt-1" style={{ color: "var(--tn-text-dim)", lineHeight: 1.5 }}>
-          CS (0–100) = streckning (55%) + distans (20%) + odds (10%) + konsistens (10%) + form (5%), kalibrerat mot historiska resultat.
+          CS (0–100) rankar fältet: streckning (55%) + distans (20%) + odds (10%) + konsistens (10%) + form (5%).
+          {" "}<strong>Chans</strong> = kalibrerad vinstsannolikhet (50% streckning + 50% oddsmarknad).
           {" "}Distans: {distLabel} ({raceMeters} m, {raceStartMethod}start).
-          {" "}Spelvärde = CS-andel − streckning.
+          {" "}Spelvärde = chans − streckning.
         </p>
         {!hasStreckning && (
           <p
@@ -166,7 +174,7 @@ export function AnalysisPanel({ starters, raceMeters, raceStartMethod, trackConf
         <table className="w-full text-sm">
           <thead>
             <tr style={{ borderBottom: "1px solid var(--tn-border)" }}>
-              {["#", "Häst", "CS", "Odds", "Ber.", "Strk.", "Distans", ...(trackConfig ? ["Spår"] : []), "Värde", "Res."].map((h) => (
+              {["#", "Häst", "CS", "Odds", "Chans", "Strk.", "Distans", ...(trackConfig ? ["Spår"] : []), "Värde", "Res."].map((h) => (
                 <th
                   key={h}
                   className="tn-eyebrow py-2.5 px-2 first:pl-4 last:pr-4 font-normal"
@@ -236,9 +244,9 @@ export function AnalysisPanel({ starters, raceMeters, raceStartMethod, trackConf
                   <td className="py-2.5 pr-2 text-right tn-mono text-xs" style={{ color: "var(--tn-text-dim)" }}>
                     {r.starter.odds != null ? `${r.starter.odds.toFixed(1)}x` : "–"}
                   </td>
-                  {/* Calculated % */}
+                  {/* Calibrated win chance */}
                   <td className="py-2.5 pr-2 text-right tn-mono text-xs font-semibold" style={{ color: "var(--tn-accent)" }}>
-                    {r.calcPct}%
+                    {r.hasChans ? `${r.chansPct}%` : "–"}
                   </td>
                   {/* Streck % */}
                   <td className="py-2.5 pr-2 text-right tn-mono text-xs" style={{ color: "var(--tn-text-dim)" }}>
@@ -272,7 +280,7 @@ export function AnalysisPanel({ starters, raceMeters, raceStartMethod, trackConf
                   )}
                   {/* Value */}
                   <td className="py-2.5 pr-2 text-right">
-                    <DeltaChip value={r.value} hasStreck={r.streckPct > 0} />
+                    <DeltaChip value={r.value} hasStreck={r.hasChans && r.streckPct > 0} />
                   </td>
                   {/* Result */}
                   <td className="py-2.5 pr-4 text-right">

--- a/components/RaceList.tsx
+++ b/components/RaceList.tsx
@@ -6,6 +6,7 @@ import { AnalysisPanel } from "./AnalysisPanel";
 import { HorseNotes } from "./notes/HorseNotes";
 import { TopFiveRanking } from "./TopFiveRanking";
 import { computeSkrallMap } from "@/lib/skrall";
+import { computeWinProbabilities, type WinProbability } from "@/lib/probability";
 import type { Group, SystemSelection, SystemHorse, TrackConfig } from "@/lib/types";
 
 interface LifeRecord {
@@ -139,16 +140,21 @@ export function RaceList({
 
   const hasActiveFilter = filterValue || filterSkrall || hideOutsiders || search.trim().length > 0;
   const compositeMap = Object.fromEntries(activeRace.starters.map((s) => [s.start_number, s.formscore ?? 0]));
-  const totalCS = activeRace.starters.reduce((sum, s) => sum + (s.formscore ?? 0), 0);
+  // Kalibrerad vinstsannolikhet och skrällsignal är relativa hela fältet —
+  // beräknas före filtrering
+  const probList = computeWinProbabilities(activeRace.starters);
+  const probMap: Record<number, WinProbability> = Object.fromEntries(
+    activeRace.starters.map((s, i) => [s.start_number, probList[i]])
+  );
+  // "Värde": kalibrerad chans överstiger streckningen för en reell kandidat
   const valueMap = Object.fromEntries(
     activeRace.starters.map((s) => {
       const cs = s.formscore ?? 0;
-      const calcPct = totalCS > 0 ? (cs / totalCS) * 100 : 0;
+      const pPct = (probMap[s.start_number]?.p ?? 0) * 100;
       const streckPct = s.bet_distribution ?? 0;
-      return [s.start_number, cs > 55 && streckPct > 0 && calcPct > streckPct];
+      return [s.start_number, cs > 55 && streckPct > 0 && pPct > streckPct];
     })
   );
-  // Skrällsignalen är relativ hela fältet — beräknas före filtrering
   const skrallMap = computeSkrallMap(activeRace.starters);
 
   const q = search.trim().toLowerCase();
@@ -288,6 +294,7 @@ export function RaceList({
           raceStartMethod={activeRace.start_method ?? "auto"}
           trackConfig={trackConfig ?? undefined}
           skrallMap={skrallMap}
+          probMap={probMap}
         />
       )}
 

--- a/components/TopFiveRanking.tsx
+++ b/components/TopFiveRanking.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { computeWinProbabilities } from "@/lib/probability";
 
 interface StarterForRanking {
   start_number: number;
@@ -41,13 +42,14 @@ export function TopFiveRanking({ races, onHorseClick }: TopFiveRankingProps) {
 
   const allHorses: RankedHorse[] = [];
   for (const race of races) {
-    for (const s of race.starters) {
+    // Kalibrerad chans beräknas över hela avdelningen (samma mått som hästkort/analys)
+    const probs = computeWinProbabilities(race.starters);
+    race.starters.forEach((s, i) => {
       const cs = s.formscore ?? 0;
-      if (cs === 0) continue;
-      const totalCS = race.starters.reduce((sum, st) => sum + (st.formscore ?? 0), 0);
-      const calcPct = totalCS > 0 ? (cs / totalCS) * 100 : 0;
+      if (cs === 0) return;
+      const pPct = (probs[i]?.p ?? 0) * 100;
       const streckPct = s.bet_distribution ?? 0;
-      const isValue = cs > 55 && streckPct > 0 && calcPct > streckPct;
+      const isValue = cs > 55 && streckPct > 0 && pPct > streckPct;
       allHorses.push({
         horseName: s.horses?.name ?? `Nr ${s.start_number}`,
         startNumber: s.start_number,
@@ -58,7 +60,7 @@ export function TopFiveRanking({ races, onHorseClick }: TopFiveRankingProps) {
         finish_position: s.finish_position ?? null,
         finish_time: s.finish_time ?? null,
       });
-    }
+    });
   }
 
   if (allHorses.length === 0) return null;

--- a/lib/__tests__/probability.test.ts
+++ b/lib/__tests__/probability.test.ts
@@ -1,0 +1,111 @@
+import {
+  computeWinProbabilities,
+  BLEND_ALPHA,
+  type ProbabilityInput,
+} from "../probability";
+
+function field(...rows: ProbabilityInput[]): ProbabilityInput[] {
+  return rows;
+}
+
+describe("computeWinProbabilities", () => {
+  it("returnerar tom array för tomt fält", () => {
+    expect(computeWinProbabilities([])).toEqual([]);
+  });
+
+  it("summerar alltid till 1 över fältet", () => {
+    const probs = computeWinProbabilities(
+      field(
+        { odds: 2, bet_distribution: 50 },
+        { odds: 5, bet_distribution: 30 },
+        { odds: 10, bet_distribution: 20 }
+      )
+    );
+    const sum = probs.reduce((a, b) => a + b.p, 0);
+    expect(sum).toBeCloseTo(1);
+  });
+
+  it("blandar streck och odds 50/50 när båda finns", () => {
+    // Häst A: streck 60 %, odds-implicit 1/2 normaliserat
+    const probs = computeWinProbabilities(
+      field(
+        { odds: 2, bet_distribution: 60 },
+        { odds: 2, bet_distribution: 40 }
+      )
+    );
+    // odds lika → odds_norm = 0.5/0.5; streck_norm = 0.6/0.4
+    // p_A = 0.5*0.6 + 0.5*0.5 = 0.55
+    expect(probs[0].source).toBe("blend");
+    expect(probs[0].p).toBeCloseTo(0.55);
+    expect(probs[1].p).toBeCloseTo(0.45);
+    expect(BLEND_ALPHA).toBe(0.5);
+  });
+
+  it("faller tillbaka på enbart streckning när odds saknas", () => {
+    const probs = computeWinProbabilities(
+      field(
+        { odds: null, bet_distribution: 70 },
+        { odds: null, bet_distribution: 30 }
+      )
+    );
+    expect(probs[0].source).toBe("streck");
+    expect(probs[0].oddsProb).toBeNull();
+    expect(probs[0].p).toBeCloseTo(0.7);
+    expect(probs[1].p).toBeCloseTo(0.3);
+  });
+
+  it("faller tillbaka på enbart odds när streckning saknas (innan pool öppnat)", () => {
+    const probs = computeWinProbabilities(
+      field(
+        { odds: 2, bet_distribution: null },
+        { odds: 6, bet_distribution: 0 }
+      )
+    );
+    expect(probs[0].source).toBe("odds");
+    expect(probs[0].streckProb).toBeNull();
+    // odds-norm: (1/2)/(1/2+1/6) = 0.75
+    expect(probs[0].p).toBeCloseTo(0.75);
+    expect(probs[1].p).toBeCloseTo(0.25);
+  });
+
+  it("ger likformig fördelning utan någon data", () => {
+    const probs = computeWinProbabilities(
+      field(
+        { odds: null, bet_distribution: null },
+        { odds: null, bet_distribution: 0 },
+        { odds: 0, bet_distribution: 0 }
+      )
+    );
+    expect(probs.every((p) => p.source === "uniform")).toBe(true);
+    expect(probs[0].p).toBeCloseTo(1 / 3);
+  });
+
+  it("hanterar fält där en enstaka häst saknar odds", () => {
+    const probs = computeWinProbabilities(
+      field(
+        { odds: 2, bet_distribution: 50 },
+        { odds: null, bet_distribution: 50 }
+      )
+    );
+    const sum = probs.reduce((a, b) => a + b.p, 0);
+    expect(sum).toBeCloseTo(1);
+    // Hästen utan odds får bara sin streckhalva → lägre p än om den haft odds
+    expect(probs[1].oddsProb).toBeNull();
+    expect(probs[0].p).toBeGreaterThan(probs[1].p);
+  });
+
+  it("favoriten i blend hamnar mellan streck- och odds-skattningen", () => {
+    const probs = computeWinProbabilities(
+      field(
+        { odds: 1.5, bet_distribution: 30 }, // odds säger mycket, streck lite
+        { odds: 8, bet_distribution: 35 },
+        { odds: 9, bet_distribution: 35 }
+      )
+    );
+    const fav = probs[0];
+    expect(fav.streckProb).not.toBeNull();
+    expect(fav.oddsProb).not.toBeNull();
+    expect(fav.p).toBeGreaterThan(fav.streckProb!);
+    expect(fav.p).toBeLessThan(fav.oddsProb!);
+  });
+});

--- a/lib/probability.ts
+++ b/lib/probability.ts
@@ -1,0 +1,94 @@
+/**
+ * Kalibrerad vinstsannolikhet.
+ *
+ * Marknadsodds och spelarnas streckning är båda brus-behäftade skattningar av
+ * en hästs verkliga vinstchans. Databasanalys av 221 lopp med facit
+ * (2026-06-13) visar att en jämn blandning av de två är bättre kalibrerad än
+ * endera ensam:
+ *
+ *   log-loss   α=0.5 (blend)   1.5795   ← bäst
+ *              α=1.0 (streck)  1.6194
+ *              α=0.0 (odds)    1.6216
+ *
+ * Kurvan är flack mellan α=0.4 och 0.6, så 0.5 är ett robust val. Sanningen
+ * ligger alltså mitt emellan poolen och oddsmarknaden — och differensen mot
+ * streckningen är just den "spelvärde"-signal som driver skrällkandidaterna.
+ *
+ * Kör om kalibreringen (scripts/backtest-weights.ts visar metodiken) när mer
+ * data samlats in.
+ */
+
+/** Vikt på streckningen i blandningen; (1 − α) läggs på oddsmarknaden. */
+export const BLEND_ALPHA = 0.5;
+
+export interface ProbabilityInput {
+  odds: number | null;
+  bet_distribution: number | null;
+}
+
+export interface WinProbability {
+  /** Kalibrerad vinstsannolikhet 0–1, normaliserad så fältet summerar till 1 */
+  p: number;
+  /** Streckningens implicita sannolikhet 0–1 (poolens röst), eller null */
+  streckProb: number | null;
+  /** Oddsmarknadens implicita sannolikhet 0–1, eller null */
+  oddsProb: number | null;
+  /** Vilka signaler som faktiskt fanns för hästen */
+  source: "blend" | "streck" | "odds" | "uniform";
+}
+
+function normalize(values: number[]): number[] {
+  const sum = values.reduce((a, b) => a + b, 0);
+  if (sum <= 0) return values.map(() => 0);
+  return values.map((v) => v / sum);
+}
+
+/**
+ * Beräknar kalibrerad vinstsannolikhet för ett helt startfält.
+ *
+ * Måste anropas med fältets samtliga hästar — normaliseringen är relativ
+ * fältet. Streckning och odds normaliseras var för sig till fördelningar som
+ * summerar till 1, blandas per häst och normaliseras till slut så att hela
+ * fältet summerar till 1 (robust även när enstaka hästar saknar odds/streck).
+ */
+export function computeWinProbabilities(
+  starters: ProbabilityInput[]
+): WinProbability[] {
+  const n = starters.length;
+  if (n === 0) return [];
+
+  const streckProbs = normalize(
+    starters.map((s) => (s.bet_distribution != null && s.bet_distribution > 0 ? s.bet_distribution : 0))
+  );
+  const oddsProbs = normalize(
+    starters.map((s) => (s.odds != null && s.odds > 0 ? 1 / s.odds : 0))
+  );
+
+  const hasStreck = streckProbs.some((v) => v > 0);
+  const hasOdds = oddsProbs.some((v) => v > 0);
+
+  // Råblandning per häst — hanterar att enstaka hästar saknar en signal
+  const raw = starters.map((_, i) => {
+    const sv = hasStreck ? streckProbs[i] : null;
+    const ov = hasOdds ? oddsProbs[i] : null;
+    if (sv != null && ov != null) return BLEND_ALPHA * sv + (1 - BLEND_ALPHA) * ov;
+    if (sv != null) return sv;
+    if (ov != null) return ov;
+    return 0;
+  });
+
+  const anyData = hasStreck || hasOdds;
+  const p = anyData && raw.some((v) => v > 0) ? normalize(raw) : starters.map(() => 1 / n);
+
+  return starters.map((s, i) => {
+    const streckProb = hasStreck && s.bet_distribution != null && s.bet_distribution > 0 ? streckProbs[i] : null;
+    const oddsProb = hasOdds && s.odds != null && s.odds > 0 ? oddsProbs[i] : null;
+    let source: WinProbability["source"];
+    if (!anyData) source = "uniform";
+    else if (streckProb != null && oddsProb != null) source = "blend";
+    else if (streckProb != null) source = "streck";
+    else if (oddsProb != null) source = "odds";
+    else source = "uniform";
+    return { p: p[i], streckProb, oddsProb, source };
+  });
+}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
-    "backtest": "tsx scripts/backtest-weights.ts"
+    "backtest": "tsx scripts/backtest-weights.ts",
+    "recompute-formscore": "tsx scripts/recompute-formscore.ts"
   },
   "dependencies": {
     "@serwist/next": "^9.5.6",

--- a/scripts/backtest-weights.ts
+++ b/scripts/backtest-weights.ts
@@ -185,16 +185,23 @@ async function loadRaces(): Promise<RaceData[]> {
 interface Metrics {
   top1: number;
   top3: number;
+  /** Genomsnittlig log-loss på vinnaren (lägre = bättre kalibrerat) */
+  logloss: number;
 }
 
 function evaluate(races: RaceData[], w: number[]): Metrics {
   let top1 = 0;
   let top3 = 0;
+  let llSum = 0;
   for (const race of races) {
     const { comp, n, winnerIdx } = race;
     let winnerScore = 0;
-    for (let k = 0; k < N_COMP; k++) {
-      winnerScore += w[k] * comp[winnerIdx * N_COMP + k];
+    let fieldSum = 0;
+    for (let i = 0; i < n; i++) {
+      let score = 0;
+      for (let k = 0; k < N_COMP; k++) score += w[k] * comp[i * N_COMP + k];
+      fieldSum += score;
+      if (i === winnerIdx) winnerScore = score;
     }
     // Vinnarens rang = 1 + antal hästar med strikt högre poäng
     let better = 0;
@@ -206,8 +213,44 @@ function evaluate(races: RaceData[], w: number[]): Metrics {
     }
     if (better === 0) top1++;
     if (better <= 2) top3++;
+    // Sannolikhet = vinnarens poängandel av fältet (samma normalisering som
+    // appens "chans"); likformig fördelning om alla poäng är 0
+    const pWinner = fieldSum > 0 ? winnerScore / fieldSum : 1 / n;
+    llSum += -Math.log(Math.max(pWinner, 1e-12));
   }
-  return { top1: top1 / races.length, top3: top3 / races.length };
+  return {
+    top1: top1 / races.length,
+    top3: top3 / races.length,
+    logloss: llSum / races.length,
+  };
+}
+
+/** Deterministisk PRNG (mulberry32) så att train/test-splitten är reproducerbar */
+function makeRng(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/** Blandar och delar loppen i train/test (Fisher–Yates med seedad RNG) */
+function trainTestSplit(
+  races: RaceData[],
+  testFraction: number,
+  seed: number
+): { train: RaceData[]; test: RaceData[] } {
+  const rng = makeRng(seed);
+  const shuffled = [...races];
+  for (let i = shuffled.length - 1; i > 0; i--) {
+    const j = Math.floor(rng() * (i + 1));
+    [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
+  }
+  const nTest = Math.round(shuffled.length * testFraction);
+  return { test: shuffled.slice(0, nTest), train: shuffled.slice(nTest) };
 }
 
 /** Alla sätt att fördela `units` enheter över N_COMP vikter (kompositioner) */
@@ -231,64 +274,97 @@ function fmtWeights(w: number[]): string {
   return COMPONENT_ORDER.map((name, k) => `${name}=${(w[k] * 100).toFixed(0)}%`).join(" ");
 }
 
+/** Binomial standardfel i procentenheter för en andel p över n försök */
+function sePct(p: number, n: number): number {
+  if (n <= 0) return 0;
+  return Math.sqrt((p * (1 - p)) / n) * 100;
+}
+
+function fmtMetrics(m: Metrics, n: number): string {
+  return (
+    `logloss=${m.logloss.toFixed(4)}  ` +
+    `top1=${(m.top1 * 100).toFixed(1)}±${sePct(m.top1, n).toFixed(1)}%  ` +
+    `top3=${(m.top3 * 100).toFixed(1)}±${sePct(m.top3, n).toFixed(1)}%`
+  );
+}
+
+function argValue(flag: string): string | undefined {
+  const i = process.argv.indexOf(flag);
+  return i >= 0 ? process.argv[i + 1] : undefined;
+}
+
 async function main() {
   loadEnv();
-  const stepArg = process.argv.indexOf("--step");
   // steg i hundradelar: 5 → vikter i steg om 0.05
-  const stepPct = stepArg >= 0 ? parseInt(process.argv[stepArg + 1]) : 5;
+  const stepPct = parseInt(argValue("--step") ?? "5");
   const units = Math.round(100 / stepPct);
+  const seed = parseInt(argValue("--seed") ?? "42");
+  const testFraction = parseFloat(argValue("--test") ?? "0.3");
+  // optimeringsmål på träningsdelen: "logloss" (default) eller "top3"
+  const objective = (argValue("--objective") ?? "logloss") as "logloss" | "top3";
 
   console.log("Hämtar lopp med resultat från Supabase …");
   const races = await loadRaces();
-  console.log(`${races.length} lopp med vinnare hittades.\n`);
+  console.log(`${races.length} lopp med vinnare hittades.`);
 
   if (races.length < 300) {
     console.warn(
-      `⚠ Endast ${races.length} lopp — resultaten är osäkra (±${(
-        (100 / Math.sqrt(races.length)) / 2
-      ).toFixed(1)} procentenheter). Kör om när mer data samlats in.\n`
+      `⚠ Endast ${races.length} lopp — testresultaten har bred osäkerhet. Kör om när mer data samlats in.`
     );
   }
 
-  const baseline = evaluate(
-    races,
-    COMPONENT_ORDER.map((name) => CS_WEIGHTS[name])
-  );
+  const { train, test } = trainTestSplit(races, testFraction, seed);
   console.log(
-    `Nuvarande vikter (${fmtWeights(COMPONENT_ORDER.map((n) => CS_WEIGHTS[n]))}):`
-  );
-  console.log(
-    `  Toppval vinner: ${(baseline.top1 * 100).toFixed(1)}%   Vinnare i topp 3: ${(baseline.top3 * 100).toFixed(1)}%\n`
+    `Split (seed ${seed}): ${train.length} träningslopp, ${test.length} testlopp.\n`
   );
 
-  console.log(`Grid-söker viktrummet i steg om ${stepPct} procentenheter …`);
+  const baseW = COMPONENT_ORDER.map((name) => CS_WEIGHTS[name]);
+  console.log(`Nuvarande vikter (${fmtWeights(baseW)}):`);
+  console.log(`  Train: ${fmtMetrics(evaluate(train, baseW), train.length)}`);
+  console.log(`  Test:  ${fmtMetrics(evaluate(test, baseW), test.length)}\n`);
+
+  console.log(
+    `Grid-söker viktrummet i steg om ${stepPct} pe, optimerar "${objective}" på träningsdelen …`
+  );
+  // Lägre logloss är bättre; högre top3 är bättre
+  const better = (a: Metrics, b: Metrics) =>
+    objective === "logloss"
+      ? a.logloss - b.logloss // sortera stigande
+      : b.top3 - a.top3 || b.top1 - a.top1;
+
   type Result = { w: number[]; m: Metrics };
-  const best: Result[] = [];
+  let best: Result[] = [];
   let count = 0;
   for (const w of weightGrid(units)) {
-    const m = evaluate(races, w);
+    best.push({ w: [...w], m: evaluate(train, w) });
     count++;
-    best.push({ w: [...w], m });
-    // Behåll bara topp 200 (sorterat på top3, sedan top1) för minnets skull
     if (best.length > 5000) {
-      best.sort((a, b) => b.m.top3 - a.m.top3 || b.m.top1 - a.m.top1);
+      best.sort((a, b) => better(a.m, b.m));
       best.length = 200;
     }
   }
-  best.sort((a, b) => b.m.top3 - a.m.top3 || b.m.top1 - a.m.top1);
-  console.log(`${count} viktuppsättningar utvärderade.\n`);
+  best.sort((a, b) => better(a.m, b.m));
+  best = best.slice(0, 200);
+  console.log(`${count} viktuppsättningar utvärderade på träningsdelen.\n`);
 
-  console.log("Topp 15 efter topp-3-täckning:");
-  for (const { w, m } of best.slice(0, 15)) {
-    console.log(
-      `  top3=${(m.top3 * 100).toFixed(1)}%  top1=${(m.top1 * 100).toFixed(1)}%  ${fmtWeights(w)}`
-    );
+  console.log(`Topp 10 på träningsdelen (efter ${objective}):`);
+  for (const { w, m } of best.slice(0, 10)) {
+    console.log(`  ${fmtMetrics(m, train.length)}  ${fmtWeights(w)}`);
   }
 
-  const bestTop1 = [...best].sort((a, b) => b.m.top1 - a.m.top1 || b.m.top3 - a.m.top3)[0];
-  console.log(
-    `\nBäst på toppval-träff: top1=${(bestTop1.m.top1 * 100).toFixed(1)}%  top3=${(bestTop1.m.top3 * 100).toFixed(1)}%  ${fmtWeights(bestTop1.w)}`
-  );
+  // Den ärliga siffran: bästa träningsvikterna utvärderade på testdelen
+  const champion = best[0];
+  const championTest = evaluate(test, champion.w);
+  console.log(`\nBästa träningsvikter: ${fmtWeights(champion.w)}`);
+  console.log(`  Train: ${fmtMetrics(champion.m, train.length)}`);
+  console.log(`  Test:  ${fmtMetrics(championTest, test.length)}   ← ärlig uppskattning av verklig prestanda`);
+
+  const overfit = champion.m.logloss - championTest.logloss;
+  if (overfit < -0.03) {
+    console.log(
+      `\n⚠ Test-logloss är ${Math.abs(overfit).toFixed(3)} sämre än train — tecken på överanpassning. Behåll hellre robusta/jämna vikter.`
+    );
+  }
 }
 
 main().catch((err) => {

--- a/scripts/recompute-formscore.ts
+++ b/scripts/recompute-formscore.ts
@@ -1,0 +1,212 @@
+/**
+ * Räknar om lagrad Composite Score (starters.formscore) för alla omgångar med
+ * de aktuella vikterna i lib/formscore.ts → CS_WEIGHTS.
+ *
+ * Bakgrund: formscore beräknas vid omgångshämtning. Omgångar som hämtades innan
+ * vikterna kalibrerades om bär därför poäng från gamla vikter, vilket gör att
+ * Top 5, sortering och utvärderingssidan visar inaktuella tal. Det här skriptet
+ * läser samma data som produktionen, kör om calculateCompositeScore och skriver
+ * tillbaka — idempotent, kör om när helst vikterna ändrats.
+ *
+ * Körning:  npm run recompute-formscore
+ *           npm run recompute-formscore -- --dry   (visar bara, skriver inget)
+ *
+ * Kräver env: NEXT_PUBLIC_SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY
+ * (.env.local läses automatiskt om den finns).
+ */
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+import { calculateCompositeScore, type RaceContext } from "../lib/formscore";
+import type { AtgStarter } from "../lib/atg";
+import type { TrackConfig } from "../lib/types";
+
+function loadEnv() {
+  for (const file of [".env.local", ".env"]) {
+    try {
+      process.loadEnvFile(file);
+    } catch {
+      // filen finns inte — ok
+    }
+  }
+}
+
+// Mappar en starters-rad från DB till AtgStarter (samma fältuppsättning som
+// scripts/backtest-weights.ts — endast fält som påverkar CS behöver vara exakta)
+function rowToStarter(r: Record<string, unknown>): AtgStarter {
+  const num = (v: unknown) => (typeof v === "number" ? v : 0);
+  const numOrNull = (v: unknown) => (typeof v === "number" ? v : null);
+  return {
+    start_number: num(r.start_number),
+    post_position: typeof r.post_position === "number" ? r.post_position : 1,
+    horse_id: String(r.horse_id ?? ""),
+    horse_name: "",
+    horse_age: numOrNull(r.horse_age),
+    horse_sex: "",
+    horse_color: "",
+    pedigree_father: "",
+    home_track: "",
+    driver: String(r.driver ?? ""),
+    driver_win_pct: numOrNull(r.driver_win_pct),
+    trainer: String(r.trainer ?? ""),
+    trainer_win_pct: numOrNull(r.trainer_win_pct),
+    odds: numOrNull(r.odds),
+    p_odds: numOrNull(r.p_odds),
+    bet_distribution: num(r.bet_distribution),
+    shoes_reported: !!r.shoes_reported,
+    shoes_front: !!r.shoes_front,
+    shoes_back: !!r.shoes_back,
+    shoes_front_changed: !!r.shoes_front_changed,
+    shoes_back_changed: !!r.shoes_back_changed,
+    sulky_type: String(r.sulky_type ?? ""),
+    starts_total: num(r.starts_total),
+    wins_total: num(r.wins_total),
+    places_2nd: num(r.places_2nd),
+    places_3rd: num(r.places_3rd),
+    earnings_total: num(r.earnings_total),
+    starts_current_year: num(r.starts_current_year),
+    wins_current_year: num(r.wins_current_year),
+    places_2nd_current_year: num(r.places_2nd_current_year),
+    places_3rd_current_year: num(r.places_3rd_current_year),
+    starts_prev_year: num(r.starts_prev_year),
+    wins_prev_year: num(r.wins_prev_year),
+    places_2nd_prev_year: num(r.places_2nd_prev_year),
+    places_3rd_prev_year: num(r.places_3rd_prev_year),
+    best_time: String(r.best_time ?? ""),
+    life_records: Array.isArray(r.life_records) ? r.life_records : [],
+    last_5_results: Array.isArray(r.last_5_results) ? r.last_5_results : [],
+    horse_starts_history: Array.isArray(r.horse_starts_history)
+      ? r.horse_starts_history
+      : undefined,
+  };
+}
+
+async function fetchAllStarters(db: SupabaseClient): Promise<Record<string, unknown>[]> {
+  const all: Record<string, unknown>[] = [];
+  const PAGE = 1000;
+  for (let from = 0; ; from += PAGE) {
+    const { data, error } = await db
+      .from("starters")
+      .select("*")
+      .order("race_id")
+      .order("start_number")
+      .range(from, from + PAGE - 1);
+    if (error) throw new Error(`starters: ${error.message}`);
+    all.push(...(data ?? []));
+    if (!data || data.length < PAGE) break;
+  }
+  return all;
+}
+
+async function main() {
+  loadEnv();
+  const dry = process.argv.includes("--dry");
+
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) {
+    console.error("Saknar NEXT_PUBLIC_SUPABASE_URL och/eller SUPABASE_SERVICE_ROLE_KEY i miljön.");
+    process.exit(1);
+  }
+  const db = createClient(url, key);
+
+  console.log("Läser games, track_configs, races och starters …");
+  const [{ data: games }, { data: configs }, { data: races }] = await Promise.all([
+    db.from("games").select("id, track"),
+    db.from("track_configs").select("*"),
+    db.from("races").select("id, game_id, distance, start_method"),
+  ]);
+
+  const trackByGame = new Map((games ?? []).map((g) => [g.id, g.track as string | null]));
+  const configByTrack = new Map(
+    ((configs ?? []) as TrackConfig[]).filter((c) => c.active).map((c) => [c.track_name, c])
+  );
+  const raceById = new Map(
+    (races ?? []).map((r) => [
+      r.id as string,
+      {
+        game_id: r.game_id as string,
+        distance: (r.distance as number) ?? 2140,
+        start_method: (r.start_method as string) ?? "auto",
+      },
+    ])
+  );
+
+  const allStarters = await fetchAllStarters(db);
+  console.log(`${allStarters.length} starters i ${raceById.size} avdelningar.\n`);
+
+  // Gruppera per lopp och bevara radordning (start_number)
+  const byRace = new Map<string, Record<string, unknown>[]>();
+  for (const s of allStarters) {
+    const rid = s.race_id as string;
+    if (!byRace.has(rid)) byRace.set(rid, []);
+    byRace.get(rid)!.push(s);
+  }
+
+  // Bygg listan av uppdateringar (rad-id → ny formscore)
+  const updates: { id: string; from: number | null; to: number }[] = [];
+  let skipped = 0;
+  for (const [raceId, rows] of byRace) {
+    const meta = raceById.get(raceId);
+    if (!meta) {
+      skipped += rows.length;
+      continue;
+    }
+    const starters = rows.map(rowToStarter);
+    const ctx: RaceContext = {
+      distance: meta.distance,
+      start_method: meta.start_method,
+      field_size: starters.length,
+    };
+    const track = trackByGame.get(meta.game_id) ?? null;
+    const config = track ? configByTrack.get(track) : undefined;
+    const scores = calculateCompositeScore(starters, ctx, config);
+    rows.forEach((r, i) => {
+      const id = r.id as string;
+      const oldScore = typeof r.formscore === "number" ? r.formscore : null;
+      if (id && oldScore !== scores[i]) {
+        updates.push({ id, from: oldScore, to: scores[i] });
+      }
+    });
+  }
+
+  const changed = updates.length;
+  console.log(
+    `${changed} rader får ny formscore${skipped ? ` (${skipped} hoppade över — saknar avdelning)` : ""}.`
+  );
+  // Visa ett par exempel på största förändringarna
+  const sample = [...updates]
+    .sort((a, b) => Math.abs((b.to - (b.from ?? 0))) - Math.abs((a.to - (a.from ?? 0))))
+    .slice(0, 5);
+  for (const u of sample) {
+    console.log(`  ${u.id.slice(0, 8)}…  ${u.from ?? "–"} → ${u.to}`);
+  }
+
+  if (dry) {
+    console.log("\n--dry: inget skrevs.");
+    return;
+  }
+  if (changed === 0) {
+    console.log("\nInget att uppdatera — alla poäng är redan aktuella.");
+    return;
+  }
+
+  console.log("\nSkriver uppdateringar …");
+  const CONCURRENCY = 20;
+  let written = 0;
+  for (let i = 0; i < updates.length; i += CONCURRENCY) {
+    const batch = updates.slice(i, i + CONCURRENCY);
+    const results = await Promise.all(
+      batch.map((u) => db.from("starters").update({ formscore: u.to }).eq("id", u.id))
+    );
+    for (const res of results) {
+      if (res.error) console.error(`  fel: ${res.error.message}`);
+      else written++;
+    }
+    process.stdout.write(`\r  ${Math.min(i + CONCURRENCY, updates.length)}/${updates.length}`);
+  }
+  console.log(`\nKlart — ${written} rader uppdaterade.`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
Fortsättning på analysarbetet. Baserat på de färska resultaten (229 lopp med facit nu, mot 155 tidigare) tar den här PR:en de tre kvarvarande issues som går att slutföra utan att hämta om omgångar.

## #67 — Kalibrerad vinstsannolikhet
Ny modul `lib/probability.ts` som blandar streckning och oddsmarknad 50/50 till en kalibrerad vinstchans. Koefficienten är inte gissad utan kalibrerad mot 221 lopp med facit:

| α (vikt streck) | log-loss |
|----------------|----------|
| 0.5 (blandning) | **1.5795** ← bäst |
| 1.0 (rent streck) | 1.6194 |
| 0.0 (rena odds) | 1.6216 |

Sanningen ligger alltså mitt emellan poolen och oddsmarknaden. I analyspanelen ersätter kolumnen **Chans** den gamla "Ber." (CS-andel), och **Värde = Chans − Streckning** — vilket är precis den odds/streck-diskrepans som driver skrällarna. VÄRDE-märket på hästkort, analystabell och Top 5 baseras nu på detta. Faller tillbaka på enbart streck, eller enbart odds innan poolen öppnat. CS behålls som rankningsmått. 8 nya enhetstester.

## #68 — Robustare backtest
`scripts/backtest-weights.ts` optimerade och utvärderade tidigare på samma lopp, vilket gör de rapporterade siffrorna optimistiska. Nu: seedad train/test-split (70/30), **log-loss** som primärt mål (straffar felkalibrering, inte bara fel ranking), binomiala standardfel och en varning vid tecken på överanpassning. Den ärliga siffran rapporteras på testdelen.

## #70 — Omräkning av lagrad formscore
`scripts/recompute-formscore.ts` (`npm run recompute-formscore`) räknar om `starters.formscore` för alla omgångar med de aktuella vikterna. Många omgångar bär poäng från vikterna som gällde vid hämtningstillfället, vilket gör att Top 5, sortering och utvärderingssidan visar inaktuella tal. Idempotent, `--dry` för torrkörning. **Kör detta efter merge** så att de färska resultaten utvärderas mot rätt poäng.

## Status på #69 (omkalibrera med kuskform/galopp) — fortfarande blockerad
Du hämtade *resultat*, men `driver_win_pct` är fortfarande 0 och hästhistoriken tom i databasen — #65-fixen får ny data först när omgångar hämtas **om** med den nya koden. Tills dess går kuskform och galopprisk inte att kalibrera. När du hämtat om några omgångar kan #69 göras (och då lönar det sig att köra om backtesten med train/test-splitten ovan).

## Test
- `npx jest`: 70 tester gröna (8 nya för sannolikheten)
- `tsc --noEmit` rent
- Lint oförändrat (3 förexisterande `set-state-in-effect`, inga nya)
- Manual (v2.3) och CLAUDE.md uppdaterade enligt konventionen

Closes #67, closes #68, closes #70.

https://claude.ai/code/session_016r3SKaqgmEtHD64UfAaQ3H

---
_Generated by [Claude Code](https://claude.ai/code/session_016r3SKaqgmEtHD64UfAaQ3H)_