### PR TITLE
Socialt: mobilingång, aktivitetssignaler och förtydliganden

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,7 +101,8 @@ components/
     spel/SystemCard.tsx     # Systemkort med score/8 och vinnarmarkeringar
     spel/BetsSection.tsx    # Insatser per omgång + ROI per medlem
   groups/
-    GroupList.tsx           # Lista sällskap med kopierbar kod/länk
+    SallskapOverview.tsx    # /sallskap-sidans innehåll (sällskapslista, skapa/gå med, profil, logga ut)
+    GroupList.tsx           # Lista sällskap med länk in + kopierbar kod/länk
     CreateGroupForm.tsx     # Skapa nytt sällskap
     JoinGroupForm.tsx       # Gå med via kod
     UserMenu.tsx            # Profilmeny

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,6 +102,7 @@ components/
     spel/BetsSection.tsx    # Insatser per omgång + ROI per medlem
   groups/
     SallskapOverview.tsx    # /sallskap-sidans innehåll (sällskapslista, skapa/gå med, profil, logga ut)
+    GroupActivitySection.tsx # "Nytt i dina sällskap" på startsidan (osedda händelser)
     GroupList.tsx           # Lista sällskap med länk in + kopierbar kod/länk
     CreateGroupForm.tsx     # Skapa nytt sällskap
     JoinGroupForm.tsx       # Gå med via kod
@@ -121,6 +122,7 @@ lib/
   types.ts                  # Delade TS-typer (Group, GroupMember, HorseNote, m.m.)
   supabase/                 # Supabase-klienter (server/browser)
   actions/
+    activity.ts             # Aktivitetssignaler: getGroupActivity (React-cachad) + markGroupSeen
     bets.ts                 # Server actions: spelförslag/bets
     games.ts                # Server actions: spel
     groups.ts               # Server actions: skapa/lämna sällskap
@@ -152,6 +154,7 @@ supabase/
 **game_systems** – sparade spelsystem (name, game_id, selections)
 **drafts** – utkast till spelsystem
 **track_configs** – banspecifik konfiguration (open_stretch, short_race_threshold)
+**group_last_seen** – när användare senast besökte ett sällskap (aktivitetsbadges)
 
 ---
 

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -258,22 +258,22 @@ Klicka på **Se systemet →** direkt efter sparning, eller gå till **System** 
 
 Sällskap låter dig och dina spelvänner diskutera hästar, dela anteckningar och följa varandras synpunkter inför spelet.
 
+**Profil-fliken** i mobilnavigeringen (eller **profilmenyn** uppe till höger på desktop) öppnar sällskapsöversikten. Där ser du dina sällskap (klicka på namnet för att öppna), skapar nya, går med via inbjudningskod, byter visningsnamn och loggar ut.
+
 ### 7.1 Skapa ett sällskap
 
-1. Gå till sällskapssidan via **Profil** i mobilnavigeringen, eller via **profilmenyn** uppe till höger på desktop.
-2. Välj **Skapa nytt sällskap**.
-3. Ange ett namn på sällskapet.
-4. Klicka på **Skapa**.
-5. Du blir automatiskt sällskapets **skapare** och ett unikt **inbjudningskod** genereras.
-6. Dela inbjudningskoden eller inbjudningslänken med de du vill bjuda in.
+1. Gå till sällskapsöversikten via **Profil**-fliken (mobil) eller **profilmenyn → Hantera sällskap** (desktop).
+2. Ange ett namn under **Skapa nytt sällskap**.
+3. Klicka på **Skapa**.
+4. Du blir automatiskt sällskapets **skapare** och en unik **inbjudningskod** genereras.
+5. Dela inbjudningskoden eller inbjudningslänken med de du vill bjuda in.
 
 ### 7.2 Gå med i ett sällskap
 
-1. Gå till sällskapssidan via **Profil** i mobilnavigeringen, eller via **profilmenyn** på desktop.
-2. Välj **Gå med i sällskap**.
-3. Ange den **inbjudningskod** du fått av sällskapets skapare (eller öppna inbjudningslänken direkt).
-4. Klicka på **Gå med**.
-5. Du är nu medlem och kan se och skriva i sällskapet.
+1. Gå till sällskapsöversikten via **Profil**-fliken (mobil) eller **profilmenyn → Hantera sällskap** (desktop).
+2. Ange den **inbjudningskod** du fått av sällskapets skapare under **Gå med via inbjudningskod** (eller öppna inbjudningslänken direkt).
+3. Klicka på **Gå med**.
+4. Du är nu medlem och kan se och skriva i sällskapet.
 
 ### 7.3 Flikar i sällskapet
 
@@ -385,4 +385,4 @@ Sidan visar:
 
 ---
 
-*Manual version 2.3 – V85 Analys*
+*Manual version 2.4 – V85 Analys*

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -260,6 +260,16 @@ Sällskap låter dig och dina spelvänner diskutera hästar, dela anteckningar o
 
 **Profil-fliken** i mobilnavigeringen (eller **profilmenyn** uppe till höger på desktop) öppnar sällskapsöversikten. Där ser du dina sällskap (klicka på namnet för att öppna), skapar nya, går med via inbjudningskod, byter visningsnamn och loggar ut.
 
+### Nytt sedan sist
+
+När andra medlemmar skrivit foruminlägg, antecknat på hästar eller sparat system sedan du senast besökte sällskapet visas det som:
+
+- En **siffer-badge** på Profil-fliken (mobil) och en prick på din avatar (desktop).
+- Sektionen **"Nytt i dina sällskap"** högst upp på startsidan med de senaste händelserna — klicka för att gå direkt till sällskapet.
+- Antal nya händelser bredvid sällskapets namn i listor och menyer.
+
+Badgen nollställs för ett sällskap när du öppnar det. Endast andras aktivitet räknas — dina egna inlägg skapar inga notiser.
+
 ### 7.1 Skapa ett sällskap
 
 1. Gå till sällskapsöversikten via **Profil**-fliken (mobil) eller **profilmenyn → Hantera sällskap** (desktop).
@@ -320,13 +330,13 @@ Anteckningar är kopplade till en specifik häst och visas för alla i de sälls
 1. Öppna en avdelning och hitta hästen du vill kommentera.
 2. Klicka på **▼ Anteckningar** längst ner på hästkortet.
 3. Skriv din text i textfältet.
-4. Välj en **etikett** (färgkod) för att kategorisera din notering:
-   - 🔴 **Röd**
-   - 🟠 **Orange**
-   - 🟡 **Gul**
-   - 🟢 **Grön**
-   - 🔵 **Blå**
-   - 🟣 **Lila**
+4. Välj en **etikett** (färgkod) för att kategorisera din notering. Färgerna har en gemensam betydelse så att alla i sällskapet läser dem likadant:
+   - 🟢 **Grön = Spik** — hästen ska med, gärna ensam.
+   - 🟡 **Gul = Skrällbud** — lågt streckad häst du tror på.
+   - 🔴 **Röd = Undvik** — stryk hästen trots streckningen.
+   - 🟠 **Orange = Risk/galopp** — osäker häst, galopprisk eller tveksam form.
+   - 🔵 **Blå = Info** — neutral fakta (skoändring, kuskbyte, etc.).
+   - 🟣 **Lila = Bevaka** — intressant till kommande starter.
 5. Välj om anteckningen ska tillhöra ett **sällskap** eller vara **Personlig**.
 6. Klicka på **Lägg till**.
 
@@ -385,4 +395,4 @@ Sidan visar:
 
 ---
 
-*Manual version 2.4 – V85 Analys*
+*Manual version 2.5 – V85 Analys*

--- a/app/(authenticated)/layout.tsx
+++ b/app/(authenticated)/layout.tsx
@@ -2,6 +2,7 @@ import { createClient } from "@/lib/supabase/server";
 import { BottomNav } from "@/components/BottomNav";
 import { TopNav } from "@/components/TopNav";
 import { InstallPrompt } from "@/components/InstallPrompt";
+import { getGroupActivity } from "@/lib/actions/activity";
 
 export default async function AuthenticatedLayout({
   children,
@@ -19,11 +20,13 @@ export default async function AuthenticatedLayout({
     .filter(Boolean);
   const isAdmin = user != null && adminIds.includes(user.id);
 
+  const activity = user ? await getGroupActivity() : null;
+
   return (
     <div className="pb-16 md:pb-0">
       <TopNav />
       {children}
-      <BottomNav isAdmin={isAdmin} />
+      <BottomNav isAdmin={isAdmin} sallskapBadge={activity?.unseenTotal ?? 0} />
       <InstallPrompt />
     </div>
   );

--- a/app/(authenticated)/page.tsx
+++ b/app/(authenticated)/page.tsx
@@ -10,6 +10,8 @@ import { CollapsibleControls } from "@/components/CollapsibleControls";
 import { RaceTabBar } from "@/components/RaceTabBar";
 import { RaceTabProvider } from "@/components/RaceTabContext";
 import { getProfile, getMyGroups } from "@/lib/actions/groups";
+import { getGroupActivity } from "@/lib/actions/activity";
+import { GroupActivitySection } from "@/components/groups/GroupActivitySection";
 import { getDraftForGame } from "@/lib/actions/systems";
 import { getTrackConfig } from "@/lib/actions/tracks";
 import { redirect } from "next/navigation";
@@ -60,10 +62,11 @@ export default async function HomePage({
   if (!user) redirect("/login");
 
   const params = await searchParams;
-  const [games, profile, userGroups] = await Promise.all([
+  const [games, profile, userGroups, activity] = await Promise.all([
     getAllGames(supabase),
     getProfile(),
     getMyGroups(),
+    getGroupActivity(),
   ]);
 
   // Välj spel: URL-param → senaste sparade
@@ -136,6 +139,7 @@ export default async function HomePage({
                 profile={profile}
                 groups={userGroups}
                 userEmail={user.email ?? ""}
+                unseenByGroup={activity.unseenByGroup}
               />
             </div>
           </div>
@@ -172,6 +176,8 @@ export default async function HomePage({
       </header>
 
       <div className="px-4 lg:px-[5%] xl:px-[8%] py-6">
+        <GroupActivitySection activity={activity} />
+
         <div className="mb-6">
           <UsefulLinks />
         </div>

--- a/app/(authenticated)/sallskap/[groupId]/SallskapPageClient.tsx
+++ b/app/(authenticated)/sallskap/[groupId]/SallskapPageClient.tsx
@@ -43,10 +43,10 @@ export function SallskapPageClient({
         style={{ background: "var(--tn-bg)", borderBottom: "1px solid var(--tn-border)" }}
       >
         <Link
-          href="/"
+          href="/sallskap"
           className="text-lg w-8 text-center shrink-0 transition"
           style={{ color: "var(--tn-text-faint)" }}
-          aria-label="Tillbaka"
+          aria-label="Tillbaka till sällskapsöversikten"
         >
           ←
         </Link>

--- a/app/(authenticated)/sallskap/[groupId]/page.tsx
+++ b/app/(authenticated)/sallskap/[groupId]/page.tsx
@@ -2,6 +2,7 @@ import { redirect } from "next/navigation";
 import { createClient, createServiceClient } from "@/lib/supabase/server";
 import { getGroupById } from "@/lib/actions/groups";
 import { getGroupMembers } from "@/lib/actions/sallskap";
+import { markGroupSeen } from "@/lib/actions/activity";
 import { getGroupPosts } from "@/lib/actions/posts";
 import { getGroupNotesForGame } from "@/lib/actions/notes";
 import { getGroupSystems } from "@/lib/actions/systems";
@@ -36,6 +37,9 @@ export default async function SallskapPage({ params }: Props) {
     .single();
 
   if (!membership) redirect("/");
+
+  // Besöket nollställer aktivitetsbadgen för det här sällskapet
+  await markGroupSeen(groupId);
 
   const [group, members, games] = await Promise.all([
     getGroupById(groupId),

--- a/app/(authenticated)/sallskap/page.tsx
+++ b/app/(authenticated)/sallskap/page.tsx
@@ -1,6 +1,7 @@
 import { redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
 import { getProfile, getMyGroups } from "@/lib/actions/groups";
+import { getGroupActivity } from "@/lib/actions/activity";
 import { SallskapOverview } from "@/components/groups/SallskapOverview";
 
 /**
@@ -12,13 +13,18 @@ export default async function SallskapOverviewPage() {
   const { data: { user } } = await supabase.auth.getUser();
   if (!user) redirect("/login");
 
-  const [profile, groups] = await Promise.all([getProfile(), getMyGroups()]);
+  const [profile, groups, activity] = await Promise.all([
+    getProfile(),
+    getMyGroups(),
+    getGroupActivity(),
+  ]);
 
   return (
     <SallskapOverview
       profile={profile}
       initialGroups={groups}
       userEmail={user.email ?? ""}
+      unseenByGroup={activity.unseenByGroup}
     />
   );
 }

--- a/app/(authenticated)/sallskap/page.tsx
+++ b/app/(authenticated)/sallskap/page.tsx
@@ -1,0 +1,24 @@
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import { getProfile, getMyGroups } from "@/lib/actions/groups";
+import { SallskapOverview } from "@/components/groups/SallskapOverview";
+
+/**
+ * Översikt över användarens sällskap + profil. Mobilens ingång till det
+ * sociala (Profil-fliken i BottomNav pekar hit).
+ */
+export default async function SallskapOverviewPage() {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) redirect("/login");
+
+  const [profile, groups] = await Promise.all([getProfile(), getMyGroups()]);
+
+  return (
+    <SallskapOverview
+      profile={profile}
+      initialGroups={groups}
+      userEmail={user.email ?? ""}
+    />
+  );
+}

--- a/components/BottomNav.tsx
+++ b/components/BottomNav.tsx
@@ -44,7 +44,14 @@ const tabs = [
   },
 ];
 
-export function BottomNav({ isAdmin = false }: { isAdmin?: boolean }) {
+export function BottomNav({
+  isAdmin = false,
+  sallskapBadge = 0,
+}: {
+  isAdmin?: boolean;
+  /** Antal osedda händelser i användarens sällskap — visas som badge på Profil-fliken */
+  sallskapBadge?: number;
+}) {
   const pathname = usePathname();
 
   return (
@@ -67,6 +74,7 @@ export function BottomNav({ isAdmin = false }: { isAdmin?: boolean }) {
         {tabs.map((tab) => {
           const isActive =
             tab.href === "/" ? pathname === "/" : pathname.startsWith(tab.href);
+          const showBadge = tab.href === "/sallskap" && sallskapBadge > 0;
           return (
             <Link
               key={tab.href}
@@ -80,7 +88,18 @@ export function BottomNav({ isAdmin = false }: { isAdmin?: boolean }) {
                 textTransform: "uppercase",
               }}
             >
-              {tab.icon}
+              <span className="relative">
+                {tab.icon}
+                {showBadge && (
+                  <span
+                    className="absolute -top-1 -right-2 min-w-[16px] h-4 px-1 rounded-full flex items-center justify-center text-[9px] font-bold"
+                    style={{ background: "var(--tn-accent)", color: "#fff", letterSpacing: 0 }}
+                    aria-label={`${sallskapBadge} nya händelser i dina sällskap`}
+                  >
+                    {sallskapBadge > 9 ? "9+" : sallskapBadge}
+                  </span>
+                )}
+              </span>
               {tab.label}
             </Link>
           );

--- a/components/TopNav.tsx
+++ b/components/TopNav.tsx
@@ -2,6 +2,7 @@ import { NavActiveLink } from "@/components/NavActiveLink";
 import { ThemeToggle } from "@/components/ThemeToggle";
 import { UserMenu } from "@/components/groups/UserMenu";
 import { getProfile, getMyGroups } from "@/lib/actions/groups";
+import { getGroupActivity } from "@/lib/actions/activity";
 import { createClient } from "@/lib/supabase/server";
 
 const tabs = [
@@ -17,9 +18,9 @@ export async function TopNav() {
     data: { user },
   } = await supabase.auth.getUser();
 
-  const [profile, groups] = user
-    ? await Promise.all([getProfile(), getMyGroups()])
-    : [null, []];
+  const [profile, groups, activity] = user
+    ? await Promise.all([getProfile(), getMyGroups(), getGroupActivity()])
+    : [null, [], null];
 
   const adminIds = (process.env.ADMIN_USER_IDS ?? "")
     .split(",")
@@ -60,6 +61,7 @@ export async function TopNav() {
             profile={profile}
             groups={groups}
             userEmail={user.email ?? ""}
+            unseenByGroup={activity?.unseenByGroup}
           />
         )}
       </div>

--- a/components/groups/GroupActivitySection.tsx
+++ b/components/groups/GroupActivitySection.tsx
@@ -1,0 +1,79 @@
+import Link from "next/link";
+import type { GroupActivitySummary, GroupActivityItem } from "@/lib/actions/activity";
+
+const TYPE_LABEL: Record<GroupActivityItem["type"], string> = {
+  post: "skrev i forumet",
+  note: "antecknade om",
+  system: "sparade systemet",
+};
+
+const TYPE_ICON: Record<GroupActivityItem["type"], string> = {
+  post: "💬",
+  note: "📝",
+  system: "🎯",
+};
+
+function relativeTime(dateStr: string): string {
+  const diff = Date.now() - new Date(dateStr).getTime();
+  const minutes = Math.floor(diff / 60_000);
+  if (minutes < 1) return "just nu";
+  if (minutes < 60) return `${minutes} min sedan`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours} tim sedan`;
+  const days = Math.floor(hours / 24);
+  return `${days} dag${days > 1 ? "ar" : ""} sedan`;
+}
+
+/**
+ * "Nytt i dina sällskap" på startsidan — det andra sett osedda inlägg,
+ * anteckningar och system sedan ditt senaste besök. Visas inte när allt är sett.
+ */
+export function GroupActivitySection({ activity }: { activity: GroupActivitySummary }) {
+  if (activity.unseenTotal === 0) return null;
+
+  return (
+    <section
+      className="mb-6 rounded-xl overflow-hidden"
+      style={{ border: "1px solid var(--tn-border)", background: "var(--tn-bg-card)" }}
+    >
+      <div className="px-4 pt-3 pb-2 flex items-center justify-between">
+        <h2 className="tn-eyebrow">Nytt i dina sällskap</h2>
+        <span
+          className="min-w-[18px] h-[18px] px-1.5 rounded-full flex items-center justify-center text-[10px] font-bold"
+          style={{ background: "var(--tn-accent)", color: "#fff" }}
+        >
+          {activity.unseenTotal > 9 ? "9+" : activity.unseenTotal}
+        </span>
+      </div>
+      <ul>
+        {activity.recent.map((item, i) => (
+          <li key={`${item.type}-${item.created_at}-${i}`}>
+            <Link
+              href={`/sallskap/${item.group_id}`}
+              className="flex items-baseline gap-2 px-4 py-2 text-sm transition hover:underline"
+              style={{ borderTop: "1px solid var(--tn-border)" }}
+            >
+              <span aria-hidden="true" className="text-xs shrink-0">{TYPE_ICON[item.type]}</span>
+              <span className="min-w-0 flex-1 truncate" style={{ color: "var(--tn-text)" }}>
+                <span className="font-medium">{item.author_name}</span>{" "}
+                <span style={{ color: "var(--tn-text-dim)" }}>
+                  {TYPE_LABEL[item.type]}{" "}
+                  {item.type === "note" && item.horse_name ? (
+                    <span style={{ color: "var(--tn-text)" }}>{item.horse_name}</span>
+                  ) : (
+                    <span style={{ color: "var(--tn-text)" }}>
+                      {item.text.length > 60 ? `${item.text.slice(0, 60)}…` : item.text}
+                    </span>
+                  )}
+                </span>
+              </span>
+              <span className="shrink-0 tn-mono text-[10px]" style={{ color: "var(--tn-text-faint)" }}>
+                {item.group_name} · {relativeTime(item.created_at)}
+              </span>
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/components/groups/GroupList.tsx
+++ b/components/groups/GroupList.tsx
@@ -44,7 +44,16 @@ function CopyLinkButton({ inviteCode }: { inviteCode: string }) {
   );
 }
 
-export function GroupList({ groups, onLeft }: { groups: Group[]; onLeft: (groupId: string) => void }) {
+export function GroupList({
+  groups,
+  onLeft,
+  unseenByGroup = {},
+}: {
+  groups: Group[];
+  onLeft: (groupId: string) => void;
+  /** Osedda händelser per sällskap — visas som badge bredvid namnet */
+  unseenByGroup?: Record<string, number>;
+}) {
   const [leaving, setLeaving] = useState<string | null>(null);
 
   async function handleLeave(groupId: string) {
@@ -76,7 +85,17 @@ export function GroupList({ groups, onLeft }: { groups: Group[]; onLeft: (groupI
               className="text-sm font-medium truncate block hover:underline"
               style={{ color: "var(--tn-text)" }}
             >
-              {g.name} <span style={{ color: "var(--tn-accent)" }}>→</span>
+              {g.name}{" "}
+              {(unseenByGroup[g.id] ?? 0) > 0 && (
+                <span
+                  className="inline-flex items-center justify-center min-w-[16px] h-4 px-1 rounded-full text-[9px] font-bold align-middle mr-1"
+                  style={{ background: "var(--tn-accent)", color: "#fff" }}
+                  aria-label={`${unseenByGroup[g.id]} nya händelser`}
+                >
+                  {unseenByGroup[g.id]! > 9 ? "9+" : unseenByGroup[g.id]}
+                </span>
+              )}
+              <span style={{ color: "var(--tn-accent)" }}>→</span>
             </Link>
             <div className="flex items-center gap-2 mt-0.5 flex-wrap">
               <div className="flex items-center gap-1">

--- a/components/groups/GroupList.tsx
+++ b/components/groups/GroupList.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import Link from "next/link";
 import { leaveGroup } from "@/lib/actions/groups";
 import type { Group } from "@/lib/types";
 
@@ -70,7 +71,13 @@ export function GroupList({ groups, onLeft }: { groups: Group[]; onLeft: (groupI
           style={{ background: "var(--tn-bg-chip)" }}
         >
           <div className="min-w-0">
-            <p className="text-sm font-medium truncate" style={{ color: "var(--tn-text)" }}>{g.name}</p>
+            <Link
+              href={`/sallskap/${g.id}`}
+              className="text-sm font-medium truncate block hover:underline"
+              style={{ color: "var(--tn-text)" }}
+            >
+              {g.name} <span style={{ color: "var(--tn-accent)" }}>→</span>
+            </Link>
             <div className="flex items-center gap-2 mt-0.5 flex-wrap">
               <div className="flex items-center gap-1">
                 <span className="text-xs" style={{ color: "var(--tn-text-faint)" }}>Kod:</span>

--- a/components/groups/SallskapOverview.tsx
+++ b/components/groups/SallskapOverview.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { createClient } from "@/lib/supabase/client";
+import { ProfileForm } from "./ProfileForm";
+import { GroupList } from "./GroupList";
+import { CreateGroupForm } from "./CreateGroupForm";
+import { JoinGroupForm } from "./JoinGroupForm";
+import type { Group, Profile } from "@/lib/types";
+
+interface SallskapOverviewProps {
+  profile: Profile | null;
+  initialGroups: Group[];
+  userEmail: string;
+}
+
+/**
+ * Innehållet på /sallskap — mobilens ingång till sällskapen (Profil-fliken i
+ * BottomNav) och profilinställningar. Desktop når samma funktioner via
+ * profilmenyn, men sidan fungerar på alla skärmstorlekar.
+ */
+export function SallskapOverview({ profile, initialGroups, userEmail }: SallskapOverviewProps) {
+  const [groups, setGroups] = useState<Group[]>(initialGroups);
+  const router = useRouter();
+
+  function handleCreated(group: Group) {
+    setGroups((prev) => [...prev, group]);
+  }
+  function handleJoined(group: Group) {
+    setGroups((prev) => (prev.find((g) => g.id === group.id) ? prev : [...prev, group]));
+  }
+  function handleLeft(groupId: string) {
+    setGroups((prev) => prev.filter((g) => g.id !== groupId));
+  }
+
+  async function handleSignOut() {
+    const supabase = createClient();
+    await supabase.auth.signOut();
+    router.push("/login");
+  }
+
+  const displayName = profile?.display_name || userEmail.split("@")[0];
+
+  return (
+    <div className="px-4 py-5 space-y-7 max-w-2xl mx-auto">
+      {/* Profil */}
+      <header className="flex items-center gap-3">
+        <span
+          className="w-12 h-12 rounded-full flex items-center justify-center text-base font-bold shrink-0"
+          style={{ background: "var(--tn-accent)", color: "#fff" }}
+        >
+          {displayName.slice(0, 2).toUpperCase()}
+        </span>
+        <div className="min-w-0">
+          <h1 className="text-lg font-bold truncate" style={{ color: "var(--tn-text)" }}>
+            {displayName}
+          </h1>
+          <p className="text-xs truncate" style={{ color: "var(--tn-text-faint)" }}>{userEmail}</p>
+        </div>
+      </header>
+
+      {/* Sällskap */}
+      <section>
+        <h2 className="tn-eyebrow mb-2">Mina sällskap</h2>
+        {groups.length === 0 && (
+          <p className="text-sm mb-3 leading-relaxed" style={{ color: "var(--tn-text-dim)" }}>
+            Sällskap är platsen där du och dina spelvänner delar anteckningar om hästarna,
+            diskuterar omgången och jämför era system när resultaten rättats. Skapa ett
+            sällskap nedan eller gå med i ett befintligt via en inbjudningskod.
+          </p>
+        )}
+        <GroupList groups={groups} onLeft={handleLeft} />
+      </section>
+
+      <section>
+        <h2 className="tn-eyebrow mb-2">Skapa nytt sällskap</h2>
+        <CreateGroupForm onCreated={handleCreated} />
+      </section>
+
+      <section>
+        <h2 className="tn-eyebrow mb-2">Gå med via inbjudningskod</h2>
+        <JoinGroupForm onJoined={handleJoined} />
+      </section>
+
+      {/* Inställningar */}
+      <section>
+        <h2 className="tn-eyebrow mb-2">Visningsnamn</h2>
+        <p className="text-xs mb-2" style={{ color: "var(--tn-text-faint)" }}>
+          Syns för övriga medlemmar i dina sällskap.
+        </p>
+        <ProfileForm initialName={profile?.display_name ?? ""} />
+      </section>
+
+      <section className="pt-1 space-y-2">
+        <Link
+          href="/manual"
+          className="block text-sm"
+          style={{ color: "var(--tn-accent)" }}
+        >
+          Användarmanual
+        </Link>
+        <button
+          onClick={handleSignOut}
+          className="text-sm transition"
+          style={{ color: "var(--tn-value-low)", background: "none", border: "none", cursor: "pointer", padding: 0 }}
+        >
+          Logga ut
+        </button>
+      </section>
+    </div>
+  );
+}

--- a/components/groups/SallskapOverview.tsx
+++ b/components/groups/SallskapOverview.tsx
@@ -14,6 +14,8 @@ interface SallskapOverviewProps {
   profile: Profile | null;
   initialGroups: Group[];
   userEmail: string;
+  /** Osedda händelser per sällskap — visas som badge i listan */
+  unseenByGroup?: Record<string, number>;
 }
 
 /**
@@ -21,7 +23,7 @@ interface SallskapOverviewProps {
  * BottomNav) och profilinställningar. Desktop når samma funktioner via
  * profilmenyn, men sidan fungerar på alla skärmstorlekar.
  */
-export function SallskapOverview({ profile, initialGroups, userEmail }: SallskapOverviewProps) {
+export function SallskapOverview({ profile, initialGroups, userEmail, unseenByGroup }: SallskapOverviewProps) {
   const [groups, setGroups] = useState<Group[]>(initialGroups);
   const router = useRouter();
 
@@ -71,7 +73,7 @@ export function SallskapOverview({ profile, initialGroups, userEmail }: Sallskap
             sällskap nedan eller gå med i ett befintligt via en inbjudningskod.
           </p>
         )}
-        <GroupList groups={groups} onLeft={handleLeft} />
+        <GroupList groups={groups} onLeft={handleLeft} unseenByGroup={unseenByGroup} />
       </section>
 
       <section>

--- a/components/groups/UserMenu.tsx
+++ b/components/groups/UserMenu.tsx
@@ -11,9 +11,11 @@ interface UserMenuProps {
   profile: Profile | null;
   groups: Group[];
   userEmail: string;
+  /** Osedda händelser per sällskap — visar prick på avataren och antal i listan */
+  unseenByGroup?: Record<string, number>;
 }
 
-export function UserMenu({ profile, groups, userEmail }: UserMenuProps) {
+export function UserMenu({ profile, groups, userEmail, unseenByGroup = {} }: UserMenuProps) {
   const [open, setOpen] = useState(false);
   const [modalOpen, setModalOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
@@ -21,6 +23,7 @@ export function UserMenu({ profile, groups, userEmail }: UserMenuProps) {
 
   const displayName = profile?.display_name || userEmail.split("@")[0];
   const initials = displayName.slice(0, 2).toUpperCase();
+  const unseenTotal = Object.values(unseenByGroup).reduce((a, b) => a + b, 0);
 
   useEffect(() => {
     function handleClick(e: MouseEvent) {
@@ -41,11 +44,18 @@ export function UserMenu({ profile, groups, userEmail }: UserMenuProps) {
       <div className="relative" ref={menuRef}>
         <button
           onClick={() => setOpen((v) => !v)}
-          className="w-9 h-9 rounded-full flex items-center justify-center text-sm font-bold shrink-0 transition"
+          className="relative w-9 h-9 rounded-full flex items-center justify-center text-sm font-bold shrink-0 transition"
           style={{ background: "var(--tn-accent)", color: "#fff" }}
-          title={displayName}
+          title={unseenTotal > 0 ? `${displayName} — ${unseenTotal} nya händelser i dina sällskap` : displayName}
         >
           {initials}
+          {unseenTotal > 0 && (
+            <span
+              className="absolute -top-0.5 -right-0.5 w-3 h-3 rounded-full"
+              style={{ background: "var(--tn-warn)", border: "2px solid var(--tn-bg)" }}
+              aria-label={`${unseenTotal} nya händelser i dina sällskap`}
+            />
+          )}
         </button>
 
         {open && (
@@ -63,17 +73,28 @@ export function UserMenu({ profile, groups, userEmail }: UserMenuProps) {
               {groups.length > 0 && (
                 <div className="px-4 py-2" style={{ borderBottom: "1px solid var(--tn-border)" }}>
                   <p className="text-xs mb-1" style={{ color: "var(--tn-text-faint)" }}>Sällskap</p>
-                  {groups.map((g) => (
-                    <Link
-                      key={g.id}
-                      href={`/sallskap/${g.id}`}
-                      onClick={() => setOpen(false)}
-                      className="block text-xs truncate py-0.5 transition"
-                      style={{ color: "var(--tn-text-dim)" }}
-                    >
-                      {g.name}
-                    </Link>
-                  ))}
+                  {groups.map((g) => {
+                    const unseen = unseenByGroup[g.id] ?? 0;
+                    return (
+                      <Link
+                        key={g.id}
+                        href={`/sallskap/${g.id}`}
+                        onClick={() => setOpen(false)}
+                        className="flex items-center gap-2 text-xs py-0.5 transition"
+                        style={{ color: "var(--tn-text-dim)" }}
+                      >
+                        <span className="truncate">{g.name}</span>
+                        {unseen > 0 && (
+                          <span
+                            className="shrink-0 min-w-[16px] h-4 px-1 rounded-full flex items-center justify-center text-[9px] font-bold"
+                            style={{ background: "var(--tn-accent)", color: "#fff" }}
+                          >
+                            {unseen > 9 ? "9+" : unseen}
+                          </span>
+                        )}
+                      </Link>
+                    );
+                  })}
                 </div>
               )}
 

--- a/components/notes/NoteLabel.tsx
+++ b/components/notes/NoteLabel.tsx
@@ -9,13 +9,17 @@ const LABEL_HEX: Record<NoteLabel, string> = {
   purple: "#a78bfa",
 };
 
+/**
+ * Gemensam betydelse per färg så att etiketterna säger samma sak för alla i
+ * sällskapet. Dokumenterad i MANUAL.md avsnitt 8.
+ */
 const LABEL_NAMES: Record<NoteLabel, string> = {
-  red: "Röd",
-  orange: "Orange",
-  yellow: "Gul",
-  green: "Grön",
-  blue: "Blå",
-  purple: "Lila",
+  red: "Undvik",
+  orange: "Risk/galopp",
+  yellow: "Skrällbud",
+  green: "Spik",
+  blue: "Info",
+  purple: "Bevaka",
 };
 
 export const NOTE_LABELS: NoteLabel[] = ["red", "orange", "yellow", "green", "blue", "purple"];
@@ -58,14 +62,20 @@ export function NoteLabelPicker({
         />
       ))}
       {value && (
-        <button
-          type="button"
-          onClick={() => onChange(null)}
-          className="text-xs ml-1"
-          style={{ color: "var(--tn-text-faint)", background: "none", border: "none", cursor: "pointer" }}
-        >
-          ✕
-        </button>
+        <>
+          <span className="text-xs ml-0.5" style={{ color: "var(--tn-text-dim)" }}>
+            {LABEL_NAMES[value]}
+          </span>
+          <button
+            type="button"
+            onClick={() => onChange(null)}
+            className="text-xs ml-1"
+            style={{ color: "var(--tn-text-faint)", background: "none", border: "none", cursor: "pointer" }}
+            aria-label="Ta bort etikett"
+          >
+            ✕
+          </button>
+        </>
       )}
     </div>
   );

--- a/components/sallskap/forum/PostList.tsx
+++ b/components/sallskap/forum/PostList.tsx
@@ -13,8 +13,10 @@ interface PostListProps {
 export function PostList({ posts, groupId, gameId, currentUserId, onDeleted, onReplied }: PostListProps) {
   if (posts.length === 0) {
     return (
-      <p className="text-sm italic py-4 text-center" style={{ color: "var(--tn-text-faint)" }}>
-        Inga inlägg ännu. Dela din analys!
+      <p className="text-sm py-4 text-center leading-relaxed" style={{ color: "var(--tn-text-faint)" }}>
+        Inga inlägg ännu för den här omgången.
+        <br />
+        Dela dina spikar och skrällbud — vem öppnar diskussionen inför lördagen?
       </p>
     );
   }

--- a/components/sallskap/notes/NotesTab.tsx
+++ b/components/sallskap/notes/NotesTab.tsx
@@ -71,8 +71,11 @@ export function NotesTab({ groupId, games, initialGameId, initialNotes }: NotesT
       {loading && <p className="text-sm text-center py-4" style={{ color: "var(--tn-text-faint)" }}>Laddar…</p>}
 
       {!loading && selectedGameId && races.length === 0 && (
-        <p className="text-sm italic text-center py-6" style={{ color: "var(--tn-text-faint)" }}>
-          Inga sällskapsanteckningar finns för denna omgång.
+        <p className="text-sm text-center py-6 leading-relaxed" style={{ color: "var(--tn-text-faint)" }}>
+          Inga sällskapsanteckningar för den här omgången ännu.
+          <br />
+          Skriv anteckningar direkt på hästkorten i loppvyn — de samlas här och
+          följer hästen till nästa start.
         </p>
       )}
 

--- a/components/sallskap/spel/SpelTab.tsx
+++ b/components/sallskap/spel/SpelTab.tsx
@@ -106,8 +106,11 @@ export function SpelTab({ groupId, games, initialGameId, initialSystems, current
         </div>
       ) : isEmpty ? (
         <div className="text-center py-10">
-          <p className="mb-2 text-sm" style={{ color: "var(--tn-text-faint)" }}>
-            Inga system sparade för denna omgång ännu.
+          <p className="mb-2 text-sm leading-relaxed" style={{ color: "var(--tn-text-faint)" }}>
+            Inga system sparade för den här omgången ännu.
+            <br />
+            Spara ett system så rättas det automatiskt mot resultaten — och ni ser
+            vem i sällskapet som prickade flest vinnare.
           </p>
           {selectedGame && (
             <Link

--- a/lib/actions/activity.ts
+++ b/lib/actions/activity.ts
@@ -1,0 +1,185 @@
+import { cache } from "react";
+import { createServiceClient } from "@/lib/supabase/server";
+import { getAuthUser } from "@/lib/supabase/guards";
+
+/** En händelse i något av användarens sällskap (annan medlems inlägg/anteckning/system) */
+export interface GroupActivityItem {
+  type: "post" | "note" | "system";
+  group_id: string;
+  group_name: string;
+  author_name: string;
+  created_at: string;
+  /** Omgång händelsen hör till (saknas för anteckningar — de sitter på hästen) */
+  game_id: string | null;
+  /** Innehållsutdrag: inläggstext, anteckningstext eller systemnamn */
+  text: string;
+  horse_name?: string;
+}
+
+export interface GroupActivitySummary {
+  /** Antal osedda händelser totalt över användarens sällskap */
+  unseenTotal: number;
+  /** Antal osedda händelser per sällskap */
+  unseenByGroup: Record<string, number>;
+  /** Senaste osedda händelserna, nyast först */
+  recent: GroupActivityItem[];
+}
+
+const EMPTY: GroupActivitySummary = { unseenTotal: 0, unseenByGroup: {}, recent: [] };
+
+/** Hur långt bak vi tittar — äldre händelser räknas aldrig som nya */
+const ACTIVITY_WINDOW_DAYS = 30;
+/** Max antal händelser i "Nytt i dina sällskap" */
+const RECENT_LIMIT = 6;
+
+/**
+ * Markerar ett sällskap som besökt — händelser fram till nu räknas som sedda.
+ * Anropas från sällskapssidan (server) när användaren öppnar den.
+ */
+export async function markGroupSeen(groupId: string): Promise<void> {
+  const user = await getAuthUser();
+  if (!user) return;
+
+  const db = createServiceClient();
+  await db
+    .from("group_last_seen")
+    .upsert(
+      { user_id: user.id, group_id: groupId, seen_at: new Date().toISOString() },
+      { onConflict: "user_id,group_id" }
+    );
+}
+
+/**
+ * Osedda händelser i användarens sällskap: foruminlägg, anteckningar och
+ * sparade system skapade av andra medlemmar efter användarens senaste besök.
+ * Utan tidigare besök räknas allt inom aktivitetsfönstret som nytt.
+ *
+ * React-cache():ad — layout, navigering och startsida kan alla anropa utan
+ * dubbla databasfrågor inom samma request.
+ */
+export const getGroupActivity = cache(async (): Promise<GroupActivitySummary> => {
+  const user = await getAuthUser();
+  if (!user) return EMPTY;
+
+  const db = createServiceClient();
+
+  // Användarens sällskap + senaste besök
+  const [{ data: memberships }, { data: seenRows }] = await Promise.all([
+    db.from("group_members").select("group_id").eq("user_id", user.id),
+    db.from("group_last_seen").select("group_id, seen_at").eq("user_id", user.id),
+  ]);
+  const groupIds = (memberships ?? []).map((m) => m.group_id as string);
+  if (groupIds.length === 0) return EMPTY;
+
+  const windowStart = new Date(Date.now() - ACTIVITY_WINDOW_DAYS * 86_400_000).toISOString();
+  const seenAt = new Map((seenRows ?? []).map((r) => [r.group_id as string, r.seen_at as string]));
+  // Brytpunkt per grupp: senaste besöket, dock aldrig äldre än fönstret
+  const cutoff = (groupId: string) => {
+    const seen = seenAt.get(groupId);
+    return seen && seen > windowStart ? seen : windowStart;
+  };
+
+  // Hämta kandidater per typ inom fönstret (per-grupp-cutoff filtreras efteråt)
+  const [{ data: posts }, { data: notes }, { data: systems }, { data: groups }] =
+    await Promise.all([
+      db
+        .from("group_posts")
+        .select("group_id, game_id, author_id, content, created_at")
+        .in("group_id", groupIds)
+        .neq("author_id", user.id)
+        .gt("created_at", windowStart)
+        .order("created_at", { ascending: false })
+        .limit(100),
+      db
+        .from("horse_notes")
+        .select("group_id, author_id, content, created_at, horses(name)")
+        .in("group_id", groupIds)
+        .neq("author_id", user.id)
+        .gt("created_at", windowStart)
+        .order("created_at", { ascending: false })
+        .limit(100),
+      db
+        .from("game_systems")
+        .select("group_id, game_id, user_id, name, created_at")
+        .in("group_id", groupIds)
+        .neq("user_id", user.id)
+        .gt("created_at", windowStart)
+        .order("created_at", { ascending: false })
+        .limit(100),
+      db.from("groups").select("id, name").in("id", groupIds),
+    ]);
+
+  const groupName = new Map((groups ?? []).map((g) => [g.id as string, g.name as string]));
+
+  type Raw = {
+    type: GroupActivityItem["type"];
+    group_id: string;
+    author_id: string;
+    created_at: string;
+    game_id: string | null;
+    text: string;
+    horse_name?: string;
+  };
+  const all: Raw[] = [
+    ...(posts ?? []).map((p) => ({
+      type: "post" as const,
+      group_id: p.group_id as string,
+      author_id: p.author_id as string,
+      created_at: p.created_at as string,
+      game_id: (p.game_id as string) ?? null,
+      text: p.content as string,
+    })),
+    ...(notes ?? []).map((n) => ({
+      type: "note" as const,
+      group_id: n.group_id as string,
+      author_id: n.author_id as string,
+      created_at: n.created_at as string,
+      game_id: null,
+      text: n.content as string,
+      horse_name: (n.horses as unknown as { name: string } | null)?.name,
+    })),
+    ...(systems ?? []).map((s) => ({
+      type: "system" as const,
+      group_id: s.group_id as string,
+      author_id: s.user_id as string,
+      created_at: s.created_at as string,
+      game_id: (s.game_id as string) ?? null,
+      text: s.name as string,
+    })),
+  ];
+
+  // Osett = nyare än användarens senaste besök i respektive sällskap
+  const unseen = all.filter((item) => item.created_at > cutoff(item.group_id));
+
+  const unseenByGroup: Record<string, number> = {};
+  for (const item of unseen) {
+    unseenByGroup[item.group_id] = (unseenByGroup[item.group_id] ?? 0) + 1;
+  }
+
+  unseen.sort((a, b) => (a.created_at < b.created_at ? 1 : -1));
+  const top = unseen.slice(0, RECENT_LIMIT);
+
+  // Författarnamn endast för de som visas
+  const authorIds = Array.from(new Set(top.map((t) => t.author_id)));
+  const { data: profiles } = authorIds.length
+    ? await db.from("profiles").select("id, display_name").in("id", authorIds)
+    : { data: [] };
+  const authorName = new Map(
+    (profiles ?? []).map((p) => [p.id as string, p.display_name as string | null])
+  );
+
+  return {
+    unseenTotal: unseen.length,
+    unseenByGroup,
+    recent: top.map((t) => ({
+      type: t.type,
+      group_id: t.group_id,
+      group_name: groupName.get(t.group_id) ?? "Sällskap",
+      author_name: authorName.get(t.author_id) ?? "Okänd",
+      created_at: t.created_at,
+      game_id: t.game_id,
+      text: t.text,
+      horse_name: t.horse_name,
+    })),
+  };
+});

--- a/supabase/migration_v11_group_last_seen.sql
+++ b/supabase/migration_v11_group_last_seen.sql
@@ -1,0 +1,17 @@
+-- v11: group_last_seen — spårar när en användare senast besökte ett sällskap.
+-- Används för aktivitetssignaler (badge i navigeringen + "Nytt i dina sällskap"
+-- på startsidan): innehåll skapat efter seen_at av andra medlemmar räknas som nytt.
+
+create table if not exists group_last_seen (
+  user_id  uuid not null references auth.users(id) on delete cascade,
+  group_id uuid not null references groups(id) on delete cascade,
+  seen_at  timestamptz not null default now(),
+  primary key (user_id, group_id)
+);
+
+alter table group_last_seen enable row level security;
+
+create policy "Användare hanterar sin egen last_seen"
+  on group_last_seen for all
+  using (user_id = auth.uid())
+  with check (user_id = auth.uid());


### PR DESCRIPTION
## Sammanfattning

Tre sociala förbättringar i ett svep — fixar att sällskapen var onåbara från mobil, gör appen "levande" med aktivitetssignaler, och förtydligar anteckningsetiketter och tomma tillstånd.

## #73 — Mobilingången (bugg)

BottomNavs Profil-flik pekade på `/sallskap` som saknade sida (404). Ny sida med sällskapslista (länkar in), skapa/gå med via kod, visningsnamn, manual-länk och logga ut. Gruppnamnen i desktop-modalen blev samtidigt klickbara, och tillbaka-pilen i ett sällskap går till översikten.

## #74 — Aktivitetssignaler

Appen var helt tyst — inget visade att en kompis skrivit något. Nu:

- **Siffer-badge på Profil-fliken** (mobil) och **prick på avataren + antal per sällskap** i profilmenyn (desktop) när andra medlemmar skrivit foruminlägg, antecknat eller sparat system sedan ditt senaste besök.
- **"Nytt i dina sällskap"** högst upp på startsidan: de senaste osedda händelserna med författare, typ och tid — klicka för att gå direkt till sällskapet.
- Besök på sällskapssidan nollställer badgen. Egna händelser räknas aldrig. 30 dagars fönster.

Teknik: ny tabell `group_last_seen` (migration v11, **redan applicerad på databasen** med RLS), ny modul `lib/actions/activity.ts` — React-`cache()`:ad så layout, TopNav och startsida delar en hämtning per request.

## #79 — Förtydliganden

- **Etikettfärgerna har nu gemensam betydelse**: grön = Spik, gul = Skrällbud, röd = Undvik, orange = Risk/galopp, blå = Info, lila = Bevaka. Visas i väljaren, som tooltip och i manualen.
- **Tomma tillstånd säljer funktionen** i Forum/Anteckningar/Spel i stället för att bara konstatera tomhet ("Spara ett system så rättas det automatiskt…").
- Profil-flikens namn: löst av #73 — sidan innehåller nu både profil och sällskap.

## Test
- `npx jest`: 70 tester gröna, `tsc --noEmit` rent, lint oförändrat (3 förexisterande)
- Migrationen är applicerad och verifierad mot produktionsdatabasen
- MANUAL.md uppdaterad (v2.5): nya avsnitt om aktivitetssignaler + etikettbetydelser

Closes #73, closes #74, closes #79.

https://claude.ai/code/session_016r3SKaqgmEtHD64UfAaQ3H