### PR TITLE
Resultatbanner: systemens utfall på startsidan när omgången rättats

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,7 @@ components/
   ResultsButton.tsx         # Knapp för att hämta loppresultat
   SaveSystemDialog.tsx      # Dialog för att spara spelsystem
   StartCountdown.tsx        # Nedräkning till start
+  SystemOutcomeBanner.tsx   # "Resultaten är rättade"-banner på startsidan (systemutfall)
   SystemDrawer.tsx          # Drawer-panel för systemkonfiguration
   SystemSidebar.tsx         # Sidebar för systembyggaren
   SystemsPageClient.tsx     # Client-wrapper för systemsidan
@@ -123,6 +124,7 @@ lib/
   supabase/                 # Supabase-klienter (server/browser)
   actions/
     activity.ts             # Aktivitetssignaler: getGroupActivity (React-cachad) + markGroupSeen
+    outcome.ts              # Senaste rättade omgångens systemutfall (resultatbannern)
     bets.ts                 # Server actions: spelförslag/bets
     games.ts                # Server actions: spel
     groups.ts               # Server actions: skapa/lämna sällskap

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -270,6 +270,10 @@ När andra medlemmar skrivit foruminlägg, antecknat på hästar eller sparat sy
 
 Badgen nollställs för ett sällskap när du öppnar det. Endast andras aktivitet räknas — dina egna inlägg skapar inga notiser.
 
+### Resultatbanner
+
+När en omgång rättats där du eller någon i dina sällskap hade sparade system visas en banner högst upp på startsidan: **"🏆 Resultaten är rättade"** med varje systems antal rätt (bästa resultatet guldmarkeras). Klicka på ett system för att gå till sällskapets Spel-flik (eller Systemsidan för privata system). Bannern kan döljas med ✕ och visas i upp till en vecka efter speldagen.
+
 ### 7.1 Skapa ett sällskap
 
 1. Gå till sällskapsöversikten via **Profil**-fliken (mobil) eller **profilmenyn → Hantera sällskap** (desktop).
@@ -395,4 +399,4 @@ Sidan visar:
 
 ---
 
-*Manual version 2.5 – V85 Analys*
+*Manual version 2.6 – V85 Analys*

--- a/app/(authenticated)/page.tsx
+++ b/app/(authenticated)/page.tsx
@@ -12,6 +12,8 @@ import { RaceTabProvider } from "@/components/RaceTabContext";
 import { getProfile, getMyGroups } from "@/lib/actions/groups";
 import { getGroupActivity } from "@/lib/actions/activity";
 import { GroupActivitySection } from "@/components/groups/GroupActivitySection";
+import { getLatestGradedOutcome } from "@/lib/actions/outcome";
+import { SystemOutcomeBanner } from "@/components/SystemOutcomeBanner";
 import { getDraftForGame } from "@/lib/actions/systems";
 import { getTrackConfig } from "@/lib/actions/tracks";
 import { redirect } from "next/navigation";
@@ -62,11 +64,12 @@ export default async function HomePage({
   if (!user) redirect("/login");
 
   const params = await searchParams;
-  const [games, profile, userGroups, activity] = await Promise.all([
+  const [games, profile, userGroups, activity, gradedOutcome] = await Promise.all([
     getAllGames(supabase),
     getProfile(),
     getMyGroups(),
     getGroupActivity(),
+    getLatestGradedOutcome(),
   ]);
 
   // Välj spel: URL-param → senaste sparade
@@ -176,6 +179,7 @@ export default async function HomePage({
       </header>
 
       <div className="px-4 lg:px-[5%] xl:px-[8%] py-6">
+        <SystemOutcomeBanner outcome={gradedOutcome} />
         <GroupActivitySection activity={activity} />
 
         <div className="mb-6">

--- a/components/SystemOutcomeBanner.tsx
+++ b/components/SystemOutcomeBanner.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import Link from "next/link";
+import type { GradedOutcome } from "@/lib/actions/outcome";
+
+const DISMISS_KEY_PREFIX = "outcome-dismissed-";
+
+/**
+ * "Resultaten är klara"-banner på startsidan: visar hur användarens och
+ * sällskapets system gick i den senaste rättade omgången. Avfärdas per
+ * omgång (localStorage) och återkommer först vid nästa rättade omgång.
+ */
+export function SystemOutcomeBanner({ outcome }: { outcome: GradedOutcome | null }) {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    if (!outcome) return;
+    try {
+      setVisible(localStorage.getItem(DISMISS_KEY_PREFIX + outcome.game.id) == null);
+    } catch {
+      setVisible(true);
+    }
+  }, [outcome]);
+
+  if (!outcome || !visible) return null;
+
+  function dismiss() {
+    try {
+      localStorage.setItem(DISMISS_KEY_PREFIX + outcome!.game.id, "1");
+    } catch {
+      // localStorage otillgänglig — bannern döljs ändå för sessionen
+    }
+    setVisible(false);
+  }
+
+  const { game, systems, bestScore } = outcome;
+  const shown = systems.slice(0, 5);
+
+  return (
+    <section
+      className="mb-6 rounded-xl overflow-hidden"
+      style={{
+        border: "1px solid color-mix(in oklab, var(--tn-p1) 35%, var(--tn-border))",
+        background: "linear-gradient(180deg, color-mix(in oklab, var(--tn-p1) 7%, var(--tn-bg-card)), var(--tn-bg-card) 70%)",
+      }}
+    >
+      <div className="px-4 pt-3 pb-2 flex items-center gap-2">
+        <span aria-hidden="true">🏆</span>
+        <h2 className="tn-eyebrow flex-1">
+          Resultaten är rättade — {game.game_type} {game.date}
+          {game.track ? ` · ${game.track}` : ""}
+        </h2>
+        <button
+          onClick={dismiss}
+          className="text-sm leading-none"
+          style={{ color: "var(--tn-text-faint)", background: "none", border: "none", cursor: "pointer" }}
+          aria-label="Dölj resultatbannern"
+        >
+          ✕
+        </button>
+      </div>
+      <ul>
+        {shown.map((s) => (
+          <li key={s.id}>
+            <Link
+              href={s.group_id ? `/sallskap/${s.group_id}` : "/system"}
+              className="flex items-center gap-2 px-4 py-2 text-sm transition hover:underline"
+              style={{ borderTop: "1px solid var(--tn-border)" }}
+            >
+              <span
+                className="tn-mono text-xs font-bold px-1.5 py-0.5 rounded shrink-0"
+                style={
+                  s.score === bestScore
+                    ? { background: "var(--tn-p1)", color: "#0a0e14" }
+                    : { background: "var(--tn-bg-chip)", color: "var(--tn-text-dim)" }
+                }
+              >
+                {s.score}/8
+              </span>
+              <span className="min-w-0 flex-1 truncate" style={{ color: "var(--tn-text)" }}>
+                {s.name}
+                <span style={{ color: "var(--tn-text-dim)" }}>
+                  {" — "}
+                  {s.is_own ? "ditt system" : s.author_name}
+                </span>
+              </span>
+              {s.group_name && (
+                <span className="shrink-0 tn-mono text-[10px]" style={{ color: "var(--tn-text-faint)" }}>
+                  {s.group_name}
+                </span>
+              )}
+            </Link>
+          </li>
+        ))}
+      </ul>
+      {systems.length > shown.length && (
+        <p className="px-4 py-2 text-xs" style={{ color: "var(--tn-text-faint)", borderTop: "1px solid var(--tn-border)" }}>
+          + {systems.length - shown.length} system till — se Spel-fliken i sällskapet.
+        </p>
+      )}
+    </section>
+  );
+}

--- a/components/SystemOutcomeBanner.tsx
+++ b/components/SystemOutcomeBanner.tsx
@@ -1,10 +1,14 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useSyncExternalStore, useCallback } from "react";
 import Link from "next/link";
 import type { GradedOutcome } from "@/lib/actions/outcome";
 
 const DISMISS_KEY_PREFIX = "outcome-dismissed-";
+
+// localStorage ändras bara via dismiss-knappen i samma komponent —
+// ingen extern prenumeration behövs
+const emptySubscribe = () => () => {};
 
 /**
  * "Resultaten är klara"-banner på startsidan: visar hur användarens och
@@ -12,26 +16,31 @@ const DISMISS_KEY_PREFIX = "outcome-dismissed-";
  * omgång (localStorage) och återkommer först vid nästa rättade omgång.
  */
 export function SystemOutcomeBanner({ outcome }: { outcome: GradedOutcome | null }) {
-  const [visible, setVisible] = useState(false);
+  const gameId = outcome?.game.id ?? "";
+  // Hydreringssäker localStorage-läsning: servern behandlar bannern som dold,
+  // klienten läser verkligt värde efter hydrering — utan setState i effekt
+  const storedDismissed = useSyncExternalStore(
+    emptySubscribe,
+    useCallback(() => {
+      try {
+        return localStorage.getItem(DISMISS_KEY_PREFIX + gameId) != null;
+      } catch {
+        return false;
+      }
+    }, [gameId]),
+    () => true
+  );
+  const [manuallyDismissed, setManuallyDismissed] = useState(false);
 
-  useEffect(() => {
-    if (!outcome) return;
-    try {
-      setVisible(localStorage.getItem(DISMISS_KEY_PREFIX + outcome.game.id) == null);
-    } catch {
-      setVisible(true);
-    }
-  }, [outcome]);
-
-  if (!outcome || !visible) return null;
+  if (!outcome || storedDismissed || manuallyDismissed) return null;
 
   function dismiss() {
     try {
-      localStorage.setItem(DISMISS_KEY_PREFIX + outcome!.game.id, "1");
+      localStorage.setItem(DISMISS_KEY_PREFIX + gameId, "1");
     } catch {
       // localStorage otillgänglig — bannern döljs ändå för sessionen
     }
-    setVisible(false);
+    setManuallyDismissed(true);
   }
 
   const { game, systems, bestScore } = outcome;

--- a/lib/actions/outcome.ts
+++ b/lib/actions/outcome.ts
@@ -1,0 +1,107 @@
+import { cache } from "react";
+import { createServiceClient } from "@/lib/supabase/server";
+import { getAuthUser } from "@/lib/supabase/guards";
+
+/** Ett rättat system i den senaste avgjorda omgången */
+export interface GradedSystem {
+  id: string;
+  name: string;
+  score: number;
+  total_rows: number;
+  author_name: string;
+  is_own: boolean;
+  group_id: string | null;
+  group_name: string | null;
+}
+
+export interface GradedOutcome {
+  game: { id: string; date: string; track: string | null; game_type: string };
+  systems: GradedSystem[];
+  /** Högsta antal rätt i omgången */
+  bestScore: number;
+}
+
+/** Hur länge efter speldagen utfallet visas på startsidan */
+const OUTCOME_WINDOW_DAYS = 7;
+
+/**
+ * Senaste rättade omgång där användaren eller någon i användarens sällskap
+ * hade sparade system. Driver "Resultaten är klara"-bannern på startsidan —
+ * återbesökskroken efter en speldag. React-cache():ad per request.
+ */
+export const getLatestGradedOutcome = cache(async (): Promise<GradedOutcome | null> => {
+  const user = await getAuthUser();
+  if (!user) return null;
+
+  const db = createServiceClient();
+
+  const { data: memberships } = await db
+    .from("group_members")
+    .select("group_id")
+    .eq("user_id", user.id);
+  const groupIds = (memberships ?? []).map((m) => m.group_id as string);
+
+  // Rättade, färdigspelade system som är mina eller ligger i mina sällskap
+  const orFilter = groupIds.length
+    ? `user_id.eq.${user.id},group_id.in.(${groupIds.join(",")})`
+    : `user_id.eq.${user.id}`;
+
+  const windowStart = new Date(Date.now() - OUTCOME_WINDOW_DAYS * 86_400_000)
+    .toISOString()
+    .slice(0, 10);
+
+  const { data: systems, error } = await db
+    .from("game_systems")
+    .select("id, user_id, group_id, game_id, name, score, total_rows, games(id, date, track, game_type)")
+    .eq("is_graded", true)
+    .eq("is_draft", false)
+    .not("score", "is", null)
+    .or(orFilter);
+  if (error || !systems || systems.length === 0) return null;
+
+  type Row = (typeof systems)[number] & {
+    games: { id: string; date: string; track: string | null; game_type: string } | null;
+  };
+  const rows = (systems as Row[]).filter(
+    (s) => s.games != null && s.games.date >= windowStart
+  );
+  if (rows.length === 0) return null;
+
+  // Senaste speldatumet med rättade system
+  rows.sort((a, b) => (a.games!.date < b.games!.date ? 1 : -1));
+  const game = rows[0].games!;
+  const gameRows = rows.filter((r) => r.games!.id === game.id);
+
+  // Författarnamn + sällskapsnamn
+  const authorIds = Array.from(new Set(gameRows.map((r) => r.user_id as string)));
+  const usedGroupIds = Array.from(
+    new Set(gameRows.map((r) => r.group_id as string | null).filter((g): g is string => g != null))
+  );
+  const [{ data: profiles }, { data: groups }] = await Promise.all([
+    db.from("profiles").select("id, display_name").in("id", authorIds),
+    usedGroupIds.length
+      ? db.from("groups").select("id, name").in("id", usedGroupIds)
+      : Promise.resolve({ data: [] as { id: string; name: string }[] }),
+  ]);
+  const authorName = new Map((profiles ?? []).map((p) => [p.id as string, p.display_name as string | null]));
+  const groupName = new Map((groups ?? []).map((g) => [g.id as string, g.name as string]));
+
+  const graded: GradedSystem[] = gameRows
+    .map((r) => ({
+      id: r.id as string,
+      name: r.name as string,
+      score: r.score as number,
+      total_rows: r.total_rows as number,
+      author_name: authorName.get(r.user_id as string) ?? "Okänd",
+      is_own: r.user_id === user.id,
+      group_id: (r.group_id as string | null) ?? null,
+      group_name: r.group_id ? groupName.get(r.group_id as string) ?? null : null,
+    }))
+    .sort((a, b) => b.score - a.score || (a.is_own ? -1 : 1));
+
+  return {
+    game: { id: game.id, date: game.date, track: game.track, game_type: game.game_type },
+    systems: graded,
+    bestScore: graded[0]?.score ?? 0,
+  };
+});


### PR DESCRIPTION
## Sammanfattning

Implementerar **steg 1 av #75** — resultatdagen som återbesökskrok. När en omgång rättats där användaren eller någon i användarens sällskap hade sparade system visas en banner högst upp på startsidan:

> 🏆 **Resultaten är rättade — V85 2026-06-13 · Solvalla**
> `7/8` Påsk — Kalle · Sällskapet
> `6/8` Lördagsspiken — ditt system

- Varje systems antal rätt visas, **bästa resultatet guldmarkeras** — tävlingsmomentet mellan medlemmarna direkt på startsidan.
- Klick på ett system går till sällskapets Spel-flik (privata system → Systemsidan).
- Avfärdas med ✕ per omgång (localStorage) och visas i max en vecka efter speldagen.
- Egna och sällskapets system hämtas i samma fråga; max 5 visas med "+N till"-rad.

## Teknik

- Ny React-cachad modul `lib/actions/outcome.ts` (`getLatestGradedOutcome`) — samma mönster som aktivitetssignalerna i #80.
- `SystemOutcomeBanner` använder `useSyncExternalStore` för hydreringssäker localStorage-läsning utan setState-i-effekt (inga nya lintfel).
- Inga databasändringar — bygger helt på befintliga `game_systems.score`/`is_graded`.
- Verifierat mot produktionsdatan: rättade system med score finns (t.ex. 7/8 från 5 april); bannern aktiveras vid nästa rättade omgång inom 7-dagarsfönstret.

## Kvar i #75 (stängs inte av denna PR)

Steg 2 (PWA-pushnotis) och steg 3 (e-post) kräver VAPID-nycklar, prenumerationstabell och utskickslogik — tas separat.

## Test
- `npx jest`: 70 tester gröna, `tsc --noEmit` rent, lint oförändrat (3 förexisterande)
- MANUAL.md uppdaterad (v2.6) med avsnitt om resultatbannern

Del 1 av #75.

https://claude.ai/code/session_016r3SKaqgmEtHD64UfAaQ3H

---
_Generated by [Claude Code](https://claude.ai/code/session_016r3SKaqgmEtHD64UfAaQ3H)_