### PR TITLE
Web push-notiser: "Resultaten är rättade" (#75 steg 2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,7 @@ components/
   ThemeToggle.tsx           # Mörkt/ljust tema-växlare
   TopNav.tsx                # Övre navigering (desktop)
   InstallPrompt.tsx         # PWA-installationsprompt
+  NotificationToggle.tsx    # Slå på/av web push-notiser (på sällskapsöversikten)
   UsefulLinks.tsx           # Hjälplänkar
   admin/                    # Adminkomponenter
   notes/
@@ -120,12 +121,15 @@ lib/
   formscore.ts              # Composite Score: computeComponents + CS_WEIGHTS
   skrall.ts                 # Skrällkandidat-signal (låg streck + odds/streck-diskrepans + klass)
   probability.ts            # Kalibrerad vinstsannolikhet (50% streck + 50% odds, BLEND_ALPHA)
+  push.ts                   # Web push-utskick (sendPushToUsers, no-op utan VAPID-env)
+  systems.ts                # gradeSystemsForGame (rättar system, returnerar notifierbara sällskap)
   atg.ts                    # Typer för ATG-data (AvailableGame m.m.)
   types.ts                  # Delade TS-typer (Group, GroupMember, HorseNote, m.m.)
   supabase/                 # Supabase-klienter (server/browser)
   actions/
     activity.ts             # Aktivitetssignaler: getGroupActivity (React-cachad) + markGroupSeen
     outcome.ts              # Senaste rättade omgångens systemutfall (resultatbannern)
+    push.ts                 # Server actions: spara/ta bort web push-prenumeration
     bets.ts                 # Server actions: insatser/ROI + addBetFromSystem (logga sparat system som spel)
     games.ts                # Server actions: spel
     groups.ts               # Server actions: skapa/lämna sällskap
@@ -158,6 +162,7 @@ supabase/
 **drafts** – utkast till spelsystem
 **track_configs** – banspecifik konfiguration (open_stretch, short_race_threshold)
 **group_last_seen** – när användare senast besökte ett sällskap (aktivitetsbadges)
+**push_subscriptions** – web push-prenumerationer per enhet (endpoint, p256dh, auth)
 
 ---
 
@@ -222,6 +227,10 @@ Trösklarna kommer från databasanalys 2026-06-12 (155 lopp med facit).
 - Teman: mörkt/ljust via `ThemeProvider` + `ThemeToggle` (localStorage).
 - Mobil-navigation via `BottomNav` (fast, döljs på md+).
 - Kontroller (sortering/filter) är kollapsibla på mobil via `CollapsibleControls`.
+- **Web push** kräver tre miljövariabler (genereras med `npx web-push generate-vapid-keys`):
+  `NEXT_PUBLIC_VAPID_PUBLIC_KEY`, `VAPID_PRIVATE_KEY`, `VAPID_SUBJECT` (mailto:/URL).
+  Saknas de är push helt avstängt — `NotificationToggle` döljs och `sendPushToUsers`
+  blir en no-op. Resultatnotisen skickas från `app/api/games/[gameId]/results/route.ts`.
 
 ---
 

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -276,6 +276,10 @@ Badgen nollställs för ett sällskap när du öppnar det. Endast andras aktivit
 
 När en omgång rättats där du eller någon i dina sällskap hade sparade system visas en banner högst upp på startsidan: **"🏆 Resultaten är rättade"** med varje systems antal rätt (bästa resultatet guldmarkeras). Klicka på ett system för att gå till sällskapets Spel-flik (eller Systemsidan för privata system). Bannern kan döljas med ✕ och visas i upp till en vecka efter speldagen.
 
+### Notiser
+
+På sällskapsöversikten (via **Profil**) kan du slå på **notiser**. Då får du en pushnotis till mobilen eller datorn när en omgång rättats och systemen fått sina poäng — så du inte missar resultatkvällen. Notiser kräver att du tillåter dem i webbläsaren. På iPhone måste appen först vara **installerad** på hemskärmen (PWA). Du kan stänga av notiserna när som helst samma väg.
+
 ### 7.1 Skapa ett sällskap
 
 1. Gå till sällskapsöversikten via **Profil**-fliken (mobil) eller **profilmenyn → Hantera sällskap** (desktop).
@@ -402,4 +406,4 @@ Sidan visar:
 
 ---
 
-*Manual version 2.9 – V85 Analys*
+*Manual version 3.0 – V85 Analys*

--- a/app/api/games/[gameId]/results/route.ts
+++ b/app/api/games/[gameId]/results/route.ts
@@ -2,6 +2,41 @@ import { NextRequest, NextResponse } from "next/server";
 import { fetchGameResults } from "@/lib/atg";
 import { createServiceClient } from "@/lib/supabase/server";
 import { gradeSystemsForGame } from "@/lib/systems";
+import { sendPushToUsers } from "@/lib/push";
+
+/**
+ * Skickar resultatnotis till medlemmar i sällskap som fick nyrättade system.
+ * Körs bara när minst ett system faktiskt nyrättades, så upprepade
+ * resultathämtningar inte ger dubbla notiser. Icke-fatal.
+ */
+async function notifyGradedGroups(
+  db: ReturnType<typeof createServiceClient>,
+  gameId: string,
+  groupIds: string[]
+) {
+  if (groupIds.length === 0) return;
+
+  const { data: game } = await db
+    .from("games")
+    .select("game_type, date, track")
+    .eq("id", gameId)
+    .single();
+
+  const { data: members } = await db
+    .from("group_members")
+    .select("user_id")
+    .in("group_id", groupIds);
+  const userIds = [...new Set((members ?? []).map((m) => m.user_id as string))];
+  if (userIds.length === 0) return;
+
+  const label = game ? `${game.game_type} ${game.date}` : "omgången";
+  await sendPushToUsers(userIds, {
+    title: "Resultaten är rättade 🏆",
+    body: `${label} är avgjord — se hur ditt sällskap gick.`,
+    url: "/",
+    tag: `results-${gameId}`,
+  });
+}
 
 export async function POST(
   _request: NextRequest,
@@ -79,9 +114,10 @@ export async function POST(
 
     // Rätta sparade system (isolerat — fel här ska inte påverka svaret)
     try {
-      await gradeSystemsForGame(supabase, gameId)
+      const newlyGradedGroups = await gradeSystemsForGame(supabase, gameId)
+      await notifyGradedGroups(supabase, gameId, newlyGradedGroups)
     } catch (err) {
-      console.warn('[results] gradeSystemsForGame failed (non-fatal):', err)
+      console.warn('[results] gradeSystemsForGame/notify failed (non-fatal):', err)
     }
 
     return NextResponse.json({

--- a/app/sw.ts
+++ b/app/sw.ts
@@ -20,3 +20,61 @@ const serwist = new Serwist({
 });
 
 serwist.addEventListeners();
+
+// --- Web push: visa notis + öppna rätt sida vid klick ---
+// Service worker-globalen och event-typerna ligger i webworker-libet som inte
+// är aktiverat i tsconfig; vi typar det minimalt här för att hålla workern
+// fristående.
+interface PushLike {
+  data: { json: () => unknown; text: () => string } | null;
+  waitUntil: (p: Promise<unknown>) => void;
+}
+interface NotificationClickLike {
+  notification: { close: () => void; data: { url?: string } | null };
+  waitUntil: (p: Promise<unknown>) => void;
+}
+type SwClient = { navigate?: (u: string) => void; focus?: () => unknown };
+interface SwScope {
+  addEventListener: (type: string, listener: (event: never) => void) => void;
+  registration: { showNotification: (title: string, options?: Record<string, unknown>) => Promise<void> };
+  clients: {
+    matchAll: (opts: { type: string; includeUncontrolled: boolean }) => Promise<SwClient[]>;
+    openWindow: (url: string) => Promise<unknown>;
+  };
+}
+const swScope = self as unknown as SwScope;
+
+swScope.addEventListener("push", (event: PushLike) => {
+  if (!event.data) return;
+  let payload: { title?: string; body?: string; url?: string; tag?: string };
+  try {
+    payload = (event.data.json() as typeof payload) ?? {};
+  } catch {
+    payload = { title: "V85 Analys", body: event.data.text() };
+  }
+  event.waitUntil(
+    swScope.registration.showNotification(payload.title ?? "V85 Analys", {
+      body: payload.body ?? "",
+      icon: "/icon-192.png",
+      badge: "/icon-192.png",
+      tag: payload.tag,
+      data: { url: payload.url ?? "/" },
+    })
+  );
+});
+
+swScope.addEventListener("notificationclick", (event: NotificationClickLike) => {
+  event.notification.close();
+  const url = event.notification.data?.url ?? "/";
+  event.waitUntil(
+    swScope.clients.matchAll({ type: "window", includeUncontrolled: true }).then((clients) => {
+      for (const client of clients) {
+        if (client.focus) {
+          client.navigate?.(url);
+          return client.focus();
+        }
+      }
+      return swScope.clients.openWindow(url);
+    })
+  );
+});

--- a/components/NotificationToggle.tsx
+++ b/components/NotificationToggle.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { savePushSubscription, deletePushSubscription } from "@/lib/actions/push";
+
+const VAPID_PUBLIC_KEY = process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY;
+
+function urlBase64ToUint8Array(base64String: string): Uint8Array {
+  const padding = "=".repeat((4 - (base64String.length % 4)) % 4);
+  const base64 = (base64String + padding).replace(/-/g, "+").replace(/_/g, "/");
+  const raw = atob(base64);
+  const arr = new Uint8Array(raw.length);
+  for (let i = 0; i < raw.length; i++) arr[i] = raw.charCodeAt(i);
+  return arr;
+}
+
+type State = "loading" | "unsupported" | "off" | "on" | "denied" | "working";
+
+/**
+ * Knapp för att slå på/av push-notiser (t.ex. "Resultaten är rättade").
+ * Renderar inget om VAPID-nyckel saknas eller webbläsaren inte stödjer push.
+ */
+export function NotificationToggle() {
+  const [state, setState] = useState<State>("loading");
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    // Inledande await gör att all state sätts asynkront (inte synkront i effekten)
+    (async () => {
+      await Promise.resolve();
+      if (cancelled) return;
+      const supported =
+        VAPID_PUBLIC_KEY &&
+        typeof window !== "undefined" &&
+        "serviceWorker" in navigator &&
+        "PushManager" in window &&
+        "Notification" in window;
+      if (!supported) return setState("unsupported");
+      if (Notification.permission === "denied") return setState("denied");
+      try {
+        const reg = await navigator.serviceWorker.ready;
+        const sub = await reg.pushManager.getSubscription();
+        if (!cancelled) setState(sub ? "on" : "off");
+      } catch {
+        if (!cancelled) setState("off");
+      }
+    })();
+    return () => { cancelled = true; };
+  }, []);
+
+  async function enable() {
+    setError(null);
+    setState("working");
+    try {
+      const permission = await Notification.requestPermission();
+      if (permission !== "granted") {
+        setState(permission === "denied" ? "denied" : "off");
+        return;
+      }
+      const reg = await navigator.serviceWorker.ready;
+      const sub = await reg.pushManager.subscribe({
+        userVisibleOnly: true,
+        applicationServerKey: urlBase64ToUint8Array(VAPID_PUBLIC_KEY!) as unknown as BufferSource,
+      });
+      const json = sub.toJSON() as { endpoint?: string; keys?: { p256dh?: string; auth?: string } };
+      const result = await savePushSubscription(
+        { endpoint: json.endpoint!, keys: { p256dh: json.keys!.p256dh!, auth: json.keys!.auth! } },
+        navigator.userAgent
+      );
+      if (result.error) {
+        setError(result.error);
+        setState("off");
+        return;
+      }
+      setState("on");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Kunde inte aktivera notiser");
+      setState("off");
+    }
+  }
+
+  async function disable() {
+    setError(null);
+    setState("working");
+    try {
+      const reg = await navigator.serviceWorker.ready;
+      const sub = await reg.pushManager.getSubscription();
+      if (sub) {
+        await deletePushSubscription(sub.endpoint);
+        await sub.unsubscribe();
+      }
+      setState("off");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Kunde inte stänga av notiser");
+      setState("on");
+    }
+  }
+
+  if (state === "loading" || state === "unsupported") return null;
+
+  return (
+    <div>
+      <div className="flex items-center justify-between gap-3">
+        <div className="min-w-0">
+          <p className="text-sm font-medium" style={{ color: "var(--tn-text)" }}>Notiser</p>
+          <p className="text-xs" style={{ color: "var(--tn-text-faint)" }}>
+            Få en pushnotis när en omgång rättats och systemen fått sina poäng.
+          </p>
+        </div>
+        {state === "denied" ? (
+          <span className="text-xs shrink-0" style={{ color: "var(--tn-text-faint)" }}>Blockerat i webbläsaren</span>
+        ) : (
+          <button
+            onClick={state === "on" ? disable : enable}
+            disabled={state === "working"}
+            className="text-sm font-semibold rounded-lg transition shrink-0 disabled:opacity-50"
+            style={{
+              padding: "6px 14px",
+              background: state === "on" ? "var(--tn-bg-chip)" : "var(--tn-accent-faint)",
+              border: `1px solid ${state === "on" ? "var(--tn-border)" : "var(--tn-accent-soft)"}`,
+              color: state === "on" ? "var(--tn-text-dim)" : "var(--tn-accent)",
+              cursor: "pointer",
+            }}
+          >
+            {state === "working" ? "…" : state === "on" ? "Av" : "Slå på"}
+          </button>
+        )}
+      </div>
+      {error && <p className="text-xs mt-1" style={{ color: "var(--tn-value-low)" }}>{error}</p>}
+    </div>
+  );
+}

--- a/components/groups/SallskapOverview.tsx
+++ b/components/groups/SallskapOverview.tsx
@@ -8,6 +8,7 @@ import { ProfileForm } from "./ProfileForm";
 import { GroupList } from "./GroupList";
 import { CreateGroupForm } from "./CreateGroupForm";
 import { JoinGroupForm } from "./JoinGroupForm";
+import { NotificationToggle } from "@/components/NotificationToggle";
 import type { Group, Profile } from "@/lib/types";
 
 interface SallskapOverviewProps {
@@ -93,6 +94,10 @@ export function SallskapOverview({ profile, initialGroups, userEmail, unseenByGr
           Syns för övriga medlemmar i dina sällskap.
         </p>
         <ProfileForm initialName={profile?.display_name ?? ""} />
+      </section>
+
+      <section>
+        <NotificationToggle />
       </section>
 
       <section className="pt-1 space-y-2">

--- a/lib/actions/push.ts
+++ b/lib/actions/push.ts
@@ -1,0 +1,54 @@
+"use server";
+
+import { createServiceClient } from "@/lib/supabase/server";
+import { getAuthUser } from "@/lib/supabase/guards";
+
+export interface SerializedSubscription {
+  endpoint: string;
+  keys: { p256dh: string; auth: string };
+}
+
+/** Sparar (eller uppdaterar) en push-prenumeration för inloggad användare. */
+export async function savePushSubscription(
+  sub: SerializedSubscription,
+  userAgent?: string
+): Promise<{ error?: string }> {
+  const user = await getAuthUser();
+  if (!user) return { error: "Ej inloggad" };
+  if (!sub?.endpoint || !sub.keys?.p256dh || !sub.keys?.auth) {
+    return { error: "Ogiltig prenumeration" };
+  }
+
+  const db = createServiceClient();
+  const { error } = await db
+    .from("push_subscriptions")
+    .upsert(
+      {
+        user_id: user.id,
+        endpoint: sub.endpoint,
+        p256dh: sub.keys.p256dh,
+        auth: sub.keys.auth,
+        user_agent: userAgent ?? null,
+      },
+      { onConflict: "endpoint" }
+    );
+
+  if (error) return { error: error.message };
+  return {};
+}
+
+/** Tar bort en prenumeration (när användaren stänger av notiser). */
+export async function deletePushSubscription(endpoint: string): Promise<{ error?: string }> {
+  const user = await getAuthUser();
+  if (!user) return { error: "Ej inloggad" };
+
+  const db = createServiceClient();
+  const { error } = await db
+    .from("push_subscriptions")
+    .delete()
+    .eq("endpoint", endpoint)
+    .eq("user_id", user.id);
+
+  if (error) return { error: error.message };
+  return {};
+}

--- a/lib/push.ts
+++ b/lib/push.ts
@@ -1,0 +1,75 @@
+import webpush from "web-push";
+import { createServiceClient } from "@/lib/supabase/server";
+
+const PUBLIC_KEY = process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY;
+const PRIVATE_KEY = process.env.VAPID_PRIVATE_KEY;
+// Kontaktpunkt som push-tjänsterna kan nå vid problem (mailto: eller https-URL)
+const SUBJECT = process.env.VAPID_SUBJECT ?? "mailto:noreply@v85-app.se";
+
+/** True om VAPID-nycklar är konfigurerade — utan dem är push avstängt (no-op). */
+export const pushConfigured = Boolean(PUBLIC_KEY && PRIVATE_KEY);
+
+if (pushConfigured) {
+  webpush.setVapidDetails(SUBJECT, PUBLIC_KEY!, PRIVATE_KEY!);
+}
+
+export interface PushPayload {
+  title: string;
+  body: string;
+  /** Relativ URL som öppnas vid klick (default "/") */
+  url?: string;
+  tag?: string;
+}
+
+/**
+ * Skickar en push-notis till samtliga prenumerationer för de angivna
+ * användarna. Tysta no-op om VAPID saknas. Utgångna prenumerationer
+ * (404/410) städas bort automatiskt. Fel på enskilda utskick sväljs så att
+ * ett trasigt abonnemang inte stoppar resten.
+ */
+export async function sendPushToUsers(
+  userIds: string[],
+  payload: PushPayload
+): Promise<{ sent: number; pruned: number }> {
+  if (!pushConfigured || userIds.length === 0) return { sent: 0, pruned: 0 };
+
+  const db = createServiceClient();
+  const { data: subs } = await db
+    .from("push_subscriptions")
+    .select("id, endpoint, p256dh, auth")
+    .in("user_id", [...new Set(userIds)]);
+
+  if (!subs || subs.length === 0) return { sent: 0, pruned: 0 };
+
+  const body = JSON.stringify(payload);
+  let sent = 0;
+  const expiredIds: string[] = [];
+
+  await Promise.all(
+    subs.map(async (s) => {
+      try {
+        await webpush.sendNotification(
+          {
+            endpoint: s.endpoint as string,
+            keys: { p256dh: s.p256dh as string, auth: s.auth as string },
+          },
+          body
+        );
+        sent++;
+      } catch (err) {
+        const status = (err as { statusCode?: number }).statusCode;
+        if (status === 404 || status === 410) {
+          expiredIds.push(s.id as string);
+        } else {
+          console.warn("[push] sendNotification misslyckades:", err instanceof Error ? err.message : String(err));
+        }
+      }
+    })
+  );
+
+  if (expiredIds.length > 0) {
+    await db.from("push_subscriptions").delete().in("id", expiredIds);
+  }
+
+  return { sent, pruned: expiredIds.length };
+}

--- a/lib/systems.ts
+++ b/lib/systems.ts
@@ -1,17 +1,23 @@
 import { SupabaseClient } from '@supabase/supabase-js'
 import { SystemSelection } from '@/lib/types'
 
+/**
+ * Rättar omgångens ograttade system och returnerar de sällskaps-id:n som fick
+ * minst ett nyrättat (icke-utkast) system. Tom array om inget nytt rättades —
+ * gör att resultatnotisen kan skickas exakt en gång även vid upprepade
+ * resultathämtningar.
+ */
 export async function gradeSystemsForGame(
   supabase: SupabaseClient,
   gameId: string
-): Promise<void> {
+): Promise<string[]> {
   // Hämta antalet avdelningar i spelet
   const { data: races, error: racesError } = await supabase
     .from('races')
     .select('race_number')
     .eq('game_id', gameId)
 
-  if (racesError || !races?.length) return
+  if (racesError || !races?.length) return []
   const totalRaces = races.length
 
   // Hämta vinnare (finish_position = 1) per avdelning för detta spel
@@ -21,7 +27,7 @@ export async function gradeSystemsForGame(
     .eq('races.game_id', gameId)
     .eq('finish_position', 1)
 
-  if (winnersError || !winners?.length) return
+  if (winnersError || !winners?.length) return []
 
   // Bygg map: race_number → winning horse_id
   const winnerMap = new Map<number, string>()
@@ -31,16 +37,16 @@ export async function gradeSystemsForGame(
   }
 
   // Rätta bara om alla avdelningar har en vinnare — annars otillräckliga data
-  if (winnerMap.size < totalRaces) return
+  if (winnerMap.size < totalRaces) return []
 
   // Hämta alla ograttade system för detta game_id
   const { data: systems, error: systemsError } = await supabase
     .from('game_systems')
-    .select('id, selections')
+    .select('id, selections, group_id, is_draft')
     .eq('game_id', gameId)
     .eq('is_graded', false)
 
-  if (systemsError || !systems?.length) return
+  if (systemsError || !systems?.length) return []
 
   // Rätta varje system
   await Promise.all(systems.map(async (system) => {
@@ -57,4 +63,11 @@ export async function gradeSystemsForGame(
       .update({ score, is_graded: true })
       .eq('id', system.id)
   }))
+
+  // Sällskap som fick nyrättade (icke-utkast) system → mål för resultatnotisen
+  const groupIds = new Set<string>()
+  for (const s of systems) {
+    if (!s.is_draft && s.group_id) groupIds.add(s.group_id as string)
+  }
+  return [...groupIds]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,10 +11,12 @@
         "@serwist/next": "^9.5.6",
         "@supabase/ssr": "^0.8.0",
         "@supabase/supabase-js": "^2.98.0",
+        "@types/web-push": "^3.6.4",
         "next": "16.1.6",
         "react": "19.2.3",
         "react-dom": "19.2.3",
-        "serwist": "^9.5.6"
+        "serwist": "^9.5.6",
+        "web-push": "^3.6.7"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
@@ -3196,6 +3198,15 @@
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "license": "MIT"
     },
+    "node_modules/@types/web-push": {
+      "version": "3.6.4",
+      "resolved": "https://registry.npmjs.org/@types/web-push/-/web-push-3.6.4.tgz",
+      "integrity": "sha512-GnJmSr40H3RAnj0s34FNTcJi1hmWFV5KXugE0mYWnYhgTAHLJ/dJKAwDmvPJYMke0RplY2XE9LnM4hqSqKIjhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/ws": {
       "version": "8.18.1",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
@@ -3816,6 +3827,15 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
@@ -4067,6 +4087,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/asn1.js": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+      "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
     "node_modules/ast-types-flow": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
@@ -4237,6 +4269,12 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/bn.js": {
+      "version": "4.12.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
+      "license": "MIT"
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -4316,6 +4354,12 @@
       "dependencies": {
         "node-int64": "^0.4.0"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
@@ -4706,7 +4750,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -4841,6 +4884,15 @@
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "license": "MIT"
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.302",
@@ -6236,6 +6288,28 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/http_ece": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http_ece/-/http_ece-1.2.0.tgz",
+      "integrity": "sha512-JrF8SSLVmcvc5NducxgyOrKXe3EsyHMgBFgSaIUGmArKe+rwr0uphRkRXvwiom3I+fpIfoItveHrfudL8/rxuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/human-signals": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
@@ -6334,7 +6408,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/internal-slot": {
@@ -7652,6 +7725,27 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -8146,6 +8240,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "license": "ISC"
+    },
     "node_modules/minimatch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
@@ -8163,7 +8263,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -8182,7 +8281,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -9146,6 +9244,26 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
@@ -9180,6 +9298,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
     },
     "node_modules/scheduler": {
       "version": "0.27.0",
@@ -10433,6 +10557,25 @@
       "license": "Apache-2.0",
       "dependencies": {
         "makeerror": "1.0.12"
+      }
+    },
+    "node_modules/web-push": {
+      "version": "3.6.7",
+      "resolved": "https://registry.npmjs.org/web-push/-/web-push-3.6.7.tgz",
+      "integrity": "sha512-OpiIUe8cuGjrj3mMBFWY+e4MMIkW3SVT+7vEIjvD9kejGUypv8GPDf84JdPWskK8zMRIJ6xYGm+Kxr8YkPyA0A==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "asn1.js": "^5.3.0",
+        "http_ece": "1.2.0",
+        "https-proxy-agent": "^7.0.0",
+        "jws": "^4.0.0",
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "web-push": "src/cli.js"
+      },
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -14,10 +14,12 @@
     "@serwist/next": "^9.5.6",
     "@supabase/ssr": "^0.8.0",
     "@supabase/supabase-js": "^2.98.0",
+    "@types/web-push": "^3.6.4",
     "next": "16.1.6",
     "react": "19.2.3",
     "react-dom": "19.2.3",
-    "serwist": "^9.5.6"
+    "serwist": "^9.5.6",
+    "web-push": "^3.6.7"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",

--- a/supabase/migration_v13_push_subscriptions.sql
+++ b/supabase/migration_v13_push_subscriptions.sql
@@ -1,0 +1,23 @@
+-- v13: web push-prenumerationer för notiser (t.ex. "Resultaten är rättade").
+-- En användare kan ha flera prenumerationer (en per enhet/webbläsare).
+-- Utskick sker server-side med service-klienten; RLS låter användaren hantera
+-- sina egna prenumerationer från klienten.
+
+create table if not exists push_subscriptions (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  endpoint text not null unique,
+  p256dh text not null,
+  auth text not null,
+  user_agent text,
+  created_at timestamptz default now()
+);
+
+create index if not exists idx_push_subscriptions_user on push_subscriptions(user_id);
+
+alter table push_subscriptions enable row level security;
+
+create policy "Användare hanterar egna push-prenumerationer"
+  on push_subscriptions for all
+  using (user_id = auth.uid())
+  with check (user_id = auth.uid());


### PR DESCRIPTION
## Sammanfattning

Slutför #75 — push-notisen som gör resultatkvällen till en återbesökskrok. När en omgång rättats skickas en notis till medlemmarna i sällskap som fick nyrättade system:

> **Resultaten är rättade 🏆**
> V85 2026-06-13 är avgjord — se hur ditt sällskap gick.

Klick öppnar startsidan med resultatbannern (från steg 1).

## Vad som ingår

- **`push_subscriptions`-tabell** (migration v13, **applicerad** med RLS) — en rad per enhet/webbläsare.
- **`lib/push.ts`** — `sendPushToUsers` via `web-push`. **No-op utan VAPID-nycklar**, städar bort utgångna prenumerationer (404/410).
- **`lib/actions/push.ts`** — spara/ta bort prenumeration, auth-skyddat.
- **Service worker** (`app/sw.ts`) — `push`- och `notificationclick`-hanterare.
- **`NotificationToggle`** på sällskapsöversikten (via Profil) — slå på/av. Döljs helt om push inte är konfigurerat eller webbläsaren saknar stöd.
- **Exakt en notis per omgång:** `gradeSystemsForGame` returnerar vilka sällskap som fick *nyrättade* system, så upprepade resultathämtningar inte spammar.

## ⚠️ Kräver VAPID-nycklar (sätts av dig, inte här)

Funktionen är **helt avstängd tills tre miljövariabler finns** (och påverkar inget annat förrän dess). Generera ett eget nyckelpar med `npx web-push generate-vapid-keys` och lägg värdena i Vercel (och `.env.local` lokalt) — dela dem aldrig publikt:

```
NEXT_PUBLIC_VAPID_PUBLIC_KEY=…
VAPID_PRIVATE_KEY=…
VAPID_SUBJECT=mailto:din@epost.se
```

## Verifiering

- `tsc --noEmit` rent, `npx jest` 70 gröna, lint oförändrat (3 förexisterande).
- **Kunde inte köra hela produktionsbygget lokalt** — det faller på att Google Fonts inte kan hämtas i den här miljön (nätverksspärr), inte på koden. `sw.js` genereras därför inte här. Verifiera att service workern byggs i din deploy. (Det finns en förexisterande Serwist+Turbopack-varning som inte rör denna ändring.)
- Test i prod: installera appen som PWA, slå på notiser under Profil, hämta resultat för en omgång med sparade system → notis ska komma.

Steg 3 (e-post) är fortsatt out of scope.

https://claude.ai/code/session_016r3SKaqgmEtHD64UfAaQ3H