### PR TITLE
Sällskapsligan: topplista över medlemmarnas systemträffar

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,8 +98,9 @@ components/
     admin/AdminTab.tsx      # Inställningar (namn, ATG-lag, inbjudan, medlemmar)
     forum/ForumTab.tsx      # Omgångsbundet diskussionsforum
     notes/NotesTab.tsx      # Anteckningar per omgång i sällskapet
-    spel/SpelTab.tsx        # Sällskapets system (rättade mot resultat) + insatser
+    spel/SpelTab.tsx        # Sällskapets system (rättade mot resultat) + liga + insatser
     spel/SystemCard.tsx     # Systemkort med score/8 och vinnarmarkeringar
+    spel/LeagueTable.tsx    # Sällskapsligan: topplista över systemträffar per medlem
     spel/BetsSection.tsx    # Insatser per omgång + ROI per medlem
   groups/
     SallskapOverview.tsx    # /sallskap-sidans innehåll (sällskapslista, skapa/gå med, profil, logga ut)

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -306,6 +306,7 @@ Inne i ett sällskap finns fyra flikar:
 **Spel**
 - Visar sällskapets sparade system och utkast för vald omgång.
 - När resultat hämtats rättas systemen automatiskt — antal rätt visas som t.ex. **6/8** och vinnande hästar markeras gröna.
+- **Sällskapsligan** — topplista över medlemmarnas systemträffar i alla rättade omgångar: antal omgångar, totala rätt, snitt och bästa omgång. Har du flera system i samma omgång räknas det bästa. 👑 markerar vem som vann den senast rättade omgången.
 - Under **Insatser** registrerar du dina spel (speltyp, eventuell avdelning/häst och insats i kronor). När omgången är avgjord fyller du i utdelningen på dina egna insatser.
 - **ROI per medlem** visar varje medlems totala insats, utdelning och avkastning över alla omgångar.
 
@@ -399,4 +400,4 @@ Sidan visar:
 
 ---
 
-*Manual version 2.6 – V85 Analys*
+*Manual version 2.7 – V85 Analys*

--- a/app/(authenticated)/sallskap/[groupId]/SallskapPageClient.tsx
+++ b/app/(authenticated)/sallskap/[groupId]/SallskapPageClient.tsx
@@ -9,6 +9,7 @@ import { NotesTab } from "@/components/sallskap/notes/NotesTab";
 import { AdminTab } from "@/components/sallskap/admin/AdminTab";
 import type { Group, GroupMember, GroupPost, GameSystem } from "@/lib/types";
 import type { RaceWithNotes } from "@/lib/actions/notes";
+import type { GroupLeague } from "@/lib/actions/systems";
 import { SpelTab } from "@/components/sallskap/spel/SpelTab";
 
 type Game = { id: string; date: string; track: string | null; game_type?: string };
@@ -20,6 +21,7 @@ interface SallskapPageClientProps {
   initialPosts: GroupPost[];
   initialNotes: RaceWithNotes[];
   initialSystems: GameSystem[];
+  league: GroupLeague;
   defaultGameId: string | null;
   currentUserId: string;
 }
@@ -31,6 +33,7 @@ export function SallskapPageClient({
   initialPosts,
   initialNotes,
   initialSystems,
+  league,
   defaultGameId,
   currentUserId,
 }: SallskapPageClientProps) {
@@ -80,6 +83,7 @@ export function SallskapPageClient({
             games={games}
             initialGameId={defaultGameId}
             initialSystems={initialSystems}
+            league={league}
             currentUserId={currentUserId}
           />
         </div>

--- a/app/(authenticated)/sallskap/[groupId]/page.tsx
+++ b/app/(authenticated)/sallskap/[groupId]/page.tsx
@@ -5,7 +5,7 @@ import { getGroupMembers } from "@/lib/actions/sallskap";
 import { markGroupSeen } from "@/lib/actions/activity";
 import { getGroupPosts } from "@/lib/actions/posts";
 import { getGroupNotesForGame } from "@/lib/actions/notes";
-import { getGroupSystems } from "@/lib/actions/systems";
+import { getGroupSystems, getGroupLeague } from "@/lib/actions/systems";
 import { SallskapPageClient } from "./SallskapPageClient";
 
 interface Props {
@@ -51,10 +51,11 @@ export default async function SallskapPage({ params }: Props) {
 
   const defaultGameId = games[0]?.id ?? null;
 
-  const [initialPosts, initialNotes, initialSystems] = await Promise.all([
+  const [initialPosts, initialNotes, initialSystems, league] = await Promise.all([
     defaultGameId ? getGroupPosts(groupId, defaultGameId) : Promise.resolve([]),
     defaultGameId ? getGroupNotesForGame(groupId, defaultGameId) : Promise.resolve([]),
     defaultGameId ? getGroupSystems(groupId, defaultGameId) : Promise.resolve([]),
+    getGroupLeague(groupId),
   ]);
 
   return (
@@ -65,6 +66,7 @@ export default async function SallskapPage({ params }: Props) {
       initialPosts={initialPosts}
       initialNotes={initialNotes}
       initialSystems={initialSystems}
+      league={league}
       defaultGameId={defaultGameId}
       currentUserId={user.id}
     />

--- a/components/sallskap/spel/LeagueTable.tsx
+++ b/components/sallskap/spel/LeagueTable.tsx
@@ -1,0 +1,77 @@
+'use client'
+
+import type { GroupLeague } from '@/lib/actions/systems'
+
+/**
+ * Sällskapsligan — topplista över medlemmarnas systemträffar i rättade
+ * omgångar. Bästa systemet per medlem och omgång räknas; 👑 markerar vem
+ * som vann den senast rättade omgången.
+ */
+export function LeagueTable({ league }: { league: GroupLeague }) {
+  if (league.rows.length === 0) return null
+
+  return (
+    <section className="mt-8">
+      <h2
+        className="text-sm font-semibold uppercase tracking-wide mb-1 tn-eyebrow"
+        style={{ color: 'var(--tn-text-dim)' }}
+      >
+        Sällskapsligan
+      </h2>
+      {league.last_round_date && (
+        <p className="text-xs mb-3" style={{ color: 'var(--tn-text-faint)' }}>
+          Bästa systemet per medlem och omgång räknas · senast rättad {league.last_round_date}
+        </p>
+      )}
+      <div
+        className="rounded-xl overflow-hidden"
+        style={{ background: 'var(--tn-bg-card)', border: '1px solid var(--tn-border)' }}
+      >
+        <table className="w-full text-sm">
+          <thead>
+            <tr style={{ borderBottom: '1px solid var(--tn-border)' }}>
+              <th className="text-left px-3 py-2 tn-eyebrow font-normal">#</th>
+              <th className="text-left px-3 py-2 tn-eyebrow font-normal">Medlem</th>
+              <th className="text-right px-3 py-2 tn-eyebrow font-normal">Omg.</th>
+              <th className="text-right px-3 py-2 tn-eyebrow font-normal">Rätt</th>
+              <th className="text-right px-3 py-2 tn-eyebrow font-normal">Snitt</th>
+              <th className="text-right px-3 py-2 tn-eyebrow font-normal">Bäst</th>
+            </tr>
+          </thead>
+          <tbody>
+            {league.rows.map((row, i) => (
+              <tr key={row.user_id} style={{ borderTop: i > 0 ? '1px solid var(--tn-border)' : 'none' }}>
+                <td
+                  className="px-3 py-2 tn-mono text-xs"
+                  style={{ color: i === 0 ? 'var(--tn-p1)' : 'var(--tn-text-faint)' }}
+                >
+                  {i + 1}
+                </td>
+                <td className="px-3 py-2 font-medium" style={{ color: 'var(--tn-text)' }}>
+                  {row.display_name}
+                  {row.is_last_round_winner && (
+                    <span className="ml-1.5" title="Vann senast rättade omgången" aria-label="Vann senast rättade omgången">
+                      👑
+                    </span>
+                  )}
+                </td>
+                <td className="px-3 py-2 text-right tn-mono" style={{ color: 'var(--tn-text-dim)' }}>
+                  {row.rounds}
+                </td>
+                <td className="px-3 py-2 text-right tn-mono font-semibold" style={{ color: 'var(--tn-text)' }}>
+                  {row.total_score}
+                </td>
+                <td className="px-3 py-2 text-right tn-mono" style={{ color: 'var(--tn-text-dim)' }}>
+                  {row.avg_score.toFixed(1).replace('.', ',')}
+                </td>
+                <td className="px-3 py-2 text-right tn-mono" style={{ color: 'var(--tn-text-dim)' }}>
+                  {row.best_score}/8
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  )
+}

--- a/components/sallskap/spel/SpelTab.tsx
+++ b/components/sallskap/spel/SpelTab.tsx
@@ -4,7 +4,8 @@ import { useState, useEffect } from 'react'
 import Link from 'next/link'
 import { SystemCard } from './SystemCard'
 import { BetsSection } from './BetsSection'
-import { getGroupSystems, getWinnersForGame } from '@/lib/actions/systems'
+import { LeagueTable } from './LeagueTable'
+import { getGroupSystems, getWinnersForGame, type GroupLeague } from '@/lib/actions/systems'
 import type { GameSystem } from '@/lib/types'
 
 type Game = { id: string; date: string; track: string | null; game_type?: string }
@@ -14,10 +15,11 @@ interface SpelTabProps {
   games: Game[]
   initialGameId: string | null
   initialSystems: GameSystem[]
+  league: GroupLeague
   currentUserId: string
 }
 
-export function SpelTab({ groupId, games, initialGameId, initialSystems, currentUserId }: SpelTabProps) {
+export function SpelTab({ groupId, games, initialGameId, initialSystems, league, currentUserId }: SpelTabProps) {
   const [selectedGameId, setSelectedGameId] = useState<string | null>(initialGameId)
   const [systems, setSystems] = useState<GameSystem[]>(initialSystems)
   const [loading, setLoading] = useState(false)
@@ -175,6 +177,8 @@ export function SpelTab({ groupId, games, initialGameId, initialSystems, current
           )}
         </div>
       )}
+
+      <LeagueTable league={league} />
 
       <BetsSection groupId={groupId} gameId={selectedGameId} currentUserId={currentUserId} />
     </div>

--- a/lib/actions/systems.ts
+++ b/lib/actions/systems.ts
@@ -237,3 +237,97 @@ export async function getWinnersForGame(
   }
   return result
 }
+
+/** En medlems rad i sällskapsligan */
+export interface LeagueRow {
+  user_id: string
+  display_name: string
+  /** Antal rättade omgångar medlemmen hade system i */
+  rounds: number
+  /** Summa av bästa systemets rätt per omgång */
+  total_score: number
+  /** Snitträtt per omgång (en decimal) */
+  avg_score: number
+  /** Bästa enskilda omgång */
+  best_score: number
+  /** Bäst i sällskapet i den senast rättade omgången */
+  is_last_round_winner: boolean
+}
+
+export interface GroupLeague {
+  rows: LeagueRow[]
+  /** Speldatum för den senast rättade omgången som ingår */
+  last_round_date: string | null
+}
+
+/**
+ * Sällskapsligan: medlemmarnas systemträffar över alla rättade omgångar.
+ * Har en medlem flera system i samma omgång räknas det bästa — ligan mäter
+ * tävlingen, inte volymen. RLS begränsar till sällskapets medlemmar.
+ */
+export async function getGroupLeague(groupId: string): Promise<GroupLeague> {
+  const supabase = await createClient()
+  const { data, error } = await supabase
+    .from('game_systems')
+    .select('user_id, game_id, score, games(date)')
+    .eq('group_id', groupId)
+    .eq('is_graded', true)
+    .eq('is_draft', false)
+    .not('score', 'is', null)
+
+  if (error) throw error
+
+  type Row = { user_id: string; game_id: string; score: number; games: { date: string } | null }
+  const rows = (data ?? []) as unknown as Row[]
+  if (rows.length === 0) return { rows: [], last_round_date: null }
+
+  // Bästa systemet per medlem och omgång
+  const bestPerUserGame = new Map<string, { user_id: string; game_id: string; score: number; date: string }>()
+  for (const r of rows) {
+    const key = `${r.user_id}|${r.game_id}`
+    const existing = bestPerUserGame.get(key)
+    if (!existing || r.score > existing.score) {
+      bestPerUserGame.set(key, {
+        user_id: r.user_id,
+        game_id: r.game_id,
+        score: r.score,
+        date: r.games?.date ?? '',
+      })
+    }
+  }
+  const entries = [...bestPerUserGame.values()]
+
+  // Senast rättade omgången + dess vinnar-score
+  const lastRoundDate = entries.reduce((max, e) => (e.date > max ? e.date : max), '')
+  const lastRoundEntries = entries.filter((e) => e.date === lastRoundDate)
+  const lastRoundBest = Math.max(...lastRoundEntries.map((e) => e.score))
+  const lastRoundWinners = new Set(
+    lastRoundEntries.filter((e) => e.score === lastRoundBest).map((e) => e.user_id)
+  )
+
+  // Aggregera per medlem
+  const byUser = new Map<string, { rounds: number; total: number; best: number }>()
+  for (const e of entries) {
+    const agg = byUser.get(e.user_id) ?? { rounds: 0, total: 0, best: 0 }
+    agg.rounds += 1
+    agg.total += e.score
+    agg.best = Math.max(agg.best, e.score)
+    byUser.set(e.user_id, agg)
+  }
+
+  const names = await fetchDisplayNames(supabase, [...byUser.keys()])
+
+  const leagueRows: LeagueRow[] = [...byUser.entries()]
+    .map(([user_id, agg]) => ({
+      user_id,
+      display_name: names.get(user_id) ?? 'Okänd',
+      rounds: agg.rounds,
+      total_score: agg.total,
+      avg_score: Math.round((agg.total / agg.rounds) * 10) / 10,
+      best_score: agg.best,
+      is_last_round_winner: lastRoundWinners.has(user_id),
+    }))
+    .sort((a, b) => b.total_score - a.total_score || b.avg_score - a.avg_score)
+
+  return { rows: leagueRows, last_round_date: lastRoundDate || null }
+}


### PR DESCRIPTION
## Sammanfattning

Implementerar #76 — **sällskapsligan**, säsongstopplistan som gör V85-lördagen till en stående tävling mellan medlemmarna.

Ny sektion i sällskapets **Spel-flik** (mellan systemen och insatserna):

| # | Medlem | Omg. | Rätt | Snitt | Bäst |
|---|--------|------|------|-------|------|
| 1 | Rikard 👑 | 4 | 23 | 5,8 | 7/8 |

- **Bästa systemet per medlem och omgång räknas** — ligan mäter tävlingen, inte hur många system man sparar.
- **👑 markerar veckans vinnare** (bäst i den senast rättade omgången).
- Ligaledaren får guldfärgad placeringssiffra.
- Sorteras på totala rätt, med snitt som tiebreak.

## Teknik

- `getGroupLeague(groupId)` i `lib/actions/systems.ts` — RLS-policyn sköter medlemsfiltreringen, ingen ny serverlogik utanför befintligt mönster.
- Data hämtas server-side på sällskapssidan och skickas genom `SallskapPageClient` → `SpelTab` → `LeagueTable`.
- Inga databasändringar — bygger helt på `game_systems.score`/`is_graded`.
- Aggregeringen verifierad mot produktionsdatan (SQL-emulering gav identiskt resultat: 4 omgångar, 23 rätt, snitt 5,8, bäst 7/8).

## Test
- `npx jest`: 70 tester gröna, `tsc --noEmit` rent, lint oförändrat (3 förexisterande)
- MANUAL.md uppdaterad (v2.7) med ligabeskrivning under Spel-fliken

Closes #76.

https://claude.ai/code/session_016r3SKaqgmEtHD64UfAaQ3H

---
_Generated by [Claude Code](https://claude.ai/code/session_016r3SKaqgmEtHD64UfAaQ3H)_