### PR TITLE
Insatser: koppla till sparade system (ett klick "Jag spelade detta")

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,7 +126,7 @@ lib/
   actions/
     activity.ts             # Aktivitetssignaler: getGroupActivity (React-cachad) + markGroupSeen
     outcome.ts              # Senaste rättade omgångens systemutfall (resultatbannern)
-    bets.ts                 # Server actions: spelförslag/bets
+    bets.ts                 # Server actions: insatser/ROI + addBetFromSystem (logga sparat system som spel)
     games.ts                # Server actions: spel
     groups.ts               # Server actions: skapa/lämna sällskap
     notes.ts                # Server actions: anteckningar + getNoteCountsForHorses (pratbubbla i loppvyn)
@@ -153,7 +153,7 @@ supabase/
 **group_members** – koppling användare↔sällskap
 **horse_notes** – anteckningar (horse_id, group_id nullable, label, parent_id)
 **group_posts** – foruminlägg (group_id, game_id, parent_id)
-**bets** – spelförslag per omgång (game_id, user_id, horse selections)
+**bets** – insatser per omgång (game_id, user_id, stake, payout, system_id nullable → koppling till spelat system)
 **game_systems** – sparade spelsystem (name, game_id, selections)
 **drafts** – utkast till spelsystem
 **track_configs** – banspecifik konfiguration (open_stretch, short_race_threshold)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,8 +129,8 @@ lib/
     bets.ts                 # Server actions: spelförslag/bets
     games.ts                # Server actions: spel
     groups.ts               # Server actions: skapa/lämna sällskap
-    notes.ts                # Server actions: hämta/skapa/ta bort anteckningar
-    posts.ts                # Server actions: foruminlägg
+    notes.ts                # Server actions: anteckningar + getNoteCountsForHorses (pratbubbla i loppvyn)
+    posts.ts                # Server actions: foruminlägg + getGamePostSummary (forumlänk i loppvyn)
     sallskap.ts             # Server actions: sällskapsdata
     systems.ts              # Server actions: spelsystem (game_systems, drafts)
     tracks.ts               # Server actions: bandata/TrackConfig

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -309,7 +309,7 @@ Inne i ett sällskap finns fyra flikar:
 - Visar sällskapets sparade system och utkast för vald omgång.
 - När resultat hämtats rättas systemen automatiskt — antal rätt visas som t.ex. **6/8** och vinnande hästar markeras gröna.
 - **Sällskapsligan** — topplista över medlemmarnas systemträffar i alla rättade omgångar: antal omgångar, totala rätt, snitt och bästa omgång. Har du flera system i samma omgång räknas det bästa. 👑 markerar vem som vann den senast rättade omgången.
-- Under **Insatser** registrerar du dina spel (speltyp, eventuell avdelning/häst och insats i kronor). När omgången är avgjord fyller du i utdelningen på dina egna insatser.
+- Under **Insatser** registrerar du dina spel. Enklast: klicka **Jag spelade detta** på ett systemkort — insatsen (rader × radpris) fylls i automatiskt och kopplas till systemet, så att insatsraden visar systemets träff (t.ex. 6/8). Du kan även lägga till spel manuellt (speltyp, eventuell avdelning/häst och insats i kronor). När omgången är avgjord fyller du i utdelningen på dina egna insatser.
 - **ROI per medlem** visar varje medlems totala insats, utdelning och avkastning över alla omgångar.
 
 **Sällskap**
@@ -402,4 +402,4 @@ Sidan visar:
 
 ---
 
-*Manual version 2.8 – V85 Analys*
+*Manual version 2.9 – V85 Analys*

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -74,6 +74,7 @@ På huvudsidan ser du en lista med alla hämtade omgångar.
 - Välj omgång via **rullgardinsmenyn** (GameSelector) längst upp.
 - Omgångens **avdelningar** visas som klickbara flikar. Klicka på en avdelning för att visa den – bytet sker direkt utan sidladdning.
 - Hästar i aktiv avdelning visas som **en häst per rad** (ATG-stil).
+- Pågår en diskussion om omgången i något av dina sällskap visas **💬 N inlägg om omgången** i informationsraden — klicka för att gå direkt till sällskapets forum för rätt omgång.
 
 ### 4.1 Top 5 – högst Composite Score
 
@@ -119,6 +120,7 @@ När en avdelning är expanderad visas ett kort per häst. Den kompakta raden in
 | **Nr** | Startnummer |
 | **Namn** | Hästens namn — en orange prick (●) intill namnet betyder skoändring inför loppet |
 | **SKRÄLL-märke** | Visas om hästen är skrällkandidat (se 6.1); håll muspekaren över för förklaring |
+| **💬 Anteckningsbubbla** | Antal anteckningar på hästen (även från tidigare omgångar) — expandera kortet och öppna **Anteckningar** för att läsa dem |
 | **Kusk** | Kuskens namn |
 | **Streck%** | Hästens andel av spelpoolen (om tillgängligt) |
 | **Odds** | Aktuellt vinnarodds |
@@ -400,4 +402,4 @@ Sidan visar:
 
 ---
 
-*Manual version 2.7 – V85 Analys*
+*Manual version 2.8 – V85 Analys*

--- a/app/(authenticated)/page.tsx
+++ b/app/(authenticated)/page.tsx
@@ -15,8 +15,11 @@ import { GroupActivitySection } from "@/components/groups/GroupActivitySection";
 import { getLatestGradedOutcome } from "@/lib/actions/outcome";
 import { SystemOutcomeBanner } from "@/components/SystemOutcomeBanner";
 import { getDraftForGame } from "@/lib/actions/systems";
+import { getNoteCountsForHorses } from "@/lib/actions/notes";
+import { getGamePostSummary } from "@/lib/actions/posts";
 import { getTrackConfig } from "@/lib/actions/tracks";
 import { redirect } from "next/navigation";
+import Link from "next/link";
 import { Suspense } from "react";
 import type { SystemSelection, TrackConfig } from "@/lib/types";
 
@@ -80,9 +83,15 @@ export default async function HomePage({
   const selectedGame = games.find((g) => g.id === selectedId) ?? null;
   const races = selectedId ? await getRaces(supabase, selectedId) : [];
 
-  const trackConfig: TrackConfig | null = selectedGame
-    ? await getTrackConfig(selectedGame.track)
-    : null;
+  // Socialt i loppvyn: anteckningsantal per häst + forumdiskussion om omgången
+  const horseIds = Array.from(
+    new Set(races.flatMap((r) => (r.starters ?? []).map((s: { horse_id: string }) => s.horse_id)))
+  );
+  const [noteCounts, postSummary, trackConfig] = await Promise.all([
+    horseIds.length ? getNoteCountsForHorses(horseIds) : Promise.resolve({}),
+    selectedId ? getGamePostSummary(selectedId) : Promise.resolve(null),
+    selectedGame ? getTrackConfig(selectedGame.track) : Promise.resolve(null),
+  ]) as [Record<string, number>, Awaited<ReturnType<typeof getGamePostSummary>>, TrackConfig | null];
 
   const initialSystemMode = params.systemMode === '1'
   const initialGroupId = params.groupId ?? null
@@ -166,6 +175,15 @@ export default async function HomePage({
             <span style={{ color: "var(--tn-accent)", fontWeight: 600 }}>{selectedGame.game_type}</span>
             <span style={{ color: "var(--tn-border-strong)" }}>·</span>
             <span>{selectedGame.track}</span>
+            {postSummary && selectedId && (
+              <Link
+                href={`/sallskap/${postSummary.group_id}?game=${selectedId}`}
+                className="ml-auto flex items-center gap-1 transition"
+                style={{ color: "var(--tn-accent)" }}
+              >
+                💬 {postSummary.count} inlägg om omgången →
+              </Link>
+            )}
           </div>
         )}
 
@@ -200,6 +218,7 @@ export default async function HomePage({
           draftId={draftId}
           initialSelections={initialSelections}
           trackConfig={trackConfig}
+          noteCounts={noteCounts}
         />
       </div>
     </main>

--- a/app/(authenticated)/sallskap/[groupId]/page.tsx
+++ b/app/(authenticated)/sallskap/[groupId]/page.tsx
@@ -10,6 +10,7 @@ import { SallskapPageClient } from "./SallskapPageClient";
 
 interface Props {
   params: Promise<{ groupId: string }>;
+  searchParams: Promise<{ game?: string }>;
 }
 
 async function getAllGames(supabase: Awaited<ReturnType<typeof createClient>>) {
@@ -20,8 +21,9 @@ async function getAllGames(supabase: Awaited<ReturnType<typeof createClient>>) {
   return data ?? [];
 }
 
-export default async function SallskapPage({ params }: Props) {
+export default async function SallskapPage({ params, searchParams }: Props) {
   const { groupId } = await params;
+  const { game: gameParam } = await searchParams;
 
   const supabase = await createClient();
   const { data: { user } } = await supabase.auth.getUser();
@@ -49,7 +51,9 @@ export default async function SallskapPage({ params }: Props) {
 
   if (!group) redirect("/");
 
-  const defaultGameId = games[0]?.id ?? null;
+  // Djuplänk från loppvyn (?game=) väljer rätt omgång, annars senaste
+  const defaultGameId =
+    (gameParam && games.find((g) => g.id === gameParam)?.id) ?? games[0]?.id ?? null;
 
   const [initialPosts, initialNotes, initialSystems, league] = await Promise.all([
     defaultGameId ? getGroupPosts(groupId, defaultGameId) : Promise.resolve([]),

--- a/components/HorseCard.tsx
+++ b/components/HorseCard.tsx
@@ -290,6 +290,7 @@ export function HorseCard({
   raceStartMethod,
   isValue,
   skrall,
+  noteCount = 0,
   sortRank,
   isSelected,
   onSelect,
@@ -302,6 +303,7 @@ export function HorseCard({
   raceStartMethod?: string;
   isValue?: boolean;
   skrall?: SkrallSignal;
+  noteCount?: number;
   sortRank?: number;
   isSelected?: boolean;
   onSelect?: () => void;
@@ -449,6 +451,19 @@ export function HorseCard({
                 title={`Skrällkandidat: odds säger ${skrall.oddsProbPct?.toFixed(1)} % chans mot ${starter.bet_distribution?.toFixed(1)} % streck, klass ${skrall.classRank} av fältet`}
               >
                 SKRÄLL
+              </span>
+            )}
+            {noteCount > 0 && (
+              <span
+                className="inline-flex items-center gap-0.5 text-[10px] font-semibold px-1 py-0.5 rounded shrink-0"
+                style={{ background: "var(--tn-accent-faint)", color: "var(--tn-accent)" }}
+                title={`${noteCount} anteckning${noteCount === 1 ? "" : "ar"} på hästen (även från tidigare omgångar)`}
+                aria-label={`${noteCount} anteckningar på hästen`}
+              >
+                <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                  <path d="M21 11.5a8.38 8.38 0 0 1-8.5 8.5 8.5 8.5 0 0 1-3.8-.9L3 21l1.9-5.7A8.38 8.38 0 0 1 4 11.5 8.5 8.5 0 0 1 12.5 3 8.38 8.38 0 0 1 21 11.5z" />
+                </svg>
+                {noteCount}
               </span>
             )}
           </div>

--- a/components/MainPageClient.tsx
+++ b/components/MainPageClient.tsx
@@ -28,6 +28,8 @@ interface MainPageClientProps {
   draftId?: string | null
   initialSelections?: SystemSelection[]
   trackConfig?: TrackConfig | null
+  /** Antal anteckningar per häst-id — pratbubbla på hästkortet */
+  noteCounts?: Record<string, number>
 }
 
 export function MainPageClient({
@@ -41,6 +43,7 @@ export function MainPageClient({
   draftId = null,
   initialSelections = [],
   trackConfig = null,
+  noteCounts = {},
 }: MainPageClientProps) {
   const [systemMode, setSystemMode] = useState(initialSystemMode)
   const { activeRaceNumber: activeRace, setActiveRaceNumber: setActiveRace } = useRaceTab()
@@ -177,6 +180,7 @@ export function MainPageClient({
             onToggleHorse={handleToggleHorse}
             onHorseClick={handleHorseClick}
             trackConfig={trackConfig}
+            noteCounts={noteCounts}
           />
         )}
       </div>

--- a/components/RaceList.tsx
+++ b/components/RaceList.tsx
@@ -83,6 +83,7 @@ export function RaceList({
   onToggleHorse,
   onHorseClick,
   trackConfig,
+  noteCounts = {},
 }: {
   races: Race[];
   activeRaceNumber: number;
@@ -93,6 +94,7 @@ export function RaceList({
   onToggleHorse?: (raceNumber: number, horse: SystemHorse) => void;
   onHorseClick?: (raceNumber: number, startNumber: number) => void;
   trackConfig?: TrackConfig | null;
+  noteCounts?: Record<string, number>;
 }) {
   const [showAnalysis, setShowAnalysis] = useState(false);
   const [sortKey, setSortKey] = useState<SortKey>("composite");
@@ -314,6 +316,7 @@ export function RaceList({
               raceStartMethod={activeRace.start_method ?? "auto"}
               isValue={valueMap[s.start_number] ?? false}
               skrall={skrallMap[s.start_number]}
+              noteCount={noteCounts[s.horse_id] ?? 0}
               sortRank={sortKey !== "number" ? idx + 1 : undefined}
               trackConfig={trackConfig ?? undefined}
               isSelected={systemMode ? (raceSelections?.horses.some((h) => h.horse_id === s.horse_id) ?? false) : undefined}

--- a/components/sallskap/spel/BetsSection.tsx
+++ b/components/sallskap/spel/BetsSection.tsx
@@ -15,13 +15,15 @@ interface BetsSectionProps {
   groupId: string
   gameId: string | null
   currentUserId: string
+  /** Bumpas av SpelTab när en insats registrerats från ett systemkort — triggar omladdning */
+  refreshSignal?: number
 }
 
 function formatKr(value: number): string {
   return value % 1 === 0 ? `${value} kr` : `${value.toFixed(2).replace('.', ',')} kr`
 }
 
-export function BetsSection({ groupId, gameId, currentUserId }: BetsSectionProps) {
+export function BetsSection({ groupId, gameId, currentUserId, refreshSignal = 0 }: BetsSectionProps) {
   const [bets, setBets] = useState<Bet[]>([])
   const [stats, setStats] = useState<BetStats[]>([])
   const [loading, setLoading] = useState(false)
@@ -58,7 +60,9 @@ export function BetsSection({ groupId, gameId, currentUserId }: BetsSectionProps
 
   useEffect(() => {
     reload()
-  }, [reload])
+    // refreshSignal bumpas när en insats registrerats från ett systemkort
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [reload, refreshSignal])
 
   async function handleAdd() {
     if (!gameId) return
@@ -135,9 +139,12 @@ export function BetsSection({ groupId, gameId, currentUserId }: BetsSectionProps
 
   return (
     <section className="mt-8">
-      <h2 className="text-sm font-semibold uppercase tracking-wide mb-3 tn-eyebrow" style={{ color: 'var(--tn-text-dim)' }}>
+      <h2 className="text-sm font-semibold uppercase tracking-wide mb-1 tn-eyebrow" style={{ color: 'var(--tn-text-dim)' }}>
         Insatser
       </h2>
+      <p className="text-xs mb-3" style={{ color: 'var(--tn-text-faint)' }}>
+        Tips: klicka <span style={{ color: 'var(--tn-accent)' }}>Jag spelade detta</span> på ett systemkort så fylls insatsen i automatiskt. Fyll i utdelningen när omgången är avgjord.
+      </p>
 
       {/* Lägg till insats */}
       <div className="rounded-xl p-3 mb-3" style={{ background: 'var(--tn-bg-card)', border: '1px solid var(--tn-border)' }}>
@@ -216,10 +223,25 @@ export function BetsSection({ groupId, gameId, currentUserId }: BetsSectionProps
               >
                 <span className="font-semibold" style={{ color: 'var(--tn-text)' }}>{bet.author_name}</span>
                 <span style={{ color: 'var(--tn-text-dim)' }}>
-                  {bet.bet_type}
-                  {bet.race_number != null && ` · Avd ${bet.race_number}`}
-                  {bet.horse_name && ` · ${bet.horse_name}`}
+                  {bet.system_name ? (
+                    <>🎯 {bet.system_name}</>
+                  ) : (
+                    <>
+                      {bet.bet_type}
+                      {bet.race_number != null && ` · Avd ${bet.race_number}`}
+                      {bet.horse_name && ` · ${bet.horse_name}`}
+                    </>
+                  )}
                 </span>
+                {bet.system_id != null && bet.system_score != null && (
+                  <span
+                    className="tn-mono text-xs font-bold px-1.5 py-0.5 rounded"
+                    style={{ background: 'var(--tn-bg-chip)', color: 'var(--tn-text-dim)' }}
+                    title="Systemets träff"
+                  >
+                    {bet.system_score}/8
+                  </span>
+                )}
                 <span className="ml-auto tn-mono" style={{ color: 'var(--tn-text-dim)' }}>{formatKr(bet.stake)}</span>
                 {isOwner ? (
                   <span className="flex items-center gap-1">

--- a/components/sallskap/spel/SpelTab.tsx
+++ b/components/sallskap/spel/SpelTab.tsx
@@ -6,6 +6,7 @@ import { SystemCard } from './SystemCard'
 import { BetsSection } from './BetsSection'
 import { LeagueTable } from './LeagueTable'
 import { getGroupSystems, getWinnersForGame, type GroupLeague } from '@/lib/actions/systems'
+import { getMyLoggedSystemIds } from '@/lib/actions/bets'
 import type { GameSystem } from '@/lib/types'
 
 type Game = { id: string; date: string; track: string | null; game_type?: string }
@@ -24,11 +25,24 @@ export function SpelTab({ groupId, games, initialGameId, initialSystems, league,
   const [systems, setSystems] = useState<GameSystem[]>(initialSystems)
   const [loading, setLoading] = useState(false)
   const [winnersByRace, setWinnersByRace] = useState<Record<number, string>>({})
+  const [loggedSystemIds, setLoggedSystemIds] = useState<Set<string>>(new Set())
+  const [betsRefresh, setBetsRefresh] = useState(0)
 
   useEffect(() => {
     if (!initialGameId) return
     getWinnersForGame(initialGameId).then(setWinnersByRace).catch(() => {})
   }, [initialGameId])
+
+  useEffect(() => {
+    getMyLoggedSystemIds(groupId)
+      .then((ids) => setLoggedSystemIds(new Set(ids)))
+      .catch(() => {})
+  }, [groupId])
+
+  function handleBetLogged(systemId: string) {
+    setLoggedSystemIds(prev => new Set(prev).add(systemId))
+    setBetsRefresh(n => n + 1)
+  }
 
   async function handleGameChange(gameId: string) {
     setSelectedGameId(gameId)
@@ -170,6 +184,8 @@ export function SpelTab({ groupId, games, initialGameId, initialSystems, league,
                     winnersByRace={winnersByRace}
                     gameType={gameType}
                     gameId={selectedGameId}
+                    alreadyLogged={loggedSystemIds.has(system.id)}
+                    onBetLogged={handleBetLogged}
                   />
                 ))}
               </div>
@@ -180,7 +196,7 @@ export function SpelTab({ groupId, games, initialGameId, initialSystems, league,
 
       <LeagueTable league={league} />
 
-      <BetsSection groupId={groupId} gameId={selectedGameId} currentUserId={currentUserId} />
+      <BetsSection groupId={groupId} gameId={selectedGameId} currentUserId={currentUserId} refreshSignal={betsRefresh} />
     </div>
   )
 }

--- a/components/sallskap/spel/SystemCard.tsx
+++ b/components/sallskap/spel/SystemCard.tsx
@@ -4,6 +4,7 @@ import { useState, useTransition } from 'react'
 import Link from 'next/link'
 import { GameSystem } from '@/lib/types'
 import { deleteSystem } from '@/lib/actions/systems'
+import { addBetFromSystem } from '@/lib/actions/bets'
 import { isWinningHorse } from '@/lib/systemsHelpers'
 import { formatRowCost } from '@/lib/atg'
 
@@ -14,14 +15,37 @@ interface SystemCardProps {
   winnersByRace?: Record<number, string>
   gameType?: string
   gameId?: string | null
+  /** True om inloggad användare redan registrerat detta system som insats */
+  alreadyLogged?: boolean
+  /** Anropas när en insats registrerats från systemet (för att uppdatera insatslistan) */
+  onBetLogged?: (systemId: string) => void
 }
 
-export function SystemCard({ system, currentUserId, onDeleted, winnersByRace, gameType = '', gameId }: SystemCardProps) {
+export function SystemCard({ system, currentUserId, onDeleted, winnersByRace, gameType = '', gameId, alreadyLogged = false, onBetLogged }: SystemCardProps) {
   const isOwner = system.user_id === currentUserId
   const [isPending, startTransition] = useTransition()
   const [deleteError, setDeleteError] = useState<string | null>(null)
   const [confirmDelete, setConfirmDelete] = useState(false)
   const [copied, setCopied] = useState(false)
+  const [logged, setLogged] = useState(alreadyLogged)
+  const [logging, setLogging] = useState(false)
+  const [logError, setLogError] = useState<string | null>(null)
+
+  // Bara sparade sällskapssystem kan registreras som spel
+  const canLogBet = !system.is_draft && system.group_id != null
+
+  async function handleLogBet() {
+    setLogging(true)
+    setLogError(null)
+    const result = await addBetFromSystem(system.id)
+    setLogging(false)
+    if (result.error) {
+      setLogError(result.error)
+      return
+    }
+    setLogged(true)
+    if (!result.alreadyLogged) onBetLogged?.(system.id)
+  }
 
   function handleCopy() {
     const sortedSelections = [...system.selections].sort((a, b) => a.race_number - b.race_number)
@@ -164,6 +188,7 @@ export function SystemCard({ system, currentUserId, onDeleted, winnersByRace, ga
       </table>
 
       {deleteError && <p className="text-xs mb-2" style={{ color: "var(--tn-value-low)" }}>{deleteError}</p>}
+      {logError && <p className="text-xs mb-2" style={{ color: "var(--tn-value-low)" }}>{logError}</p>}
 
       <div className="flex gap-2 flex-wrap">
         {system.is_draft && isOwner && continueHref && (
@@ -186,6 +211,21 @@ export function SystemCard({ system, currentUserId, onDeleted, winnersByRace, ga
             }
           >
             {copied ? 'Kopierat ✓' : 'Kopiera system'}
+          </button>
+        )}
+        {canLogBet && (
+          <button
+            onClick={handleLogBet}
+            disabled={logged || logging}
+            title={logged ? undefined : `Registrerar ${formatRowCost(system.total_rows, gameType)} som din insats`}
+            className="text-xs px-3 py-1.5 rounded-lg transition disabled:cursor-default"
+            style={
+              logged
+                ? { background: "rgba(52,211,153,0.15)", border: "1px solid rgba(52,211,153,0.3)", color: "var(--tn-value-high)", cursor: "default" }
+                : { background: "var(--tn-accent-faint)", border: "1px solid var(--tn-accent-soft)", color: "var(--tn-accent)", cursor: "pointer" }
+            }
+          >
+            {logged ? '✓ Spelat' : logging ? 'Registrerar…' : 'Jag spelade detta'}
           </button>
         )}
         {isOwner && !confirmDelete && (

--- a/lib/actions/bets.ts
+++ b/lib/actions/bets.ts
@@ -2,6 +2,7 @@
 
 import { createServiceClient } from "@/lib/supabase/server";
 import { getAuthUser, isGroupMember } from "@/lib/supabase/guards";
+import { getRowPrice } from "@/lib/atg";
 
 export interface Bet {
   id: string;
@@ -15,6 +16,10 @@ export interface Bet {
   stake: number;
   payout: number | null;
   created_at: string;
+  /** Kopplat system (om insatsen registrerades från ett systemkort) */
+  system_id: string | null;
+  system_name: string | null;
+  system_score: number | null;
 }
 
 export interface BetStats {
@@ -53,6 +58,76 @@ export async function addBet(
 
   if (error) return { error: error.message };
   return {};
+}
+
+/**
+ * Registrerar en insats direkt från ett sparat system: insatsen (rader ×
+ * radpris) fylls i automatiskt och kopplas till systemet. Idempotent — samma
+ * användare kan inte logga samma system två gånger. Endast sällskapssystem
+ * (group_id satt, ej utkast) kan loggas.
+ */
+export async function addBetFromSystem(
+  systemId: string
+): Promise<{ error?: string; alreadyLogged?: boolean }> {
+  const user = await getAuthUser();
+  if (!user) return { error: "Ej inloggad" };
+
+  const db = createServiceClient();
+  const { data: system } = await db
+    .from("game_systems")
+    .select("id, group_id, game_id, total_rows, is_draft, games(game_type)")
+    .eq("id", systemId)
+    .single();
+
+  if (!system) return { error: "Systemet hittades inte" };
+  if (system.is_draft || !system.group_id) {
+    return { error: "Bara sparade sällskapssystem kan registreras som spel" };
+  }
+  if (!(await isGroupMember(user.id, system.group_id as string))) {
+    return { error: "Du är inte medlem i detta sällskap" };
+  }
+
+  // Idempotent: redan loggat av denna användare?
+  const { data: existing } = await db
+    .from("bets")
+    .select("id")
+    .eq("user_id", user.id)
+    .eq("system_id", systemId)
+    .maybeSingle();
+  if (existing) return { alreadyLogged: true };
+
+  const gameRel = system.games as unknown as { game_type: string } | { game_type: string }[] | null;
+  const gameType =
+    (Array.isArray(gameRel) ? gameRel[0]?.game_type : gameRel?.game_type) ?? "V85";
+  const stake = Math.round((system.total_rows as number) * getRowPrice(gameType));
+
+  const { error } = await db.from("bets").insert({
+    user_id: user.id,
+    group_id: system.group_id,
+    game_id: system.game_id,
+    bet_type: gameType,
+    stake,
+    system_id: systemId,
+  });
+
+  if (error) return { error: error.message };
+  return {};
+}
+
+/** System-id som den inloggade användaren redan registrerat insats för i sällskapet. */
+export async function getMyLoggedSystemIds(groupId: string): Promise<string[]> {
+  const user = await getAuthUser();
+  if (!user) return [];
+
+  const db = createServiceClient();
+  const { data } = await db
+    .from("bets")
+    .select("system_id")
+    .eq("group_id", groupId)
+    .eq("user_id", user.id)
+    .not("system_id", "is", null);
+
+  return (data ?? []).map((b) => b.system_id as string);
 }
 
 export async function updateBetPayout(
@@ -120,19 +195,38 @@ export async function getGroupBets(
   const nameMap = new Map<string, string>();
   for (const p of profiles ?? []) nameMap.set(p.id, p.display_name ?? "Okänd");
 
-  return data.map((b) => ({
-    id: b.id as string,
-    user_id: b.user_id as string,
-    author_name: nameMap.get(b.user_id as string) ?? "Okänd",
-    group_id: b.group_id as string,
-    game_id: b.game_id as string,
-    race_number: b.race_number as number | null,
-    horse_name: b.horse_name as string | null,
-    bet_type: b.bet_type as string,
-    stake: b.stake as number,
-    payout: b.payout as number | null,
-    created_at: b.created_at as string,
-  }));
+  // Hämta namn/score för kopplade system
+  const systemIds = [...new Set(data.map((b) => b.system_id as string | null).filter((id): id is string => id != null))];
+  const systemMap = new Map<string, { name: string; score: number | null }>();
+  if (systemIds.length > 0) {
+    const { data: systems } = await db
+      .from("game_systems")
+      .select("id, name, score")
+      .in("id", systemIds);
+    for (const s of systems ?? []) {
+      systemMap.set(s.id as string, { name: s.name as string, score: s.score as number | null });
+    }
+  }
+
+  return data.map((b) => {
+    const sys = b.system_id ? systemMap.get(b.system_id as string) : undefined;
+    return {
+      id: b.id as string,
+      user_id: b.user_id as string,
+      author_name: nameMap.get(b.user_id as string) ?? "Okänd",
+      group_id: b.group_id as string,
+      game_id: b.game_id as string,
+      race_number: b.race_number as number | null,
+      horse_name: b.horse_name as string | null,
+      bet_type: b.bet_type as string,
+      stake: b.stake as number,
+      payout: b.payout as number | null,
+      created_at: b.created_at as string,
+      system_id: (b.system_id as string | null) ?? null,
+      system_name: sys?.name ?? null,
+      system_score: sys?.score ?? null,
+    };
+  });
 }
 
 export async function getGroupBetStats(groupId: string): Promise<BetStats[]> {

--- a/lib/actions/notes.ts
+++ b/lib/actions/notes.ts
@@ -228,3 +228,29 @@ export async function deleteNote(noteId: string): Promise<{ error: string | null
   if (error) return { error: error.message };
   return { error: null };
 }
+
+/**
+ * Antal anteckningar (inkl. svar) per häst som användaren får se, för en lista
+ * av häst-id:n. Driver pratbubblan på hästkortet i loppvyn — anteckningar
+ * följer hästen mellan omgångar, så siffran signalerar "här finns historik".
+ * RLS filtrerar till sällskaps- och egna personliga anteckningar.
+ */
+export async function getNoteCountsForHorses(
+  horseIds: string[]
+): Promise<Record<string, number>> {
+  if (horseIds.length === 0) return {};
+  const supabase = await createClient();
+
+  const { data, error } = await supabase
+    .from("horse_notes")
+    .select("horse_id")
+    .in("horse_id", horseIds);
+
+  if (error || !data) return {};
+
+  const counts: Record<string, number> = {};
+  for (const row of data as { horse_id: string }[]) {
+    counts[row.horse_id] = (counts[row.horse_id] ?? 0) + 1;
+  }
+  return counts;
+}

--- a/lib/actions/posts.ts
+++ b/lib/actions/posts.ts
@@ -122,3 +122,39 @@ export async function deletePost(postId: string): Promise<{ error: string | null
   if (error) return { error: error.message };
   return { error: null };
 }
+
+export interface GamePostSummary {
+  group_id: string;
+  group_name: string;
+  count: number;
+}
+
+/**
+ * Sammanfattning av forumdiskussionen om en omgång för länken i loppvyn.
+ * Returnerar det av användarens sällskap som har flest inlägg om omgången
+ * (RLS begränsar till sällskap användaren är medlem i), eller null om inga
+ * inlägg finns. Driver "💬 N inlägg om omgången"-länken på startsidan.
+ */
+export async function getGamePostSummary(gameId: string): Promise<GamePostSummary | null> {
+  const supabase = await createClient();
+
+  const { data, error } = await supabase
+    .from("group_posts")
+    .select("group_id, groups(name)")
+    .eq("game_id", gameId);
+
+  if (error || !data || data.length === 0) return null;
+
+  const counts = new Map<string, { name: string; count: number }>();
+  for (const row of data as unknown as { group_id: string; groups: { name: string } | null }[]) {
+    const entry = counts.get(row.group_id) ?? { name: row.groups?.name ?? "Sällskap", count: 0 };
+    entry.count += 1;
+    counts.set(row.group_id, entry);
+  }
+
+  let best: GamePostSummary | null = null;
+  for (const [group_id, { name, count }] of counts) {
+    if (!best || count > best.count) best = { group_id, group_name: name, count };
+  }
+  return best;
+}

--- a/supabase/migration_v12_bets_system_link.sql
+++ b/supabase/migration_v12_bets_system_link.sql
@@ -1,0 +1,10 @@
+-- v12: koppla insatser till sparade system.
+-- En insats kan registreras direkt från ett systemkort ("Jag spelade detta
+-- system") — då fylls insatsen (rader × radpris) i automatiskt och kopplas till
+-- systemet så att ROI-tabellen kan visa systemets träff. system_id är nullable;
+-- manuellt inmatade insatser saknar koppling.
+
+ALTER TABLE bets
+  ADD COLUMN IF NOT EXISTS system_id uuid REFERENCES game_systems(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_bets_system ON bets(system_id);


### PR DESCRIPTION
## Sammanfattning

Implementerar #78 **väg A** (du valde "Koppla till system"). Insatsfunktionen hade 0 användning eftersom den krävde manuell återinmatning av allt man redan byggt i appen. Nu:

- **"Jag spelade detta"-knapp på varje sällskapssystem-kort** → registrerar en insats med beloppet (rader × radpris) förifyllt och kopplat till systemet. Ett klick i stället för att skriva in speltyp + insats för hand.
- **Insatsraden visar systemets träff** (🎯 systemnamn + t.ex. `6/8`) bredvid beloppet, så ROI-tabellen blir meningsfull utan handpåläggning.
- Knappen blir **✓ Spelat** efteråt; idempotent (samma system kan inte loggas dubbelt).
- Manuell inmatning finns kvar för spel utanför systemen.

## Ärlig avgränsning

Utdelningen fylls fortfarande i manuellt. ATG:s faktiska utdelning finns inte i vår data, så kronutfallet kan inte härledas ur antal rätt — att "föreslå utdelning automatiskt" vore att hitta på siffror. Score-kopplingen ger ändå rätt kontext för att fylla i utdelningen snabbt.

## Teknik

- **migration v12** (applicerad på databasen): `bets.system_id → game_systems(id) ON DELETE SET NULL`, nullable så manuella insatser fungerar oförändrat.
- `addBetFromSystem()` — idempotent, med samma auth-/medlemskapskontroll som övriga bets-actions (bevarar säkerhetsfixarna i `guards.ts`). `getMyLoggedSystemIds()` driver knappens läge.
- `getGroupBets()` join:ar systemnamn/score; `BetsSection` laddar om när ett system loggats.

## Test
- `npx jest`: 70 tester gröna, `tsc --noEmit` rent, lint oförändrat (3 förexisterande)
- MANUAL.md (v2.9) och CLAUDE.md uppdaterade

> **Obs:** stackad på #83 (#77) — innehåller dess commits tills #83 mergats. **Merga #83 först**, sedan visar denna bara sin egen diff.

Closes #78.

https://claude.ai/code/session_016r3SKaqgmEtHD64UfAaQ3H

---
_Generated by [Claude Code](https://claude.ai/code/session_016r3SKaqgmEtHD64UfAaQ3H)_