### PR TITLE
Fix: Spara-knappen i kupong-drawern dold bakom mobilnavigeringen

### DIFF
--- a/components/SaveSystemDialog.tsx
+++ b/components/SaveSystemDialog.tsx
@@ -121,7 +121,7 @@ export function SaveSystemDialog({
   return (
     <div className="fixed inset-0 z-50 flex items-end sm:items-center justify-center" style={{ background: "rgba(0,0,0,0.6)" }}>
       <div
-        className="w-full sm:max-w-md rounded-t-2xl sm:rounded-2xl p-6 pb-[calc(1.5rem+4rem)] sm:pb-6 shadow-xl"
+        className="w-full sm:max-w-md rounded-t-2xl sm:rounded-2xl p-6 pb-[calc(1.5rem+4rem+env(safe-area-inset-bottom))] sm:pb-6 shadow-xl"
         style={{ background: "var(--tn-bg-raised)", border: "1px solid var(--tn-border)" }}
       >
         <h2 className="text-lg font-bold mb-4" style={{ color: "var(--tn-text)" }}>Spara system</h2>

--- a/components/SystemDrawer.tsx
+++ b/components/SystemDrawer.tsx
@@ -57,11 +57,11 @@ export function SystemDrawer({
 
   return (
     <>
-      <div className="fixed inset-0 z-40 md:hidden" style={{ background: "rgba(0,0,0,0.6)" }} onClick={onClose} />
+      <div className="fixed inset-0 z-[55] md:hidden" style={{ background: "rgba(0,0,0,0.6)" }} onClick={onClose} />
       <div
         role="dialog"
         aria-modal="true"
-        className="fixed bottom-0 left-0 right-0 z-50 md:hidden rounded-t-2xl max-h-[70vh] flex flex-col"
+        className="fixed bottom-0 left-0 right-0 z-[60] md:hidden rounded-t-2xl max-h-[80vh] flex flex-col"
         style={{ background: "var(--tn-bg-raised)", border: "1px solid var(--tn-border)" }}
       >
         <div className="flex justify-center pt-3 pb-1 flex-shrink-0">
@@ -118,8 +118,12 @@ export function SystemDrawer({
         </div>
 
         <div
-          className="px-4 py-3 flex-shrink-0"
-          style={{ borderTop: "2px solid var(--tn-accent)" }}
+          className="px-4 pt-3 flex-shrink-0"
+          style={{
+            borderTop: "2px solid var(--tn-accent)",
+            // Plats för home-indikatorn så Spara-/Avbryt-knapparna inte döljs
+            paddingBottom: "calc(12px + env(safe-area-inset-bottom))",
+          }}
         >
           <div className="flex items-baseline justify-between mb-1">
             <span className="text-lg font-extrabold" style={{ color: "var(--tn-accent)" }}>


### PR DESCRIPTION
## Problem

I kupong-drawern ("DIN KUPONG", som öppnas via **Visa kupong** i systemläget) låg **"Spara system →"-knappen dold bakom mobilnavigeringen** och gick inte att klicka. Orsak: drawern och `BottomNav` hade samma `z-index` (50), och eftersom navigeringen ligger senare i DOM målades den ovanpå drawerns nedre del (Spara-/Avbryt-knapparna).

Syns i skärmbilden: "1512 rader / 756 kr / 8 av 8 avd. klara" är synligt, men Spara-knappen under det ligger bakom LOPP/ANALYS/SYSTEM/PROFIL.

## Fix

- **SystemDrawer:** overlay höjd till `z-[55]` och själva panelen till `z-[60]` — nu *ovanför* navigeringen (z-50), så drawern täcker den medan den är öppen (rätt beteende för en modal). Footer-paddingen följer home-indikatorns säkra yta så knapparna inte hamnar under den. `max-h` 70→80vh för lite mer luft.
- **SaveSystemDialog** (nästa steg efter Spara): bottenmarginalen inkluderar nu `env(safe-area-inset-bottom)`, så knapparna säkert klarar den något högre navigeringen efter #87 på iPhone.

Endast positionering/z-index — ingen logik ändrad. `tsc` rent, lint oförändrat (3 förexisterande).

> Som tidigare kan jag inte bygga produktionsbundlen lokalt (Google Fonts-spärr i miljön), men z-index- och safe-area-logiken är standard och låg risk. Värt en snabb titt i din PWA efter deploy.

https://claude.ai/code/session_016r3SKaqgmEtHD64UfAaQ3H

---
_Generated by [Claude Code](https://claude.ai/code/session_016r3SKaqgmEtHD64UfAaQ3H)_