### PR TITLE
Koppla socialt till loppvyn: anteckningsbubbla på hästkortet + forumlänk

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,8 +129,8 @@ lib/
     bets.ts                 # Server actions: spelförslag/bets
     games.ts                # Server actions: spel
     groups.ts               # Server actions: skapa/lämna sällskap
-    notes.ts                # Server actions: hämta/skapa/ta bort anteckningar
-    posts.ts                # Server actions: foruminlägg
+    notes.ts                # Server actions: anteckningar + getNoteCountsForHorses (pratbubbla i loppvyn)
+    posts.ts                # Server actions: foruminlägg + getGamePostSummary (forumlänk i loppvyn)
     sallskap.ts             # Server actions: sällskapsdata
     systems.ts              # Server actions: spelsystem (game_systems, drafts)
     tracks.ts               # Server actions: bandata/TrackConfig

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -74,6 +74,7 @@ På huvudsidan ser du en lista med alla hämtade omgångar.
 - Välj omgång via **rullgardinsmenyn** (GameSelector) längst upp.
 - Omgångens **avdelningar** visas som klickbara flikar. Klicka på en avdelning för att visa den – bytet sker direkt utan sidladdning.
 - Hästar i aktiv avdelning visas som **en häst per rad** (ATG-stil).
+- Pågår en diskussion om omgången i något av dina sällskap visas **💬 N inlägg om omgången** i informationsraden — klicka för att gå direkt till sällskapets forum för rätt omgång.
 
 ### 4.1 Top 5 – högst Composite Score
 
@@ -119,6 +120,7 @@ När en avdelning är expanderad visas ett kort per häst. Den kompakta raden in
 | **Nr** | Startnummer |
 | **Namn** | Hästens namn — en orange prick (●) intill namnet betyder skoändring inför loppet |
 | **SKRÄLL-märke** | Visas om hästen är skrällkandidat (se 6.1); håll muspekaren över för förklaring |
+| **💬 Anteckningsbubbla** | Antal anteckningar på hästen (även från tidigare omgångar) — expandera kortet och öppna **Anteckningar** för att läsa dem |
 | **Kusk** | Kuskens namn |
 | **Streck%** | Hästens andel av spelpoolen (om tillgängligt) |
 | **Odds** | Aktuellt vinnarodds |
@@ -400,4 +402,4 @@ Sidan visar:
 
 ---
 
-*Manual version 2.7 – V85 Analys*
+*Manual version 2.8 – V85 Analys*

--- a/app/(authenticated)/page.tsx
+++ b/app/(authenticated)/page.tsx
@@ -15,8 +15,11 @@ import { GroupActivitySection } from "@/components/groups/GroupActivitySection";
 import { getLatestGradedOutcome } from "@/lib/actions/outcome";
 import { SystemOutcomeBanner } from "@/components/SystemOutcomeBanner";
 import { getDraftForGame } from "@/lib/actions/systems";
+import { getNoteCountsForHorses } from "@/lib/actions/notes";
+import { getGamePostSummary } from "@/lib/actions/posts";
 import { getTrackConfig } from "@/lib/actions/tracks";
 import { redirect } from "next/navigation";
+import Link from "next/link";
 import { Suspense } from "react";
 import type { SystemSelection, TrackConfig } from "@/lib/types";
 
@@ -80,9 +83,15 @@ export default async function HomePage({
   const selectedGame = games.find((g) => g.id === selectedId) ?? null;
   const races = selectedId ? await getRaces(supabase, selectedId) : [];
 
-  const trackConfig: TrackConfig | null = selectedGame
-    ? await getTrackConfig(selectedGame.track)
-    : null;
+  // Socialt i loppvyn: anteckningsantal per häst + forumdiskussion om omgången
+  const horseIds = Array.from(
+    new Set(races.flatMap((r) => (r.starters ?? []).map((s: { horse_id: string }) => s.horse_id)))
+  );
+  const [noteCounts, postSummary, trackConfig] = await Promise.all([
+    horseIds.length ? getNoteCountsForHorses(horseIds) : Promise.resolve({}),
+    selectedId ? getGamePostSummary(selectedId) : Promise.resolve(null),
+    selectedGame ? getTrackConfig(selectedGame.track) : Promise.resolve(null),
+  ]) as [Record<string, number>, Awaited<ReturnType<typeof getGamePostSummary>>, TrackConfig | null];
 
   const initialSystemMode = params.systemMode === '1'
   const initialGroupId = params.groupId ?? null
@@ -166,6 +175,15 @@ export default async function HomePage({
             <span style={{ color: "var(--tn-accent)", fontWeight: 600 }}>{selectedGame.game_type}</span>
             <span style={{ color: "var(--tn-border-strong)" }}>·</span>
             <span>{selectedGame.track}</span>
+            {postSummary && selectedId && (
+              <Link
+                href={`/sallskap/${postSummary.group_id}?game=${selectedId}`}
+                className="ml-auto flex items-center gap-1 transition"
+                style={{ color: "var(--tn-accent)" }}
+              >
+                💬 {postSummary.count} inlägg om omgången →
+              </Link>
+            )}
           </div>
         )}
 
@@ -200,6 +218,7 @@ export default async function HomePage({
           draftId={draftId}
           initialSelections={initialSelections}
           trackConfig={trackConfig}
+          noteCounts={noteCounts}
         />
       </div>
     </main>

--- a/app/(authenticated)/sallskap/[groupId]/page.tsx
+++ b/app/(authenticated)/sallskap/[groupId]/page.tsx
@@ -10,6 +10,7 @@ import { SallskapPageClient } from "./SallskapPageClient";
 
 interface Props {
   params: Promise<{ groupId: string }>;
+  searchParams: Promise<{ game?: string }>;
 }
 
 async function getAllGames(supabase: Awaited<ReturnType<typeof createClient>>) {
@@ -20,8 +21,9 @@ async function getAllGames(supabase: Awaited<ReturnType<typeof createClient>>) {
   return data ?? [];
 }
 
-export default async function SallskapPage({ params }: Props) {
+export default async function SallskapPage({ params, searchParams }: Props) {
   const { groupId } = await params;
+  const { game: gameParam } = await searchParams;
 
   const supabase = await createClient();
   const { data: { user } } = await supabase.auth.getUser();
@@ -49,7 +51,9 @@ export default async function SallskapPage({ params }: Props) {
 
   if (!group) redirect("/");
 
-  const defaultGameId = games[0]?.id ?? null;
+  // Djuplänk från loppvyn (?game=) väljer rätt omgång, annars senaste
+  const defaultGameId =
+    (gameParam && games.find((g) => g.id === gameParam)?.id) ?? games[0]?.id ?? null;
 
   const [initialPosts, initialNotes, initialSystems, league] = await Promise.all([
     defaultGameId ? getGroupPosts(groupId, defaultGameId) : Promise.resolve([]),

--- a/components/HorseCard.tsx
+++ b/components/HorseCard.tsx
@@ -290,6 +290,7 @@ export function HorseCard({
   raceStartMethod,
   isValue,
   skrall,
+  noteCount = 0,
   sortRank,
   isSelected,
   onSelect,
@@ -302,6 +303,7 @@ export function HorseCard({
   raceStartMethod?: string;
   isValue?: boolean;
   skrall?: SkrallSignal;
+  noteCount?: number;
   sortRank?: number;
   isSelected?: boolean;
   onSelect?: () => void;
@@ -449,6 +451,19 @@ export function HorseCard({
                 title={`Skrällkandidat: odds säger ${skrall.oddsProbPct?.toFixed(1)} % chans mot ${starter.bet_distribution?.toFixed(1)} % streck, klass ${skrall.classRank} av fältet`}
               >
                 SKRÄLL
+              </span>
+            )}
+            {noteCount > 0 && (
+              <span
+                className="inline-flex items-center gap-0.5 text-[10px] font-semibold px-1 py-0.5 rounded shrink-0"
+                style={{ background: "var(--tn-accent-faint)", color: "var(--tn-accent)" }}
+                title={`${noteCount} anteckning${noteCount === 1 ? "" : "ar"} på hästen (även från tidigare omgångar)`}
+                aria-label={`${noteCount} anteckningar på hästen`}
+              >
+                <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                  <path d="M21 11.5a8.38 8.38 0 0 1-8.5 8.5 8.5 8.5 0 0 1-3.8-.9L3 21l1.9-5.7A8.38 8.38 0 0 1 4 11.5 8.5 8.5 0 0 1 12.5 3 8.38 8.38 0 0 1 21 11.5z" />
+                </svg>
+                {noteCount}
               </span>
             )}
           </div>

--- a/components/MainPageClient.tsx
+++ b/components/MainPageClient.tsx
@@ -28,6 +28,8 @@ interface MainPageClientProps {
   draftId?: string | null
   initialSelections?: SystemSelection[]
   trackConfig?: TrackConfig | null
+  /** Antal anteckningar per häst-id — pratbubbla på hästkortet */
+  noteCounts?: Record<string, number>
 }
 
 export function MainPageClient({
@@ -41,6 +43,7 @@ export function MainPageClient({
   draftId = null,
   initialSelections = [],
   trackConfig = null,
+  noteCounts = {},
 }: MainPageClientProps) {
   const [systemMode, setSystemMode] = useState(initialSystemMode)
   const { activeRaceNumber: activeRace, setActiveRaceNumber: setActiveRace } = useRaceTab()
@@ -177,6 +180,7 @@ export function MainPageClient({
             onToggleHorse={handleToggleHorse}
             onHorseClick={handleHorseClick}
             trackConfig={trackConfig}
+            noteCounts={noteCounts}
           />
         )}
       </div>

--- a/components/RaceList.tsx
+++ b/components/RaceList.tsx
@@ -83,6 +83,7 @@ export function RaceList({
   onToggleHorse,
   onHorseClick,
   trackConfig,
+  noteCounts = {},
 }: {
   races: Race[];
   activeRaceNumber: number;
@@ -93,6 +94,7 @@ export function RaceList({
   onToggleHorse?: (raceNumber: number, horse: SystemHorse) => void;
   onHorseClick?: (raceNumber: number, startNumber: number) => void;
   trackConfig?: TrackConfig | null;
+  noteCounts?: Record<string, number>;
 }) {
   const [showAnalysis, setShowAnalysis] = useState(false);
   const [sortKey, setSortKey] = useState<SortKey>("composite");
@@ -314,6 +316,7 @@ export function RaceList({
               raceStartMethod={activeRace.start_method ?? "auto"}
               isValue={valueMap[s.start_number] ?? false}
               skrall={skrallMap[s.start_number]}
+              noteCount={noteCounts[s.horse_id] ?? 0}
               sortRank={sortKey !== "number" ? idx + 1 : undefined}
               trackConfig={trackConfig ?? undefined}
               isSelected={systemMode ? (raceSelections?.horses.some((h) => h.horse_id === s.horse_id) ?? false) : undefined}

--- a/lib/actions/notes.ts
+++ b/lib/actions/notes.ts
@@ -228,3 +228,29 @@ export async function deleteNote(noteId: string): Promise<{ error: string | null
   if (error) return { error: error.message };
   return { error: null };
 }
+
+/**
+ * Antal anteckningar (inkl. svar) per häst som användaren får se, för en lista
+ * av häst-id:n. Driver pratbubblan på hästkortet i loppvyn — anteckningar
+ * följer hästen mellan omgångar, så siffran signalerar "här finns historik".
+ * RLS filtrerar till sällskaps- och egna personliga anteckningar.
+ */
+export async function getNoteCountsForHorses(
+  horseIds: string[]
+): Promise<Record<string, number>> {
+  if (horseIds.length === 0) return {};
+  const supabase = await createClient();
+
+  const { data, error } = await supabase
+    .from("horse_notes")
+    .select("horse_id")
+    .in("horse_id", horseIds);
+
+  if (error || !data) return {};
+
+  const counts: Record<string, number> = {};
+  for (const row of data as { horse_id: string }[]) {
+    counts[row.horse_id] = (counts[row.horse_id] ?? 0) + 1;
+  }
+  return counts;
+}

--- a/lib/actions/posts.ts
+++ b/lib/actions/posts.ts
@@ -122,3 +122,39 @@ export async function deletePost(postId: string): Promise<{ error: string | null
   if (error) return { error: error.message };
   return { error: null };
 }
+
+export interface GamePostSummary {
+  group_id: string;
+  group_name: string;
+  count: number;
+}
+
+/**
+ * Sammanfattning av forumdiskussionen om en omgång för länken i loppvyn.
+ * Returnerar det av användarens sällskap som har flest inlägg om omgången
+ * (RLS begränsar till sällskap användaren är medlem i), eller null om inga
+ * inlägg finns. Driver "💬 N inlägg om omgången"-länken på startsidan.
+ */
+export async function getGamePostSummary(gameId: string): Promise<GamePostSummary | null> {
+  const supabase = await createClient();
+
+  const { data, error } = await supabase
+    .from("group_posts")
+    .select("group_id, groups(name)")
+    .eq("game_id", gameId);
+
+  if (error || !data || data.length === 0) return null;
+
+  const counts = new Map<string, { name: string; count: number }>();
+  for (const row of data as unknown as { group_id: string; groups: { name: string } | null }[]) {
+    const entry = counts.get(row.group_id) ?? { name: row.groups?.name ?? "Sällskap", count: 0 };
+    entry.count += 1;
+    counts.set(row.group_id, entry);
+  }
+
+  let best: GamePostSummary | null = null;
+  for (const [group_id, { name, count }] of counts) {
+    if (!best || count > best.count) best = { group_id, group_name: name, count };
+  }
+  return best;
+}


### PR DESCRIPTION
## Sammanfattning

Implementerar #77 — knyter ihop det sociala med loppvyn där analysen faktiskt sker, så att anteckningar och diskussioner blir synliga i stället för instängda i sällskapsflikarna.

## Anteckningsbubbla på hästkortet

En liten **💬-bubbla med antal anteckningar** visas direkt på hästkortets kompakta rad (tidigare syntes anteckningar först efter att man expanderat kortet *och* öppnat anteckningssektionen). Eftersom anteckningar sitter på hästen och följer med mellan omgångar signalerar siffran "den här hästen finns det historik och åsikter om" — t.ex. *"4 anteckningar"* på en häst ni bevakat tidigare.

- `getNoteCountsForHorses()` batch-hämtar antal för alla hästar i omgången i en fråga (page.tsx), skickas genom MainPageClient → RaceList → HorseCard.
- RLS filtrerar till sällskaps- och egna personliga anteckningar.

## "💬 N inlägg om omgången"-länk

I spelinformationsraden visas en länk när något av användarens sällskap diskuterar den aktuella omgången — så att man ser att en diskussion pågår utan att leta. Klick går direkt till rätt sällskaps forum med **rätt omgång förvald** (SallskapPage läser nu `?game=`).

- `getGamePostSummary()` returnerar det sällskap som har flest inlägg om omgången (RLS begränsar till användarens sällskap).

## Övrigt

- Inga databasändringar — bygger på befintliga `horse_notes` och `group_posts` med deras RLS.
- Verifierat mot produktionsdatan: 5 hästar har anteckningar (en med 4), 5 omgångar har forumdiskussion — båda funktionerna visar verkligt innehåll.

## Test
- `npx jest`: 70 tester gröna, `tsc --noEmit` rent, lint oförändrat (3 förexisterande)
- MANUAL.md uppdaterad (v2.8)

Closes #77.

https://claude.ai/code/session_016r3SKaqgmEtHD64UfAaQ3H

---
_Generated by [Claude Code](https://claude.ai/code/session_016r3SKaqgmEtHD64UfAaQ3H)_