### PR TITLE
Fix: kupongraden döljs bakom mobilnavigeringen i systemläget

### DIFF
--- a/app/(authenticated)/layout.tsx
+++ b/app/(authenticated)/layout.tsx
@@ -23,7 +23,7 @@ export default async function AuthenticatedLayout({
   const activity = user ? await getGroupActivity() : null;
 
   return (
-    <div className="pb-16 md:pb-0">
+    <div className="pb-24 md:pb-0">
       <TopNav />
       {children}
       <BottomNav isAdmin={isAdmin} sallskapBadge={activity?.unseenTotal ?? 0} />

--- a/components/BottomNav.tsx
+++ b/components/BottomNav.tsx
@@ -68,7 +68,9 @@ export function BottomNav({
         className="grid"
         style={{
           gridTemplateColumns: `repeat(${isAdmin ? 5 : 4}, 1fr)`,
-          padding: "8px 8px 22px",
+          // Botten följer hemindikatorns säkra yta (minst 22px) så ikonerna
+          // inte hamnar under iPhones home-indikator
+          padding: "8px 8px max(22px, env(safe-area-inset-bottom))",
         }}
       >
         {tabs.map((tab) => {

--- a/components/MainPageClient.tsx
+++ b/components/MainPageClient.tsx
@@ -204,8 +204,14 @@ export function MainPageClient({
 
       {systemMode && (
         <div
-          className="fixed bottom-16 left-0 right-0 z-50 md:hidden shadow-lg"
-          style={{ background: "var(--tn-bg-raised)", borderTop: "1px solid var(--tn-border)" }}
+          className="fixed left-0 right-0 z-50 md:hidden shadow-lg"
+          style={{
+            // Sitter precis ovanför BottomNav — höjden följer hemindikatorns
+            // säkra yta så kupongraden inte döljs bakom navigeringen
+            bottom: "calc(66px + max(22px, env(safe-area-inset-bottom)))",
+            background: "var(--tn-bg-raised)",
+            borderTop: "1px solid var(--tn-border)",
+          }}
         >
           <button
             aria-label="Öppna kupong"


### PR DESCRIPTION
## Problem

I systemläget låg kupongsammanfattningen ("0 av 8 avd. klara / 0 rader / ↑ Visa kupong") på `bottom-16` (64px), men BottomNav är ~80px hög — så radens nederkant hamnade bakom navigeringen. Värst på iPhone med home-indikator, där den extra säkra ytan gör navigeringen ännu högre. (Detta är samma mobil-överlapp som flaggades i `docs/systemgranskning-2026-06.md` punkt 5.)

## Fix

- **Kupongraden** sitter nu precis ovanför navigeringen, med höjd som följer hemindikatorns säkra yta: `calc(66px + max(22px, env(safe-area-inset-bottom)))`.
- **BottomNav** bottenpadding följer `max(22px, env(safe-area-inset-bottom))` så ikonerna aldrig hamnar under iPhones home-indikator (var hårdkodat 22px).
- **Layout** reserverar `pb-24` (var `pb-16`) så sista innehållet klarar den något högre navigeringen vid scroll.

Endast CSS/positionering — ingen logik ändrad. `tsc` rent, lint oförändrat (3 förexisterande).

> Svårt att verifiera pixelperfekt här (produktionsbygget faller på Google Fonts i den här miljön), men formeln binder kupongraden till navigeringens faktiska höjd inkl. säker yta, så den ska klara alla skärmstorlekar. Värt en snabb titt i din PWA efter deploy.

https://claude.ai/code/session_016r3SKaqgmEtHD64UfAaQ3H

---
_Generated by [Claude Code](https://claude.ai/code/session_016r3SKaqgmEtHD64UfAaQ3H)_